### PR TITLE
Improvement: Remove link placeholder text.

### DIFF
--- a/ckanext/ontario_theme/schemas/external/ontario_theme_dataset.json
+++ b/ckanext/ontario_theme/schemas/external/ontario_theme_dataset.json
@@ -265,7 +265,7 @@
       },
       "help_inline" : true,
       "help_text": {
-        "en": "Let others know when they can expect new data. [more information on selecting an update frequency]"
+        "en": "Let others know when they can expect new data."
       }, 
       "preset": "select",
       "validators": "ignore_missing scheming_choices",

--- a/ckanext/ontario_theme/schemas/internal/ontario_theme_dataset.json
+++ b/ckanext/ontario_theme/schemas/internal/ontario_theme_dataset.json
@@ -266,7 +266,7 @@
       },
       "help_inline" : true,
       "help_text": {
-        "en": "Let others know when they can expect new data. [more information on selecting an update frequency]"
+        "en": "Let others know when they can expect new data."
       }, 
       "preset": "select",
       "validators": "ignore_missing scheming_choices",


### PR DESCRIPTION
Remove link placeholder text for update_frequency help text.
Currently there's nothing in the guidebook to link to.