### PR TITLE
Add french ga tags

### DIFF
--- a/ckanext/ontario_theme/plugin.py
+++ b/ckanext/ontario_theme/plugin.py
@@ -9,6 +9,7 @@ from flask import render_template, render_template_string
 import ckanapi_exporter.exporter as exporter
 import json
 import ckan.lib.i18n as i18n
+import ckan.lib.helpers as helpers
 
 from ckan.model import Package
 
@@ -230,11 +231,7 @@ def get_translated_lang(data_dict, field, specified_language):
     try:
         return data_dict[field + u'_translated'][specified_language]
     except KeyError:
-        try:
-            return data_dict[field + u'_translated'][site_language]
-        except KeyError:
-            val = data_dict.get(field, '')
-            return _(val) if val and isinstance(val, string_types) else val
+        return helpers.get_translated(data_dict, field)
 
 
 def get_package_keywords(language='en'):

--- a/ckanext/ontario_theme/plugin.py
+++ b/ckanext/ontario_theme/plugin.py
@@ -8,7 +8,6 @@ from flask import render_template, render_template_string
 
 import ckanapi_exporter.exporter as exporter
 import json
-import ckan.lib.i18n as i18n
 import ckan.lib.helpers as helpers
 
 from ckan.model import Package
@@ -227,7 +226,6 @@ def get_license(license_id):
     return Package.get_license_register().get(license_id)
 
 def get_translated_lang(data_dict, field, specified_language):
-    site_language = i18n.get_lang()
     try:
         return data_dict[field + u'_translated'][specified_language]
     except KeyError:

--- a/ckanext/ontario_theme/plugin.py
+++ b/ckanext/ontario_theme/plugin.py
@@ -8,6 +8,7 @@ from flask import render_template, render_template_string
 
 import ckanapi_exporter.exporter as exporter
 import json
+import ckan.lib.i18n as i18n
 
 from ckan.model import Package
 
@@ -224,6 +225,17 @@ def get_license(license_id):
     '''
     return Package.get_license_register().get(license_id)
 
+def get_translated_lang(data_dict, field, specified_language):
+    site_language = i18n.get_lang()
+    try:
+        return data_dict[field + u'_translated'][specified_language]
+    except KeyError:
+        try:
+            return data_dict[field + u'_translated'][site_language]
+        except KeyError:
+            val = data_dict.get(field, '')
+            return _(val) if val and isinstance(val, string_types) else val
+
 
 def get_package_keywords(language='en'):
     '''Helper to return a list of the top 3 keywords based on specified
@@ -348,6 +360,7 @@ type data_last_updated
 
     def get_helpers(self):
         return {'ontario_theme_get_license': get_license,
+                'ontario_theme_get_translated_lang': get_translated_lang,
                 'ontario_theme_get_popular_datasets': get_popular_datasets,
                 'ontario_theme_get_recently_updated_datasets': get_recently_updated_datasets,
                 'extrafields_default_locale': default_locale,

--- a/ckanext/ontario_theme/templates/internal/organization/read_base.html
+++ b/ckanext/ontario_theme/templates/internal/organization/read_base.html
@@ -4,7 +4,7 @@
 
 {% block breadcrumb_content %}
   <li>{% link_for _('Organizations'), controller='organization', action='index', named_route=group_type + '_index' %}</li>
-  <li id="ministry-name" ministry-name="{{c.group_dict.title}}" class="active">{% link_for h.get_translated(c.group_dict,"title")|truncate(35), controller='organization', action='read', id=c.group_dict.name, named_route=group_type + '_read' %}</li>
+  <li id="ministry-name" ministry-name="{{c.group_dict.title}}" ministry-name-fr="{{ h.ontario_theme_get_translated_lang(c.group_dict, 'title', 'fr') }}" class="active">{% link_for h.get_translated(c.group_dict,"title")|truncate(35), controller='organization', action='read', id=c.group_dict.name, named_route=group_type + '_read' %}</li>
 {% endblock %}
 
 {% block content_action %}

--- a/ckanext/ontario_theme/templates/internal/package/base.html
+++ b/ckanext/ontario_theme/templates/internal/package/base.html
@@ -3,15 +3,16 @@
 {% block breadcrumb_content %}
   {% if pkg %}
     {% set dataset = h.dataset_display_name(pkg) %}
+    {% set organization_dict = h.get_organization(pkg.organization.name) %}
     {% if pkg.organization %}
       {% set organization = h.get_translated(pkg.organization, 'title') or pkg.organization.name %}
       {% set group_type = pkg.organization.type %}
       <li>{% link_for _('Organizations'), controller='organization', action='index', named_route=group_type + '_index' %}</li>
-      <li id='ministry-name' ministry-name="{{pkg.organization.title}}">{% link_for organization|truncate(30), controller='organization', action='read', id=pkg.organization.name, named_route=group_type + '_read' %}</li>
+      <li id='ministry-name' ministry-name="{{pkg.organization.title}}" ministry-name-fr="{{ h.ontario_theme_get_translated_lang(organization_dict, 'title', 'fr') }}">{% link_for organization|truncate(30), controller='organization', action='read', id=pkg.organization.name, named_route=group_type + '_read' %}</li>
     {% else %}
       <li>{% link_for _('Datasets'), controller='package', action='search' %}</li>
     {% endif %}
-    <li id='dataset-name' dataset-name="{{pkg.title}}" {{ self.breadcrumb_content_selected() }}>{% link_for dataset|truncate(30), controller='package', action='read', id=pkg.name %}</li>
+    <li id='dataset-name' dataset-name="{{pkg.title}}" dataset-name-fr="{{ h.ontario_theme_get_translated_lang(pkg, 'title', 'fr') }}" {{ self.breadcrumb_content_selected() }}>{% link_for dataset|truncate(30), controller='package', action='read', id=pkg.name %}</li>
   {% else %}
     <li>{% link_for _('Datasets'), controller='package', action='search' %}</li>
     <li class="active"><a href="">{{ _('Create Dataset') }}</a></li>


### PR DESCRIPTION
This PR consists of 2 commits to:
 - add a get_translated function that takes a specified language
 - use that function to create ministry-name-fr and dataset-name-fr attributes for GA use on organization and dataset pages