### PR TITLE
Bug: Fix link to OG leads dataset

### DIFF
--- a/ckanext/ontario_theme/templates/organization/snippets/helper.html
+++ b/ckanext/ontario_theme/templates/organization/snippets/helper.html
@@ -18,13 +18,13 @@ Renders the general organization description/definition.
           Questions
         </h3>
         <p>
-          For questions about ministry data and records, contact the ministry’s <a href="/dataset/open-government-staff-leads">open government lead</a>.
+          For questions about ministry data and records, contact the ministry’s <a href="/dataset/open-government-ministries-staff-and-executive-leads">open government lead</a>.
         </p>
         <h3>
           Managing Ministry Data
         </h3>
         <p>
-          Ministries can only manage their own data and records. If you’re having trouble with your account or permissions, contact your ministry's <a href="/dataset/open-government-staff-leads">open government lead</a>.
+          Ministries can only manage their own data and records. If you’re having trouble with your account or permissions, contact your ministry's <a href="/dataset/open-government-ministries-staff-and-executive-leads">open government lead</a>.
         </p>
         <!--h3>
           Keeping up-to-date


### PR DESCRIPTION
This PR consists of one commit and one change: Update the featured content section on the hopepage with a link to the AI and algorithms group.