### PR TITLE
Task: Add CSRF for Pylons and Flask.

### DIFF
--- a/ckanext/ontario_theme/anti_csrf.py
+++ b/ckanext/ontario_theme/anti_csrf.py
@@ -1,0 +1,283 @@
+# encoding: utf-8
+"""Provides a self-contained filter to prevent Cross-Site Request Forgery,
+based on the Double Submit Cookie pattern,
+www.owasp.org/index.php/Cross-Site_Request_Forgery_(CSRF)_Prevention_Cheat_Sheet#Double_Submit_Cookie
+The filter can be enabled simply by invoking 'intercept_csrf()'.
+"""
+import hashlib
+import hmac
+import random
+import re
+from re import IGNORECASE, MULTILINE
+import time
+import urllib
+from logging import getLogger
+
+from ckan.common import config, request, response, g
+import ckan.lib.base as base
+
+LOG = getLogger(__name__)
+
+RAW_RENDER_JINJA = base.render_jinja2
+RAW_BEFORE = base.BaseController.__before__
+
+""" Used as the cookie name and input field name.
+"""
+TOKEN_FIELD_NAME = 'token'
+
+"""
+This will match a POST form that has whitespace after the opening tag (which all existing forms do).
+Once we have injected a token immediately after the opening tag,
+it won't match any more, which avoids redundant injection.
+"""
+POST_FORM = re.compile(r'(<form [^>]*method=["\']post["\'][^>]*>)(\s[^<]*<)', IGNORECASE|MULTILINE)
+
+"""The format of the token HTML field.
+"""
+TOKEN_VALIDATION_PATTERN = re.compile(r'^[0-9a-z]+![0-9]+/[0-9]+/[-_a-z0-9%]+$', IGNORECASE)
+API_URL = re.compile(r'^/api\b.*')
+CONFIRM_MODULE_PATTERN = r'data-module=["\']confirm-action["\']'
+HREF_URL_PATTERN = r'href=["\']([^"\']+)'
+
+# We need to edit confirm-action links, which get intercepted by JavaScript,
+#regardless of which order their 'data-module' and 'href' attributes appear.
+CONFIRM_LINK = re.compile(r'(<a [^>]*{}[^>]*{})(["\'])'.format(
+    CONFIRM_MODULE_PATTERN, HREF_URL_PATTERN),
+                          IGNORECASE|MULTILINE)
+CONFIRM_LINK_REVERSED = re.compile(r'(<a [^>]*{})(["\'][^>]*{})'.format(
+    HREF_URL_PATTERN, CONFIRM_MODULE_PATTERN),
+                                   IGNORECASE|MULTILINE)
+
+def is_logged_in():
+    """ Determine whether the user is currently logged in and thus needs a token.
+    TODO Also require a token on login/logout forms.
+    """
+    return _get_user()
+
+def anti_csrf_render_jinja2(template_name, extra_vars=None):
+    """ Wrap the core page-rendering function and inject tokens into HTML where appropriate.
+    """
+    html = apply_token(RAW_RENDER_JINJA(template_name, extra_vars))
+    return html
+
+def apply_token(html):
+    """ Rewrite HTML to insert tokens if applicable.
+    """
+    if not is_logged_in() or (
+            not POST_FORM.search(html) and not re.search(CONFIRM_MODULE_PATTERN, html)):
+        return html
+
+    token = _get_response_token()
+
+    def insert_form_token(form_match):
+        """ Inject a token into a POST form. """
+        return form_match.group(1) + '<input type="hidden" name="{}" value="{}"/>'.format(TOKEN_FIELD_NAME, token) + form_match.group(2)
+
+    def insert_link_token(link_match):
+        """ Inject a token into a link that uses data-module="confirm-action".
+        These links are picked up by JavaScript and converted into empty POST requests.
+        """
+        if TOKEN_FIELD_NAME + '=' in link_match.group(1):
+            return link_match.group(0)
+        if '?' in link_match.group(2):
+            separator = '&'
+        else:
+            separator = '?'
+        return link_match.group(1) + separator + TOKEN_FIELD_NAME + '=' + token + link_match.group(3)
+
+    return CONFIRM_LINK_REVERSED.sub(insert_link_token, CONFIRM_LINK.sub(insert_link_token, POST_FORM.sub(insert_form_token, html)))
+
+def _get_cookie_token():
+    """ Retrieve the token expected by the server.
+    This will be retrieved from the 'token' cookie, if it exists.
+    If not, an error will occur.
+    """
+    token = None
+    if request.cookies.has_key(TOKEN_FIELD_NAME):
+        LOG.debug("Obtaining token from cookie")
+        token = request.cookies.get(TOKEN_FIELD_NAME)
+    if token is None or token.strip() == "":
+        csrf_fail("CSRF token is blank")
+
+    return token
+
+def _get_user():
+    """ Retrieve the current user object.
+    """
+    return g.userobj
+
+def _get_safe_username():
+    """ Retrieve the current username with unsafe characters URL-encoded.
+    """
+    return urllib.quote(_get_user().name, safe='')
+
+def validate_token(token):
+    """ Verify the integrity of the provided token.
+    It must have the expected format (hash!timestamp/nonce/username),
+    the hash must match the other values,
+    the username must match the current account,
+    and it must not be older than our limit (currently 30 minutes).
+    """
+    token_values = read_token_values(token)
+    if not 'hash' in token_values:
+        return False
+
+    expected_hmac = unicode(get_digest(token_values['message']))
+    if not hmac.compare_digest(expected_hmac, token_values['hash']):
+        return False
+
+    now = int(time.time())
+    timestamp = token_values['timestamp']
+    # allow tokens up to 30 minutes old
+    if now < timestamp or now - timestamp > 60 * 30:
+        return False
+
+    if token_values['username'] != _get_safe_username():
+        return False
+
+    return True
+
+def read_token_values(token):
+    """ Parse the provided token string. Invalid tokens are parsed as empty dicts.
+    """
+    if not TOKEN_VALIDATION_PATTERN.match(token):
+        return {}
+
+    parts = token.split('!', 1)
+    message = parts[1]
+    # limiting to 2 means that even if a username contains a slash, it won't cause an extra split
+    message_parts = message.split('/', 2)
+
+    return {
+        "message": message,
+        "hash": unicode(parts[0]),
+        "timestamp": int(message_parts[0]),
+        "nonce": int(message_parts[1]),
+        "username": message_parts[2]
+    }
+
+def _get_response_token():
+    """Retrieve the token to be injected into pages.
+    This will be retrieved from the 'token' cookie, if it exists and is fresh.
+    If not, a new token will be generated and a new cookie set.
+    """
+    # ensure that the same token is used when a page is assembled from pieces
+    if request.environ['webob.adhoc_attrs'].has_key('response_token'):
+        LOG.debug("Reusing response token from request attributes")
+        token = request.response_token
+    elif request.cookies.has_key(TOKEN_FIELD_NAME):
+        LOG.debug("Obtaining token from cookie")
+        token = request.cookies.get(TOKEN_FIELD_NAME)
+        if not validate_token(token) or is_soft_expired(token):
+            LOG.debug("Invalid or expired cookie token; making new token cookie")
+            token = create_response_token()
+        request.response_token = token
+    else:
+        LOG.debug("No valid token found; making new token cookie")
+        token = create_response_token()
+        request.response_token = token
+
+    return token
+
+def is_soft_expired(token):
+    """Check whether the token is old enough to need rotation.
+    It may still be valid, but it's time to generate a new one.
+    The current rotation age is 10 minutes.
+    """
+    if not validate_token(token):
+        return False
+
+    now = int(time.time())
+    token_values = read_token_values(token)
+
+    return now - token_values['timestamp'] > 60 * 10
+
+def _get_secret_key():
+    """ Retrieve the secret key to use in generating secure hashes.
+    Currently this is the Beaker session secret.
+    """
+    return config.get('beaker.session.secret')
+
+def get_digest(message):
+    """ Generate a secure (unforgeable) hash of the provided data.
+    """
+    return hmac.HMAC(_get_secret_key(), message, hashlib.sha512).hexdigest()
+
+def create_response_token():
+    """ Generate an unforgeable CSRF token. The format of this token is:
+    hash!timestamp/nonce/username
+    where the hash is a secure HMAC of the other values plus a secret key.
+    """
+    username = _get_safe_username()
+    timestamp = int(time.time())
+    nonce = random.randint(1, 999999)
+    message = "{}/{}/{}".format(timestamp, nonce, username)
+    token = "{}!{}".format(get_digest(message), message)
+
+    _set_response_token_cookie(token)
+    return token
+
+def _set_response_token_cookie(token):
+    """ Add a generated token cookie to the HTTP response
+    """
+    response.set_cookie(TOKEN_FIELD_NAME, token, secure=True, httponly=True)
+
+def is_request_exempt():
+    """ Determine whether a request needs to provide a token.
+    HTTP methods without side effects (GET, HEAD, OPTIONS) are exempt, as are API calls
+    (which should instead provide an API key).
+    """
+    return not is_logged_in() or API_URL.match(request.path) or request.method in {'GET', 'HEAD', 'OPTIONS'}
+
+def anti_csrf_before(obj, action, **params):
+    """ Wrap the core pre-rendering function to require tokens on applicable requests.
+    """
+    RAW_BEFORE(obj, action)
+
+    if not is_request_exempt() and _get_cookie_token() != _get_post_token():
+        csrf_fail("Could not match session token with form token")
+
+def csrf_fail(message):
+    """ Abort the request and return an error when there is a problem with the CSRF token.
+    """
+    LOG.error(message)
+    base.abort(403, "Your form submission could not be validated")
+
+def _get_post_token():
+    """Retrieve the token provided by the client.
+    This is normally a single 'token' parameter in the POST body.
+    However, for compatibility with 'confirm-action' links,
+    it is also acceptable to provide the token as a query string parameter,
+    if there is no POST body.
+    """
+    if request.environ['webob.adhoc_attrs'].has_key(TOKEN_FIELD_NAME):
+        return request.token
+
+    # handle query string token if there are no POST parameters
+    # this is needed for the 'confirm-action' JavaScript module
+    if not request.POST and len(request.GET.getall(TOKEN_FIELD_NAME)) == 1:
+        request.token = request.GET.getone(TOKEN_FIELD_NAME)
+        del request.GET[TOKEN_FIELD_NAME]
+        return request.token
+
+    post_tokens = request.POST.getall(TOKEN_FIELD_NAME)
+    if not post_tokens:
+        csrf_fail("Missing CSRF token in form submission")
+    elif len(post_tokens) > 1:
+        csrf_fail("More than one CSRF token in form submission")
+    else:
+        request.token = post_tokens[0]
+
+    # drop token from request so it doesn't populate resource extras
+    del request.POST[TOKEN_FIELD_NAME]
+
+    if not validate_token(request.token):
+        csrf_fail("Invalid token format")
+
+    return request.token
+
+def intercept_csrf():
+    """ Monkey-patch the core rendering methods to apply our CSRF tokens.
+    """
+    base.render_jinja2 = anti_csrf_render_jinja2
+    base.BaseController.__before__ = anti_csrf_before

