### PR TITLE
Dependent field validator

### DIFF
--- a/ckanext/ontario_theme/fanstatic/ontario_theme_dataset_form_validators.js
+++ b/ckanext/ontario_theme/fanstatic/ontario_theme_dataset_form_validators.js
@@ -1,0 +1,45 @@
+// Enable JavaScript's strict mode. Strict mode catches some common
+// programming errors and throws exceptions, prevents some unsafe actions from
+// being taken, and disables some confusing and bad JavaScript features.
+"use strict";
+
+ckan.module('conditional_behaviours', function ($) {  
+  return {
+    hide_if: null,
+    show_if: null,
+    trigger_values: null,
+    initialize: function () {
+
+      $(this.options.trigger_field).on('change', jQuery.proxy(this._onChange, this));
+      // which values will trigger hide/show
+      this.trigger_values = ("show_if" in this.options ? this.options.show_if : this.options.hide_if).split(",")
+      this.field_container = this.el.parents("div.controls.row")
+
+      $(this.options.trigger_field).change()
+      return null
+    },
+    _onChange: function (event) {
+      var value_selected = event.target.value
+
+      if ($.inArray(value_selected, this.trigger_values) != -1) {
+        if (!!this.options.hide_if) {
+          this.field_container.hide()
+        }
+        else if (!!this.options.show_if) {
+          this.field_container.show()
+
+        }
+      } else {
+        if (!!this.options.hide_if) {
+          this.field_container.show()
+        }
+        else if (!!this.options.show_if) {
+          this.field_container.hide()
+
+        }
+      }
+    }
+  };
+});
+
+

--- a/ckanext/ontario_theme/ontario_theme_dataset.json
+++ b/ckanext/ontario_theme/ontario_theme_dataset.json
@@ -505,6 +505,11 @@
       "help_text": {
         "en": "What is the specific exemption for this collection of resources to not be shared with the public? Refer to the <a href='https://www.ontario.ca/document/open-data-guidebook-guide-open-data-directive-2015/data-inventory#section-1' target='_blank'>Open Data Guidebook</a> for more on exemptions."
       },
+      "form_attrs": {
+        "data-module": "conditional_behaviours",
+        "data-module-trigger_field": "#field-access_level",
+        "data-module-show_if": "restricted"
+      },
       "classes": ["form-group","col-md-12"],
       "preset": "select",
       "validators": "ignore_missing default(none) scheming_choices",
@@ -563,6 +568,11 @@
       "help_text": {
         "en": "Explain why the resource cannot be disclosed to the public"
       }, 
+      "form_attrs": {
+        "data-module": "conditional_behaviours",
+        "data-module-trigger_field": "#field-access_level",
+        "data-module-show_if": "restricted"
+      },
       "classes": ["form-group","col-md-12"],
       "form_placeholder": "e.g., This dataset cannot be sufficiently de-identified to assure users cannot use it to identify members of the public.",      
       "preset": "fluent_markdown"

--- a/ckanext/ontario_theme/ontario_theme_dataset.json
+++ b/ckanext/ontario_theme/ontario_theme_dataset.json
@@ -512,7 +512,7 @@
       },
       "classes": ["form-group","col-md-12"],
       "preset": "select",
-      "validators": "ignore_missing default(none) scheming_choices",
+      "validators": "ignore_missing default(none) scheming_choices conditional_save(access_level,restricted)",
       "choices": [
         {
           "value": "commercial_sensitivity",
@@ -575,6 +575,7 @@
       },
       "classes": ["form-group","col-md-12"],
       "form_placeholder": "e.g., This dataset cannot be sufficiently de-identified to assure users cannot use it to identify members of the public.",      
+      "validators": "conditional_save(access_level,restricted)",
       "preset": "fluent_markdown"
     },
     {

--- a/ckanext/ontario_theme/plugin.py
+++ b/ckanext/ontario_theme/plugin.py
@@ -234,6 +234,18 @@ def get_package_keywords(language='en'):
     package_top_keywords = package_top_keywords['search_facets'][facet]['items']
     return package_top_keywords
 
+def conditional_save(dependent_field, dependent_value):
+    '''When key is missing or value is an empty string or None, replace it with
+    a default value'''
+
+    def callable(key, data, errors, context):
+
+        value = data.get(key)
+
+        if (data.get(dependent_field) != dependent_value):
+            data[key] = None
+
+    return callable
 
 def default_locale():
     '''Wrap the ckan default locale in a helper function to access
@@ -274,6 +286,7 @@ def num_resources_filter_scrub(search_params):
 class OntarioThemePlugin(plugins.SingletonPlugin):
     plugins.implements(plugins.IConfigurer)
     plugins.implements(plugins.IBlueprint)
+    plugins.implements(plugins.IValidators)
     plugins.implements(plugins.ITemplateHelpers)
     plugins.implements(plugins.IUploader, inherit=True)
     plugins.implements(plugins.IDatasetForm)
@@ -290,6 +303,14 @@ class OntarioThemePlugin(plugins.SingletonPlugin):
         # the above template and resource directories.
         # toolkit.add_template_directory(config_, 'templates-bs2')
         # toolkit.add_resource('fanstatic-bs2', 'ontario_theme')
+
+
+    # IValidators
+
+    def get_validators(self):
+        return {
+                'conditional_save': conditional_save}
+
 
     # ITemplateHelpers
 

--- a/ckanext/ontario_theme/templates/scheming/package/snippets/package_form.html
+++ b/ckanext/ontario_theme/templates/scheming/package/snippets/package_form.html
@@ -17,6 +17,9 @@ control-rows to align french and english fields side by side.
 {% endblock %}
 
 {% block basic_fields %}
+
+  {% resource 'ontario_theme/ontario_theme_dataset_form_validators.js' %}
+
   {%- if not dataset_type -%}
     <p>
     dataset_type not passed to template. your version of CKAN


### PR DESCRIPTION
This PR consists of two features, both applied to the exemption and exemption rationale fields:
 * a ckan js module that shows and hides a field based on the value of another field
 * a form validator that removes the values of a field unless another field has a certain value