--- a/ckanext/ontario_theme/anti_csrf.py
+++ b/ckanext/ontario_theme/anti_csrf.py
@@ -1,88 +1,61 @@
-# encoding: utf-8
-"""Provides a self-contained filter to prevent Cross-Site Request Forgery,
+"""Provides a filter to prevent Cross-Site Request Forgery,
 based on the Double Submit Cookie pattern,
-www.owasp.org/index.php/Cross-Site_Request_Forgery_(CSRF)_Prevention_Cheat_Sheet#Double_Submit_Cookie
-The filter can be enabled simply by invoking 'intercept_csrf()'.
+https://github.com/OWASP/CheatSheetSeries/blob/master/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.md#double-submit-cookie
+This is integrated in the CSRFMiddleware
 """
-import hashlib
-import hmac
-import random
+import ckan.lib.base as base
 import re
 from re import IGNORECASE, MULTILINE
-import time
-import urllib
 from logging import getLogger
-
-from ckan.common import config, request, response, g, is_flask_request
-import ckan.lib.base as base
-import ckan.plugins.toolkit as toolkit
-import ckan.views as views
-
-import flask
+from ckan.common import request
 
 LOG = getLogger(__name__)
 
+RAW_RENDER = base.render
 RAW_RENDER_JINJA = base.render_jinja2
 RAW_BEFORE = base.BaseController.__before__
-RAW_RENDER = base.render
-RAW_IDENTIFY_USER = views.identify_user
 
 """ Used as the cookie name and input field name.
 """
 TOKEN_FIELD_NAME = 'token'
+""" Used to rotate the token cookie periodically.
+If the freshness cookie doesn't appear, the token cookie is still OK,
+but we'll set a new one for next time.
+"""
+TOKEN_FRESHNESS_COOKIE_NAME = 'token-fresh'
+
+# We need to edit confirm-action links, which get intercepted by JavaScript,
+#regardless of which order their 'data-module' and 'href' attributes appear.
+CONFIRM_LINK = re.compile(r'(<a [^>]*data-module=["\']confirm-action["\'][^>]*href=["\']([^"\']+))(["\'])', IGNORECASE | MULTILINE)
+CONFIRM_LINK_REVERSED = re.compile(r'(<a [^>]*href=["\']([^"\']+))(["\'][^>]*data-module=["\']confirm-action["\'])', IGNORECASE | MULTILINE)
 
 """
 This will match a POST form that has whitespace after the opening tag (which all existing forms do).
 Once we have injected a token immediately after the opening tag,
 it won't match any more, which avoids redundant injection.
 """
-POST_FORM = re.compile(r'(<form [^>]*method=["\']post["\'][^>]*>)(\s[^<]*<)', IGNORECASE|MULTILINE)
+POST_FORM = re.compile(r'(<form [^>]*method=["\']post["\'][^>]*>)([^<]*\s<)', IGNORECASE | MULTILINE)
 
 """The format of the token HTML field.
 """
-TOKEN_VALIDATION_PATTERN = re.compile(r'^[0-9a-z]+![0-9]+/[0-9]+/[-_a-z0-9%]+$', IGNORECASE)
+HEX_PATTERN=re.compile(r'^[0-9a-z]+$')
+TOKEN_PATTERN = r'<input type="hidden" name="' + TOKEN_FIELD_NAME + '" value="{token}"/>'
+TOKEN_SEARCH_PATTERN = re.compile(TOKEN_PATTERN.format(token=r'([0-9a-f]+)'))
 API_URL = re.compile(r'^/api\b.*')
-CONFIRM_MODULE_PATTERN = r'data-module=["\']confirm-action["\']'
-HREF_URL_PATTERN = r'href=["\']([^"\']+)'
 
-# We need to edit confirm-action links, which get intercepted by JavaScript,
-#regardless of which order their 'data-module' and 'href' attributes appear.
-CONFIRM_LINK = re.compile(r'(<a [^>]*{}[^>]*{})(["\'])'.format(
-    CONFIRM_MODULE_PATTERN, HREF_URL_PATTERN),
-                          IGNORECASE|MULTILINE)
-CONFIRM_LINK_REVERSED = re.compile(r'(<a [^>]*{})(["\'][^>]*{})'.format(
-    HREF_URL_PATTERN, CONFIRM_MODULE_PATTERN),
-                                   IGNORECASE|MULTILINE)
 
-def is_logged_in():
-    """ Determine whether the user is currently logged in and thus needs a token.
-    TODO Also require a token on login/logout forms.
-    """
-    return _get_user()
-
-def anti_csrf_render(template_name, extra_vars=None, *pargs, **kwargs):
-    html = apply_token(RAW_RENDER(template_name, extra_vars, *pargs, **kwargs))
-    return html
-
-def apply_token(html):
+def apply_token(html, token):
     """ Rewrite HTML to insert tokens if applicable.
     """
-    if not is_logged_in() or (
-            not POST_FORM.search(html) and not re.search(CONFIRM_MODULE_PATTERN, html)):
-        return html
 
-    token = _get_response_token()
+    token_match = TOKEN_SEARCH_PATTERN.search(html)
+    if token_match:
+        token = token_match.group(1)
 
     def insert_form_token(form_match):
-        """ Inject a token into a POST form. """
-        return form_match.group(1) + '<input type="hidden" name="{}" value="{}"/>'.format(TOKEN_FIELD_NAME, token) + form_match.group(2)
+        return form_match.group(1) + TOKEN_PATTERN.format(token=token) + form_match.group(2)
 
     def insert_link_token(link_match):
-        """ Inject a token into a link that uses data-module="confirm-action".
-        These links are picked up by JavaScript and converted into empty POST requests.
-        """
-        if TOKEN_FIELD_NAME + '=' in link_match.group(1):
-            return link_match.group(0)
         if '?' in link_match.group(2):
             separator = '&'
         else:
@@ -91,170 +64,54 @@ def apply_token(html):
 
     return CONFIRM_LINK_REVERSED.sub(insert_link_token, CONFIRM_LINK.sub(insert_link_token, POST_FORM.sub(insert_form_token, html)))
 
-def _get_cookie_token():
-    """ Retrieve the token expected by the server.
+
+def get_cookie_token(request):
+    """Retrieve the token expected by the server.
     This will be retrieved from the 'token' cookie, if it exists.
     If not, an error will occur.
     """
     token = None
     if request.cookies.has_key(TOKEN_FIELD_NAME):
-        LOG.debug("_get_cookie_token(): Obtaining token from cookie")
+        LOG.debug("Obtaining token from cookie")
         token = request.cookies.get(TOKEN_FIELD_NAME)
     if token is None or token.strip() == "":
         csrf_fail("CSRF token is blank")
     return token
 
-def _get_user():
-    """ Retrieve the current user object.
-    """
-    return g.userobj
 
-def _get_safe_username():
-    """ Retrieve the current username with unsafe characters URL-encoded.
-    """
-    return urllib.quote(_get_user().name, safe='')
-
-def validate_token(token):
-    """ Verify the integrity of the provided token.
-    It must have the expected format (hash!timestamp/nonce/username),
-    the hash must match the other values,
-    the username must match the current account,
-    and it must not be older than our limit (currently 30 minutes).
-    """
-    token_values = read_token_values(token)
-    if not 'hash' in token_values:
-        return False
-
-    expected_hmac = unicode(get_digest(token_values['message']))
-    if not hmac.compare_digest(expected_hmac, token_values['hash']):
-        return False
-
-    now = int(time.time())
-    timestamp = token_values['timestamp']
-    # allow tokens up to 30 minutes old
-    if now < timestamp or now - timestamp > 60 * 30:
-        return False
-
-    if token_values['username'] != _get_safe_username():
-        return False
-
-    return True
-
-def read_token_values(token):
-    """ Parse the provided token string. Invalid tokens are parsed as empty dicts.
-    """
-    if not TOKEN_VALIDATION_PATTERN.match(token):
-        return {}
-
-    parts = token.split('!', 1)
-    message = parts[1]
-    # limiting to 2 means that even if a username contains a slash, it won't cause an extra split
-    message_parts = message.split('/', 2)
-
-    return {
-        "message": message,
-        "hash": unicode(parts[0]),
-        "timestamp": int(message_parts[0]),
-        "nonce": int(message_parts[1]),
-        "username": message_parts[2]
-    }
-
-def _get_response_token():
+def get_response_token(request, response):
     """Retrieve the token to be injected into pages.
     This will be retrieved from the 'token' cookie, if it exists and is fresh.
     If not, a new token will be generated and a new cookie set.
     """
     # ensure that the same token is used when a page is assembled from pieces
-    if request.environ['webob.adhoc_attrs'].has_key('response_token'):
-        LOG.debug("Reusing response token from request attributes")
-        token = request.response_token
-    elif request.cookies.has_key(TOKEN_FIELD_NAME):
-        LOG.debug("_get_response_token(): Obtaining token from cookie")
+    if TOKEN_FIELD_NAME in request.cookies and TOKEN_FRESHNESS_COOKIE_NAME in request.cookies:
+        LOG.debug("Obtaining token from cookie")
         token = request.cookies.get(TOKEN_FIELD_NAME)
-        if not validate_token(token) or is_soft_expired(token):
-            LOG.debug("Invalid or expired cookie token; making new token cookie")
-            token = create_response_token()
-        request.response_token = token
+        if not HEX_PATTERN.match(token):
+            LOG.debug("Invalid cookie token; making new token cookie")
+            token = create_response_token(response)
     else:
-        LOG.debug("No valid token found; making new token cookie")
-        token = create_response_token()
-        request.response_token = token
-
+        LOG.debug("No fresh token found; making new token cookie")
+        token = create_response_token(response)
     return token
 
-def is_soft_expired(token):
-    """Check whether the token is old enough to need rotation.
-    It may still be valid, but it's time to generate a new one.
-    The current rotation age is 10 minutes.
-    """
-    if not validate_token(token):
-        return False
 
-    now = int(time.time())
-    token_values = read_token_values(token)
-
-    return now - token_values['timestamp'] > 60 * 10
-
-def _get_secret_key():
-    """ Retrieve the secret key to use in generating secure hashes.
-    Currently this is the Beaker session secret.
-    """
-    return config.get('beaker.session.secret')
-
-def get_digest(message):
-    """ Generate a secure (unforgeable) hash of the provided data.
-    """
-    return hmac.HMAC(_get_secret_key(), message, hashlib.sha512).hexdigest()
-
-def create_response_token():
-    """ Generate an unforgeable CSRF token. The format of this token is:
-    hash!timestamp/nonce/username
-    where the hash is a secure HMAC of the other values plus a secret key.
-    """
-    username = _get_safe_username()
-    timestamp = int(time.time())
-    nonce = random.randint(1, 999999)
-    message = "{}/{}/{}".format(timestamp, nonce, username)
-    token = "{}!{}".format(get_digest(message), message)
-
-    _set_response_token_cookie(token)
+def create_response_token(response):
+    import binascii, os
+    token = binascii.hexlify(os.urandom(32))
+    response.set_cookie(TOKEN_FIELD_NAME, token, secure=True, httponly=True)
+    response.set_cookie(TOKEN_FRESHNESS_COOKIE_NAME, '1', max_age=600, secure=True, httponly=True)
     return token
-
-def _set_response_token_cookie(token):
-    """ Add a generated token cookie to the HTTP response
-    """
-    try:
-        # Flask requests are handled in the after_request.
-        if not is_flask_request():
-            response.set_cookie(TOKEN_FIELD_NAME, token, secure=True, httponly=True)
-            LOG.error(response)
-    except Exception as e:
-        LOG.error(e)
-        LOG.error("Setting response cookie failed.")
-
-def is_request_exempt():
-    """ Determine whether a request needs to provide a token.
-    HTTP methods without side effects (GET, HEAD, OPTIONS) are exempt, as are API calls
-    (which should instead provide an API key).
-    """
-    return (not is_logged_in() or bool(API_URL.match(request.path)) or request.method in {'GET', 'HEAD', 'OPTIONS'})
-
-def anti_csrf_before(obj, action, **params):
-    """ Wrap the core pre-rendering function to require tokens on applicable requests.
-    """
-    RAW_BEFORE(obj, action)
-
-    if not is_request_exempt() and _get_cookie_token() != _get_post_token():
-        csrf_fail("Could not match session token with form token")
 
 
 def csrf_fail(message):
-    """ Abort the request and return an error when there is a problem with the CSRF token.
-    """
+    from flask import abort
     LOG.error(message)
-    base.abort(403, "Your form submission could not be validated")
+    abort(403, "Your form submission could not be validated")
 
-def _get_post_token():
+
+def get_post_token(request):
     """Retrieve the token provided by the client.
     This is normally a single 'token' parameter in the POST body.
     However, for compatibility with 'confirm-action' links,
@@ -266,41 +123,21 @@ def _get_post_token():
 
     # handle query string token if there are no POST parameters
     # this is needed for the 'confirm-action' JavaScript module
-    try:
-        if (not request.method == 'POST') and (request.args.get(TOKEN_FIELD_NAME) and len(request.args.get(TOKEN_FIELD_NAME)) == 1):
-            request.token = request.GET.getone(TOKEN_FIELD_NAME)
-            if request.args.get(TOKEN_FIELD_NAME):
-                del request.args[TOKEN_FIELD_NAME]
-            return request.token
-    except Exception as e:
-        LOG.error(e)
+    if not request.POST and len(request.GET.getall(TOKEN_FIELD_NAME)) == 1:
+        request.token = request.GET.getone(TOKEN_FIELD_NAME)
+        del request.GET[TOKEN_FIELD_NAME]
+        return request.token
 
-    post_tokens = request.form.getlist(TOKEN_FIELD_NAME)
-
-    if not post_tokens:
+    postTokens = request.POST.getall(TOKEN_FIELD_NAME)
+    if not postTokens:
         csrf_fail("Missing CSRF token in form submission")
-    elif len(post_tokens) > 1:
+    elif len(postTokens) > 1:
         csrf_fail("More than one CSRF token in form submission")
     else:
-        request.token = post_tokens[0]
-    # drop token from request so it doesn't populate resource extras
-    #del request.form.get[TOKEN_FIELD_NAME]
+        request.token = postTokens[0]
 
-    if not validate_token(request.token):
-        csrf_fail("Invalid token format")
+    # drop token from request so it doesn't populate resource extras
+    del request.POST[TOKEN_FIELD_NAME]
 
     return request.token
-
-
-def anti_csrf_ckan_before_request():
-    if (not is_request_exempt() and (_get_cookie_token() != _get_post_token())):
-        csrf_fail("Could not match session token with form token")
-
-
-
-def intercept_csrf():
-    """ Monkey-patch the core rendering methods to apply our CSRF tokens.
-    """
-    base.render = anti_csrf_render
-#    base.BaseController.__before__ = anti_csrf_before
 

--- a/ckanext/ontario_theme/anti_csrf3.py
+++ b/ckanext/ontario_theme/anti_csrf3.py
@@ -1,0 +1,120 @@
+import anti_csrf
+import webob
+from webob.exc import HTTPForbidden
+
+import logging
+
+log = logging.getLogger(__name__)
+
+
+CSRF_ERR = 'CSRF authentication failed. Token missing or invalid.'
+
+
+class Request(webob.Request):
+    def __init__(self, environ):
+        super(Request, self).__init__(environ)
+        self.token = self._get_post_token()
+
+    def is_secure(self):
+        # allow requests which have the x-forwarded-proto of https (inserted by nginx)
+        if self.headers.get('X-Forwarded-Proto') == 'https':
+            return True
+        return self.scheme == 'https'
+
+    def is_safe(self):
+        "Check if the request is 'safe', if the request is safe it will not be checked for csrf"
+        # api requests are exempt from csrf checks
+        if self.path.startswith("/api"):
+            return True
+
+        # get/head/options/trace are exempt from csrf checks
+        return self.method in ('GET', 'HEAD', 'OPTIONS', 'TRACE')
+
+    def good_referer(self, domain):
+        "Returns true if the referrer is https and matching the host"
+        if not self.referer:
+            return False
+        else:
+            match = "https://{}".format(domain)
+            return self.referer.startswith(match)
+
+    def good_origin(self, domain):
+        """
+        checks if the origin header is present and matches the header"
+        :param domain: string: the expected origin domain
+        :return: boolean: true if the origin header is present and matches the expected domain
+        """
+        origin = self.headers.get('origin', None)
+        if not origin:
+            log.warning("Potentially unsafe CSRF request is missing the origin header")
+            return True
+        else:
+            match = "https://{}".format(domain)
+            return origin.startswith(match)
+
+    def _get_post_token(self):
+        """Retrieve the token provided by the client. Or return None if not present
+            This is normally a single 'token' parameter in the POST body.
+            However, for compatibility with 'confirm-action' links,
+            it is also acceptable to provide the token as a query string parameter,
+            if there is no POST body.
+        """
+        # handle query string token if there are no POST parameters
+        # this is needed for the 'confirm-action' JavaScript module
+        if not self.POST and len(self.GET.getall(anti_csrf.TOKEN_FIELD_NAME)) == 1:
+            token = self.GET.getone(anti_csrf.TOKEN_FIELD_NAME)
+            del self.GET[anti_csrf.TOKEN_FIELD_NAME]
+            return token
+        post_tokens = self.POST.getall(anti_csrf.TOKEN_FIELD_NAME)
+        if not post_tokens or len(post_tokens) != 1:
+            return None
+        token = post_tokens[0]
+        # drop token from request so it doesn't populate resource extras
+        del self.POST[anti_csrf.TOKEN_FIELD_NAME]
+        return token
+
+    def get_cookie_token(self):
+        """Retrieve the token expected by the server.
+           This will be retrieved from the 'token' cookie
+           """
+        if anti_csrf.TOKEN_FIELD_NAME in self.cookies:
+            log.debug("Obtaining token from cookie")
+            return self.cookies.get(anti_csrf.TOKEN_FIELD_NAME)
+        else:
+            return None
+
+    def check_token(self):
+        log.debug("Checking token matches Token {}, cookie_token: {}".format(self.token, self.get_cookie_token()))
+        return self.token is not None and self.token == self.get_cookie_token()
+
+class CSRFMiddleware(object):
+    def __init__(self, app, config):
+        self.app = app
+        self.domain = config['ckanext.security.domain']
+
+    def __call__(self, environ, start_response):
+        request = Request(environ)
+        self.session = environ['beaker.session']
+        self.session.save()
+        if self.is_valid(request):
+            resp = request.get_response(self.app)
+        else:
+            resp = HTTPForbidden(CSRF_ERR)
+            return resp(environ, start_response)
+        if 'text/html' in resp.headers.get('Content-type', ''):
+            token = anti_csrf.get_response_token(request, resp)
+
+            new_response = anti_csrf.apply_token(resp.unicode_body, token)
+            resp.unicode_body = new_response
+            return resp(environ, start_response)
+
+        else:
+            response_value = resp(environ, start_response)
+            return response_value
+
+    def is_valid(self, request):
+        return request.is_safe() or self.unsafe_request_is_valid(request)
+
+    def unsafe_request_is_valid(self, request):
+        return request.is_secure() and request.good_referer(self.domain) and \
+               request.good_origin(self.domain) and request.check_token()

--- a/ckanext/ontario_theme/anti_csrf3.py
+++ b/ckanext/ontario_theme/anti_csrf3.py
@@ -2,6 +2,10 @@ import anti_csrf
 import webob
 from webob.exc import HTTPForbidden
 
+from flask import Flask, make_response, render_template, request
+from ckan.common import config, is_flask_request
+import ckan.lib.base as base
+
 import logging
 
 log = logging.getLogger(__name__)
@@ -9,112 +13,109 @@ log = logging.getLogger(__name__)
 
 CSRF_ERR = 'CSRF authentication failed. Token missing or invalid.'
 
+domain = config.get('ckan.ontario_theme.csrf_domain', '')
 
-class Request(webob.Request):
-    def __init__(self, environ):
-        super(Request, self).__init__(environ)
-        self.token = self._get_post_token()
 
-    def is_secure(self):
-        # allow requests which have the x-forwarded-proto of https (inserted by nginx)
-        if self.headers.get('X-Forwarded-Proto') == 'https':
-            return True
-        return self.scheme == 'https'
 
-    def is_safe(self):
-        "Check if the request is 'safe', if the request is safe it will not be checked for csrf"
-        # api requests are exempt from csrf checks
-        if self.path.startswith("/api"):
-            return True
+def after_request_function(response):
+    #request = Request(environ)
+    #self.session = environ['beaker.session']
+    #self.session.save()
+    #if is_valid():
+    resp = response
+    #else:
+    #    return response
+    if 'text/html' in resp.headers.get('Content-type', ''):
+        token = anti_csrf.get_response_token(request, resp)
+        new_response = anti_csrf.apply_token(resp.get_data(as_text=True), token)
+        resp.set_data(new_response)
+        return resp
 
-        # get/head/options/trace are exempt from csrf checks
-        return self.method in ('GET', 'HEAD', 'OPTIONS', 'TRACE')
+    else:
+        return response
 
-    def good_referer(self, domain):
-        "Returns true if the referrer is https and matching the host"
-        if not self.referer:
-            return False
-        else:
-            match = "https://{}".format(domain)
-            return self.referer.startswith(match)
+def is_valid():#
+    return is_safe() or unsafe_request_is_valid()
 
-    def good_origin(self, domain):
-        """
-        checks if the origin header is present and matches the header"
-        :param domain: string: the expected origin domain
-        :return: boolean: true if the origin header is present and matches the expected domain
-        """
-        origin = self.headers.get('origin', None)
-        if not origin:
-            log.warning("Potentially unsafe CSRF request is missing the origin header")
-            return True
-        else:
-            match = "https://{}".format(domain)
-            return origin.startswith(match)
+def unsafe_request_is_valid():
+#        return is_secure() and good_referer() and \
+#               good_origin() and check_token()
+    return check_token()
 
-    def _get_post_token(self):
-        """Retrieve the token provided by the client. Or return None if not present
-            This is normally a single 'token' parameter in the POST body.
-            However, for compatibility with 'confirm-action' links,
-            it is also acceptable to provide the token as a query string parameter,
-            if there is no POST body.
-        """
-        # handle query string token if there are no POST parameters
-        # this is needed for the 'confirm-action' JavaScript module
-        if not self.POST and len(self.GET.getall(anti_csrf.TOKEN_FIELD_NAME)) == 1:
-            token = self.GET.getone(anti_csrf.TOKEN_FIELD_NAME)
-            del self.GET[anti_csrf.TOKEN_FIELD_NAME]
-            return token
-        post_tokens = self.POST.getall(anti_csrf.TOKEN_FIELD_NAME)
-        if not post_tokens or len(post_tokens) != 1:
-            return None
-        token = post_tokens[0]
-        # drop token from request so it doesn't populate resource extras
-        del self.POST[anti_csrf.TOKEN_FIELD_NAME]
+##############################################################################
+
+
+def is_secure():
+    # allow requests which have the x-forwarded-proto of https (inserted by nginx)
+    if request.headers.get('X-Forwarded-Proto') == 'https':
+        return True
+    return request.scheme == 'https'
+
+def is_safe():
+    "Check if the request is 'safe', if the request is safe it will not be checked for csrf"
+    # api requests are exempt from csrf checks
+    if request.path.startswith("/api"):
+        return True
+
+    # get/head/options/trace are exempt from csrf checks
+    return request.method in ('GET', 'HEAD', 'OPTIONS', 'TRACE')
+
+def good_referer():
+    "Returns true if the referrer is https and matching the host"
+    if not request.headers.get('Referer'):
+        return False
+    else:
+        match = "https://{}".format(domain)
+        return request.headers.get('Referer').startswith(match)
+
+def good_origin():
+    """
+    checks if the origin header is present and matches the header"
+    :param domain: string: the expected origin domain
+    :return: boolean: true if the origin header is present and matches the expected domain
+    """
+    origin = request.headers.get('origin', None)
+    if not origin:
+        log.warning("Potentially unsafe CSRF request is missing the origin header")
+        return True
+    else:
+        match = "https://{}".format(domain)
+        return origin.startswith(match)
+
+def _get_post_token():
+    """Retrieve the token provided by the client. Or return None if not present
+        This is normally a single 'token' parameter in the POST body.
+        However, for compatibility with 'confirm-action' links,
+        it is also acceptable to provide the token as a query string parameter,
+        if there is no POST body.
+    """
+    if request.environ['webob.adhoc_attrs'].has_key(anti_csrf.TOKEN_FIELD_NAME):
+        return request.token
+    # handle query string token if there are no POST parameters
+    # this is needed for the 'confirm-action' JavaScript module
+    if not request.method == 'POST' and (request.args.get(anti_csrf.TOKEN_FIELD_NAME) and len(request.args.get(anti_csrf.TOKEN_FIELD_NAME)) == 1):
+        token = request.args.get(TOKEN_FIELD_NAME)
+        #del request.GET[anti_csrf.TOKEN_FIELD_NAME]
         return token
+    post_tokens = request.form.getlist(anti_csrf.TOKEN_FIELD_NAME)
+    if not post_tokens or len(post_tokens) != 1:
+        return None
+    token = post_tokens[0]
+    # drop token from request so it doesn't populate resource extras
+    #del request.POST[anti_csrf.TOKEN_FIELD_NAME]
+    return token
 
-    def get_cookie_token(self):
-        """Retrieve the token expected by the server.
-           This will be retrieved from the 'token' cookie
-           """
-        if anti_csrf.TOKEN_FIELD_NAME in self.cookies:
-            log.debug("Obtaining token from cookie")
-            return self.cookies.get(anti_csrf.TOKEN_FIELD_NAME)
-        else:
-            return None
+def get_cookie_token():
+    """Retrieve the token expected by the server.
+       This will be retrieved from the 'token' cookie
+       """
+    if anti_csrf.TOKEN_FIELD_NAME in request.cookies:
+        log.debug("Obtaining token from cookie")
+        return request.cookies.get(anti_csrf.TOKEN_FIELD_NAME)
+    else:
+        return None
 
-    def check_token(self):
-        log.debug("Checking token matches Token {}, cookie_token: {}".format(self.token, self.get_cookie_token()))
-        return self.token is not None and self.token == self.get_cookie_token()
+def check_token():
+    log.debug("Checking token matches Token {}, cookie_token: {}".format(_get_post_token(), get_cookie_token()))
+    return _get_post_token() is not None and _get_post_token() == get_cookie_token()
 
-class CSRFMiddleware(object):
-    def __init__(self, app, config):
-        self.app = app
-        self.domain = config['ckanext.security.domain']
-
-    def __call__(self, environ, start_response):
-        request = Request(environ)
-        self.session = environ['beaker.session']
-        self.session.save()
-        if self.is_valid(request):
-            resp = request.get_response(self.app)
-        else:
-            resp = HTTPForbidden(CSRF_ERR)
-            return resp(environ, start_response)
-        if 'text/html' in resp.headers.get('Content-type', ''):
-            token = anti_csrf.get_response_token(request, resp)
-
-            new_response = anti_csrf.apply_token(resp.unicode_body, token)
-            resp.unicode_body = new_response
-            return resp(environ, start_response)
-
-        else:
-            response_value = resp(environ, start_response)
-            return response_value
-
-    def is_valid(self, request):
-        return request.is_safe() or self.unsafe_request_is_valid(request)
-
-    def unsafe_request_is_valid(self, request):
-        return request.is_secure() and request.good_referer(self.domain) and \
-               request.good_origin(self.domain) and request.check_token()

--- a/ckanext/ontario_theme/orig_anti_csrf.py
+++ b/ckanext/ontario_theme/orig_anti_csrf.py
@@ -1,0 +1,283 @@
+# encoding: utf-8
+"""Provides a self-contained filter to prevent Cross-Site Request Forgery,
+based on the Double Submit Cookie pattern,
+www.owasp.org/index.php/Cross-Site_Request_Forgery_(CSRF)_Prevention_Cheat_Sheet#Double_Submit_Cookie
+The filter can be enabled simply by invoking 'intercept_csrf()'.
+"""
+import hashlib
+import hmac
+import random
+import re
+from re import IGNORECASE, MULTILINE
+import time
+import urllib
+from logging import getLogger
+
+from ckan.common import config, request, response, g
+import ckan.lib.base as base
+
+LOG = getLogger(__name__)
+
+RAW_RENDER_JINJA = base.render_jinja2
+RAW_BEFORE = base.BaseController.__before__
+
+""" Used as the cookie name and input field name.
+"""
+TOKEN_FIELD_NAME = 'token'
+
+"""
+This will match a POST form that has whitespace after the opening tag (which all existing forms do).
+Once we have injected a token immediately after the opening tag,
+it won't match any more, which avoids redundant injection.
+"""
+POST_FORM = re.compile(r'(<form [^>]*method=["\']post["\'][^>]*>)(\s[^<]*<)', IGNORECASE|MULTILINE)
+
+"""The format of the token HTML field.
+"""
+TOKEN_VALIDATION_PATTERN = re.compile(r'^[0-9a-z]+![0-9]+/[0-9]+/[-_a-z0-9%]+$', IGNORECASE)
+API_URL = re.compile(r'^/api\b.*')
+CONFIRM_MODULE_PATTERN = r'data-module=["\']confirm-action["\']'
+HREF_URL_PATTERN = r'href=["\']([^"\']+)'
+
+# We need to edit confirm-action links, which get intercepted by JavaScript,
+#regardless of which order their 'data-module' and 'href' attributes appear.
+CONFIRM_LINK = re.compile(r'(<a [^>]*{}[^>]*{})(["\'])'.format(
+    CONFIRM_MODULE_PATTERN, HREF_URL_PATTERN),
+                          IGNORECASE|MULTILINE)
+CONFIRM_LINK_REVERSED = re.compile(r'(<a [^>]*{})(["\'][^>]*{})'.format(
+    HREF_URL_PATTERN, CONFIRM_MODULE_PATTERN),
+                                   IGNORECASE|MULTILINE)
+
+def is_logged_in():
+    """ Determine whether the user is currently logged in and thus needs a token.
+    TODO Also require a token on login/logout forms.
+    """
+    return _get_user()
+
+def anti_csrf_render_jinja2(template_name, extra_vars=None):
+    """ Wrap the core page-rendering function and inject tokens into HTML where appropriate.
+    """
+    html = apply_token(RAW_RENDER_JINJA(template_name, extra_vars))
+    return html
+
+def apply_token(html):
+    """ Rewrite HTML to insert tokens if applicable.
+    """
+    if not is_logged_in() or (
+            not POST_FORM.search(html) and not re.search(CONFIRM_MODULE_PATTERN, html)):
+        return html
+
+    token = _get_response_token()
+
+    def insert_form_token(form_match):
+        """ Inject a token into a POST form. """
+        return form_match.group(1) + '<input type="hidden" name="{}" value="{}"/>'.format(TOKEN_FIELD_NAME, token) + form_match.group(2)
+
+    def insert_link_token(link_match):
+        """ Inject a token into a link that uses data-module="confirm-action".
+        These links are picked up by JavaScript and converted into empty POST requests.
+        """
+        if TOKEN_FIELD_NAME + '=' in link_match.group(1):
+            return link_match.group(0)
+        if '?' in link_match.group(2):
+            separator = '&'
+        else:
+            separator = '?'
+        return link_match.group(1) + separator + TOKEN_FIELD_NAME + '=' + token + link_match.group(3)
+
+    return CONFIRM_LINK_REVERSED.sub(insert_link_token, CONFIRM_LINK.sub(insert_link_token, POST_FORM.sub(insert_form_token, html)))
+
+def _get_cookie_token():
+    """ Retrieve the token expected by the server.
+    This will be retrieved from the 'token' cookie, if it exists.
+    If not, an error will occur.
+    """
+    token = None
+    if request.cookies.has_key(TOKEN_FIELD_NAME):
+        LOG.debug("Obtaining token from cookie")
+        token = request.cookies.get(TOKEN_FIELD_NAME)
+    if token is None or token.strip() == "":
+        csrf_fail("CSRF token is blank")
+
+    return token
+
+def _get_user():
+    """ Retrieve the current user object.
+    """
+    return g.userobj
+
+def _get_safe_username():
+    """ Retrieve the current username with unsafe characters URL-encoded.
+    """
+    return urllib.quote(_get_user().name, safe='')
+
+def validate_token(token):
+    """ Verify the integrity of the provided token.
+    It must have the expected format (hash!timestamp/nonce/username),
+    the hash must match the other values,
+    the username must match the current account,
+    and it must not be older than our limit (currently 30 minutes).
+    """
+    token_values = read_token_values(token)
+    if not 'hash' in token_values:
+        return False
+
+    expected_hmac = unicode(get_digest(token_values['message']))
+    if not hmac.compare_digest(expected_hmac, token_values['hash']):
+        return False
+
+    now = int(time.time())
+    timestamp = token_values['timestamp']
+    # allow tokens up to 30 minutes old
+    if now < timestamp or now - timestamp > 60 * 30:
+        return False
+
+    if token_values['username'] != _get_safe_username():
+        return False
+
+    return True
+
+def read_token_values(token):
+    """ Parse the provided token string. Invalid tokens are parsed as empty dicts.
+    """
+    if not TOKEN_VALIDATION_PATTERN.match(token):
+        return {}
+
+    parts = token.split('!', 1)
+    message = parts[1]
+    # limiting to 2 means that even if a username contains a slash, it won't cause an extra split
+    message_parts = message.split('/', 2)
+
+    return {
+        "message": message,
+        "hash": unicode(parts[0]),
+        "timestamp": int(message_parts[0]),
+        "nonce": int(message_parts[1]),
+        "username": message_parts[2]
+    }
+
+def _get_response_token():
+    """Retrieve the token to be injected into pages.
+    This will be retrieved from the 'token' cookie, if it exists and is fresh.
+    If not, a new token will be generated and a new cookie set.
+    """
+    # ensure that the same token is used when a page is assembled from pieces
+    if request.environ['webob.adhoc_attrs'].has_key('response_token'):
+        LOG.debug("Reusing response token from request attributes")
+        token = request.response_token
+    elif request.cookies.has_key(TOKEN_FIELD_NAME):
+        LOG.debug("Obtaining token from cookie")
+        token = request.cookies.get(TOKEN_FIELD_NAME)
+        if not validate_token(token) or is_soft_expired(token):
+            LOG.debug("Invalid or expired cookie token; making new token cookie")
+            token = create_response_token()
+        request.response_token = token
+    else:
+        LOG.debug("No valid token found; making new token cookie")
+        token = create_response_token()
+        request.response_token = token
+
+    return token
+
+def is_soft_expired(token):
+    """Check whether the token is old enough to need rotation.
+    It may still be valid, but it's time to generate a new one.
+    The current rotation age is 10 minutes.
+    """
+    if not validate_token(token):
+        return False
+
+    now = int(time.time())
+    token_values = read_token_values(token)
+
+    return now - token_values['timestamp'] > 60 * 10
+
+def _get_secret_key():
+    """ Retrieve the secret key to use in generating secure hashes.
+    Currently this is the Beaker session secret.
+    """
+    return config.get('beaker.session.secret')
+
+def get_digest(message):
+    """ Generate a secure (unforgeable) hash of the provided data.
+    """
+    return hmac.HMAC(_get_secret_key(), message, hashlib.sha512).hexdigest()
+
+def create_response_token():
+    """ Generate an unforgeable CSRF token. The format of this token is:
+    hash!timestamp/nonce/username
+    where the hash is a secure HMAC of the other values plus a secret key.
+    """
+    username = _get_safe_username()
+    timestamp = int(time.time())
+    nonce = random.randint(1, 999999)
+    message = "{}/{}/{}".format(timestamp, nonce, username)
+    token = "{}!{}".format(get_digest(message), message)
+
+    _set_response_token_cookie(token)
+    return token
+
+def _set_response_token_cookie(token):
+    """ Add a generated token cookie to the HTTP response
+    """
+    response.set_cookie(TOKEN_FIELD_NAME, token, secure=True, httponly=True)
+
+def is_request_exempt():
+    """ Determine whether a request needs to provide a token.
+    HTTP methods without side effects (GET, HEAD, OPTIONS) are exempt, as are API calls
+    (which should instead provide an API key).
+    """
+    return not is_logged_in() or API_URL.match(request.path) or request.method in {'GET', 'HEAD', 'OPTIONS'}
+
+def anti_csrf_before(obj, action, **params):
+    """ Wrap the core pre-rendering function to require tokens on applicable requests.
+    """
+    RAW_BEFORE(obj, action)
+
+    if not is_request_exempt() and _get_cookie_token() != _get_post_token():
+        csrf_fail("Could not match session token with form token")
+
+def csrf_fail(message):
+    """ Abort the request and return an error when there is a problem with the CSRF token.
+    """
+    LOG.error(message)
+    base.abort(403, "Your form submission could not be validated")
+
+def _get_post_token():
+    """Retrieve the token provided by the client.
+    This is normally a single 'token' parameter in the POST body.
+    However, for compatibility with 'confirm-action' links,
+    it is also acceptable to provide the token as a query string parameter,
+    if there is no POST body.
+    """
+    if request.environ['webob.adhoc_attrs'].has_key(TOKEN_FIELD_NAME):
+        return request.token
+
+    # handle query string token if there are no POST parameters
+    # this is needed for the 'confirm-action' JavaScript module
+    if not request.POST and len(request.GET.getall(TOKEN_FIELD_NAME)) == 1:
+        request.token = request.GET.getone(TOKEN_FIELD_NAME)
+        del request.GET[TOKEN_FIELD_NAME]
+        return request.token
+
+    post_tokens = request.POST.getall(TOKEN_FIELD_NAME)
+    if not post_tokens:
+        csrf_fail("Missing CSRF token in form submission")
+    elif len(post_tokens) > 1:
+        csrf_fail("More than one CSRF token in form submission")
+    else:
+        request.token = post_tokens[0]
+
+    # drop token from request so it doesn't populate resource extras
+    del request.POST[TOKEN_FIELD_NAME]
+
+    if not validate_token(request.token):
+        csrf_fail("Invalid token format")
+
+    return request.token
+
+def intercept_csrf():
+    """ Monkey-patch the core rendering methods to apply our CSRF tokens.
+    """
+    base.render_jinja2 = anti_csrf_render_jinja2
+    base.BaseController.__before__ = anti_csrf_before

--- a/ckanext/ontario_theme/orig_anti_csrf.py
+++ b/ckanext/ontario_theme/orig_anti_csrf.py
@@ -23,7 +23,7 @@ RAW_BEFORE = base.BaseController.__before__
 
 """ Used as the cookie name and input field name.
 """
-TOKEN_FIELD_NAME = 'token'
+TOKEN_FIELD_NAME = 'pylons_token'
 
 """
 This will match a POST form that has whitespace after the opening tag (which all existing forms do).


### PR DESCRIPTION
CKAN is currently running both pylons and flask and migrating
towards only flask. Current CSRF approaches only address pylons
requests.

After trying numerous options this seemed like the most reliable and enables
easy throw away once pylons is completely gone from CKAN.

Basic concept is to run the original CSRF with very minor changes. Then use a
modified version to handle Flask.

I used 2 repos as my bases: [ckanext-security](https://github.com/data-govt-nz/ckanext-security) and [ckan-ex-qgov](https://github.com/qld-gov-au/ckan-ex-qgov).

anti_csrf3.py is the modified [middleware.py](https://github.com/data-govt-nz/ckanext-security/blob/master/ckanext/security/middleware.py) that breaks apart the classes
and modified for Flask. I liked most of how this version, ckanext-security,
was implemented which is why I used it instead of the ckan-ex-qgov.

ckan-ex-qgov I used as the base for pylons as it didn't
require middleware or modifying CKAN directly (middleware implementation).

**File references:**

1. orig_anti_csrf.py was from https://github.com/qld-gov-au/ckan-ex-qgov/blob/master/ckanext/qgov/common/anti_csrf.py
2. anti_csrf.py was from https://github.com/data-govt-nz/ckanext-security/blob/master/ckanext/security/anti_csrf.py
3. anti_csrf3.py was from https://github.com/data-govt-nz/ckanext-security/blob/master/ckanext/security/middleware.py