### PR TITLE
Task: Cleanup tests.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -138,17 +138,20 @@ Running the Tests
 To run the tests, make sure your ckan install is `setup for tests <https://docs.ckan.org/en/latest/contributing/test.html>`_, do::
 
     cd ckanext-ontario_theme # go to extension directory
-    nosetests --nologcapture --with-pylons=test.ini # active vertual environment that has nosetests.
+    nosetests --nologcapture --with-pylons=test.ini # run in virtual environment that has nosetests.
 
 To run the tests and produce a coverage report, first make sure you have
 coverage installed in your virtualenv (``pip install coverage``) then run::
 
     nosetests --nologcapture --with-pylons=test.ini --with-coverage --cover-package=ckanext.ontario_theme --cover-inclusive --cover-erase --cover-tests
 
-Also, add scheming and fluent to ``/usr/lib/ckan/default/src/ckan/test-core.ini``::
+Our custom config settings are in ``./test.ini``.
 
-    ckan.plugins = stats scheming_datasets fluent
-    scheming.dataset_schemas = ckanext.extrafields:ontario_theme_dataset.json
-    scheming.presets = ckanext.scheming:presets.json
-                       ckanext.fluent:presets.json
+Additional ways to run tests:
 
+    # Single Test method
+    nosetests ckanext/ontario_theme/tests/test_create_dataset.py:TestCreateDataset.test_package_create_with_invalid_update_frequency --nologcapture --with-pylons=test.ini
+    # Single Test class
+    nosetests ckanext/ontario_theme/tests/test_create_dataset.py:TestCreateDataset --nologcapture --with-pylons=test.ini
+    # Single Test module
+    nosetests ckanext/ontario_theme/tests/test_create_dataset.py --nologcapture --with-pylons=test.ini

--- a/ckanext/ontario_theme/plugin.py
+++ b/ckanext/ontario_theme/plugin.py
@@ -315,7 +315,6 @@ class OntarioThemePlugin(plugins.SingletonPlugin, DefaultTranslation):
     plugins.implements(plugins.IBlueprint)
     plugins.implements(plugins.ITemplateHelpers)
     plugins.implements(plugins.IUploader, inherit=True)
-    plugins.implements(plugins.IDatasetForm)
     plugins.implements(plugins.IFacets)
     plugins.implements(plugins.IPackageController)
 
@@ -375,18 +374,6 @@ type data_last_updated
 
     def get_resource_uploader(self, data_dict):
         return ResourceUpload(data_dict)
-
-    # IDatasetForm
-
-    def is_fallback(self):
-        # Return True to register this plugin as the default handler for
-        # package types not handled by any other IDatasetForm plugin.
-        return True
-
-    def package_types(self):
-        # This plugin doesn't handle any special package types, it just
-        # registers itself as the default (above).
-        return []
 
     # IFacets
 

--- a/ckanext/ontario_theme/tests/test_create_dataset.py
+++ b/ckanext/ontario_theme/tests/test_create_dataset.py
@@ -54,15 +54,25 @@ class TestCreateDataset(object):
     def test_package_create_with_minimum_values(self):
         '''If dataset is given it's basic fields it is created.
         '''
+        org = factories.Organization()
         dataset = helpers.call_action(
             'package_create',
-            name='package-name',
-            maintainer='Joe Smith',
-            maintainer_email='Joe.Smith@ontario.ca',
-            title_translated={
-                'en': u'A Novel By Tolstoy', 'fr':u'Un novel par Tolstoy'},
-            notes_translated={'en': u'short description', 'fr': u'...'}
-            )
+            name = 'package-name',
+            maintainer_translated = {
+                'en': u'Joe Smith',
+                'fr': u'...'
+            },
+            maintainer_email = 'Joe.Smith@ontario.ca',
+            title_translated = {
+                'en': u'A Novel By Tolstoy',
+                'fr':u'Un novel par Tolstoy'
+            },
+            notes_translated = {
+                'en': u'short description',
+                'fr': u'...'
+            },
+            owner_org = org['name'] # depends on config.
+        )
         assert_equals(dataset['name'], 'package-name')
 
         dataset = helpers.call_action('package_show', id=dataset['id'])
@@ -71,43 +81,34 @@ class TestCreateDataset(object):
         dataset = helpers.call_action('package_show', id=dataset['id'])
         assert dataset['notes_translated']['en'] == u'short description'
 
-    def test_wrong_node_id_type(self):
-        '''If dataset is given a value for node_id it must be a positive integer.
-        Empty and missing values are allowed.
-        '''
-        assert_raises(
-            logic.ValidationError, helpers.call_action,
-            'package_create',
-            node_id='apple',
-            name='package-name',
-            maintainer='Joe Smith',
-            maintainer_email='Joe.Smith@ontario.ca',
-            title_translated={
-                'en': u'A Novel By Tolstoy', 'fr':u'Un novel par Tolstoy'},
-            notes_translated={'en': u'short description', 'fr': u'...'}
-        )
-
     def test_package_create_with_validated_values(self):
         '''If dataset is given custom validated keys with valid values
         a dataset is created.
         '''
+        org = factories.Organization()
         dataset = helpers.call_action(
             'package_create',
-            name='package-name',
-            maintainer='Joe Smith',
-            maintainer_email='Joe.Smith@ontario.ca',
-            title_translated={
-                'en': u'A Novel By Tolstoy', 'fr':u'Un novel par Tolstoy'},
-            node_id='123',
-            notes_translated={'en': u'short description', 'fr': u'...'},
+            name = 'package-name',
+            maintainer_translated = {
+                'en': u'Joe Smith',
+                'fr': u'...'
+            },
+            maintainer_email = 'Joe.Smith@ontario.ca',
+            title_translated = {
+                'en': u'A Novel By Tolstoy',
+                'fr':u'Un novel par Tolstoy'
+            },
+            notes_translated = {
+                'en': u'short description',
+                'fr': u'...'
+            },
+            owner_org = org['name'], # depends on config.
             current_as_of='',
             update_frequency='as_required',
             access_level='open',
             exemption='' # Defaults to none when key provided and value is empty.
         )
-        assert_equals(dataset['node_id'], '123')
         package_show = helpers.call_action('package_show', id=dataset['id'])
-        assert_equals(package_show['node_id'], '123')
         assert_equals(package_show['notes_translated']['en'], 'short description')
         assert 'current_as_of' not in package_show
         assert_equals(package_show['update_frequency'], 'as_required')
@@ -127,15 +128,24 @@ class TestCreateDataset(object):
         '''
 
         try:
-            helpers.call_action(
+            org = factories.Organization()
+            dataset = helpers.call_action(
                 'package_create',
-                name='package-name',
-                maintainer='Joe Smith',
-                maintainer_email='Joe.Smith@ontario.ca',
-                title_translated={
-                    'en': u'A Novel By Tolstoy', 'fr':u'Un novel par Tolstoy'},
-                node_id='123',
-                notes_translated={'en': u'short description', 'fr': u'...'},
+                name = 'package-name',
+                maintainer_translated = {
+                    'en': u'Joe Smith',
+                    'fr': u'...'
+                },
+                maintainer_email = 'Joe.Smith@ontario.ca',
+                title_translated = {
+                    'en': u'A Novel By Tolstoy',
+                    'fr':u'Un novel par Tolstoy'
+                },
+                notes_translated = {
+                    'en': u'short description',
+                    'fr': u'...'
+                },
+                owner_org = org['name'], # depends on config.
                 current_as_of='',
                 update_frequency='required',
                 access_level='open',
@@ -144,7 +154,7 @@ class TestCreateDataset(object):
         except logic.ValidationError as e:
             assert_equals(
                 e.error_dict['update_frequency'],
-                ['Value must be one of: as_required; biannually; current; daily; historical; monthly; never; on_demand; other; periodically; quarterly; weekly; yearly (not \'required\')']
+                ['Value must be one of: as_required; biannually; current; daily; historical; monthly; never; on_demand; other; periodically; quarterly; weekly; yearly; quinquennial (not \'required\')']
             )
         else:
             raise AssertionError('ValidationError not raised')
@@ -162,15 +172,24 @@ class TestCreateDataset(object):
         '''
 
         try:
-            helpers.call_action(
+            org = factories.Organization()
+            dataset = helpers.call_action(
                 'package_create',
-                name='package-name',
-                maintainer='Joe Smith',
-                maintainer_email='Joe.Smith@ontario.ca',
-                title_translated={
-                    'en': u'A Novel By Tolstoy', 'fr':u'Un novel par Tolstoy'},
-                node_id='123',
-                notes_translated={'en': u'short description', 'fr': u'...'},
+                name = 'package-name',
+                maintainer_translated = {
+                    'en': u'Joe Smith',
+                    'fr': u'...'
+                },
+                maintainer_email = 'Joe.Smith@ontario.ca',
+                title_translated = {
+                    'en': u'A Novel By Tolstoy',
+                    'fr':u'Un novel par Tolstoy'
+                },
+                notes_translated = {
+                    'en': u'short description',
+                    'fr': u'...'
+                },
+                owner_org = org['name'], # depends on config.
                 current_as_of='31/11/2018',
                 update_frequency='as_required',
                 access_level='open',

--- a/ckanext/ontario_theme/tests/test_helpers.py
+++ b/ckanext/ontario_theme/tests/test_helpers.py
@@ -6,6 +6,7 @@ import nose.tools
 import json
 import os
 import ckan.tests.helpers as helpers
+import ckan.tests.factories as factories
 import ckan.model as model
 import ckan.plugins as plugins
 import ckan.lib.search as search
@@ -17,13 +18,12 @@ from ckanext.ontario_theme.plugin import (
 )
 assert_equals = nose.tools.assert_equals
 
-
 class TestGetLicense(object):
     def test_get_license_returns_proper_value(self):
         '''Ensure get_license returns proper license object from licences.json.
         '''
         with open(os.path.join(
-            os.path.dirname(__file__), '..', 'licences.json')
+            os.path.dirname(__file__), '../schemas', 'licences.json')
         ) as licenses:
             license = json.load(licenses)[0]
         assert_equals(get_license("OGL-ON-1.0")._data, license)
@@ -68,16 +68,26 @@ class TestGetPackageKeywords(object):
         plugins.unload('ontario_theme')
 
     def test_get_package_keywords_returns_english_as_default(self):
+        org = factories.Organization()
         dataset = helpers.call_action(
-                'package_create',
-                name='package-name',
-                maintainer='Joe Smith',
-                maintainer_email='Joe.Smith@ontario.ca',
-                title_translated={
-                    'en': u'A Novel By Tolstoy', 'fr':u'Un novel par Tolstoy'},
-                notes_translated={'en': u'short description', 'fr': u'...'},
-                keywords={'en': [u'English Tag'], 'fr': [u'French Tag']}
-                )
+            'package_create',
+            name = 'package-name',
+            maintainer_translated = {
+                'en': u'Joe Smith',
+                'fr': u'...'
+            },
+            maintainer_email = 'Joe.Smith@ontario.ca',
+            title_translated = {
+                'en': u'A Novel By Tolstoy',
+                'fr':u'Un novel par Tolstoy'
+            },
+            notes_translated = {
+                'en': u'short description',
+                'fr': u'...'
+            },
+            owner_org = org['name'], # depends on config.
+            keywords={'en': [u'English Tag'], 'fr': [u'French Tag']}
+        )
         # Make sure package was returned as expected.
         assert_equals(dataset['name'], 'package-name')
         # Expected keyword list based on dataset above.
@@ -89,16 +99,29 @@ class TestGetPackageKeywords(object):
         assert_equals(get_package_keywords(), keywords)
 
     def test_get_package_keywords_returns_english(self):
+        org = factories.Organization()
         dataset = helpers.call_action(
-                'package_create',
-                name='package-name',
-                maintainer='Joe Smith',
-                maintainer_email='Joe.Smith@ontario.ca',
-                title_translated={
-                    'en': u'A Novel By Tolstoy', 'fr':u'Un novel par Tolstoy'},
-                notes_translated={'en': u'short description', 'fr': u'...'},
-                keywords={'en': [u'English Tag'], 'fr': [u'French Tag']}
-                )
+            'package_create',
+            name = 'package-name',
+            maintainer_translated = {
+                'en': u'Joe Smith',
+                'fr': u'...'
+            },
+            maintainer_email = 'Joe.Smith@ontario.ca',
+            title_translated = {
+                'en': u'A Novel By Tolstoy',
+                'fr':u'Un novel par Tolstoy'
+            },
+            notes_translated = {
+                'en': u'short description',
+                'fr': u'...'
+            },
+            owner_org = org['name'], # depends on config.
+            keywords = {
+                'en': [u'English Tag'],
+                'fr': [u'French Tag']
+            }
+        )
         # Make sure package was returned as expected.
         assert_equals(dataset['name'], 'package-name')
         # Expected keyword list based on dataset above.
@@ -110,16 +133,29 @@ class TestGetPackageKeywords(object):
         assert_equals(get_package_keywords(language='en'), keywords)
 
     def test_get_package_keywords_returns_french(self):
+        org = factories.Organization()
         dataset = helpers.call_action(
-                'package_create',
-                name='package-name',
-                maintainer='Joe Smith',
-                maintainer_email='Joe.Smith@ontario.ca',
-                title_translated={
-                    'en': u'A Novel By Tolstoy', 'fr':u'Un novel par Tolstoy'},
-                notes_translated={'en': u'short description', 'fr': u'...'},
-                keywords={'en': [u'English Tag'], 'fr': [u'French Tag']}
-                )
+            'package_create',
+            name = 'package-name',
+            maintainer_translated = {
+                'en': u'Joe Smith',
+                'fr': u'...'
+            },
+            maintainer_email = 'Joe.Smith@ontario.ca',
+            title_translated = {
+                'en': u'A Novel By Tolstoy',
+                'fr':u'Un novel par Tolstoy'
+            },
+            notes_translated = {
+                'en': u'short description',
+                'fr': u'...'
+            },
+            owner_org = org['name'], # depends on config.
+            keywords = {
+                'en': [u'English Tag'],
+                'fr': [u'French Tag']
+            }
+        )
         # Make sure package was returned as expected.
         assert_equals(dataset['name'], 'package-name')
         # Expected keyword list based on dataset above.
@@ -131,17 +167,29 @@ class TestGetPackageKeywords(object):
         assert_equals(get_package_keywords(language='fr'), keywords)
 
     def test_get_package_keywords_returns_multiple_values(self):
+        org = factories.Organization()
         dataset = helpers.call_action(
-                'package_create',
-                name='package-name',
-                maintainer='Joe Smith',
-                maintainer_email='Joe.Smith@ontario.ca',
-                title_translated={
-                    'en': u'A Novel By Tolstoy', 'fr':u'Un novel par Tolstoy'},
-                notes_translated={'en': u'short description', 'fr': u'...'},
-                keywords={'en': [u'English Tag', u'English Tag 2'], 'fr': 
-                [u'French Tag', u'French Tag 2', u'French Tag 3']}
-                )
+            'package_create',
+            name = 'package-name',
+            maintainer_translated = {
+                'en': u'Joe Smith',
+                'fr': u'...'
+            },
+            maintainer_email = 'Joe.Smith@ontario.ca',
+            title_translated = {
+                'en': u'A Novel By Tolstoy',
+                'fr':u'Un novel par Tolstoy'
+            },
+            notes_translated = {
+                'en': u'short description',
+                'fr': u'...'
+            },
+            owner_org = org['name'], # depends on config.
+            keywords = {
+                'en': [u'English Tag', u'English Tag 2'],
+                'fr': [u'French Tag', u'French Tag 2', u'French Tag 3']
+            }
+        )
         # Make sure package was returned as expected.
         assert_equals(dataset['name'], 'package-name')
         # Expected keyword list based on dataset above.

--- a/ckanext/ontario_theme/tests/test_resource_upload.py
+++ b/ckanext/ontario_theme/tests/test_resource_upload.py
@@ -113,15 +113,25 @@ class TestResourceCreate(object):
         ''')
         test_resource = TestResourceCreate.FakeFileStorage(test_file, 'test.json')
 
+        org = factories.Organization()
         dataset = helpers.call_action(
             'package_create',
-            name='package-name',
-            maintainer='Joe Smith',
-            maintainer_email='Joe.Smith@ontario.ca',
-            title_translated={
-                'en': u'A Novel By Tolstoy', 'fr':u'Un novel par Tolstoy'},
-            notes_translated={'en': u'short description', 'fr': u'...'}
-            )
+            name = 'package-name',
+            maintainer_translated = {
+                'en': u'Joe Smith',
+                'fr': u'...'
+            },
+            maintainer_email = 'Joe.Smith@ontario.ca',
+            title_translated = {
+                'en': u'A Novel By Tolstoy',
+                'fr':u'Un novel par Tolstoy'
+            },
+            notes_translated = {
+                'en': u'short description',
+                'fr': u'...'
+            },
+            owner_org = org['name'] # depends on config.
+        )
         assert_equals(dataset['name'], 'package-name')
 
         context = {}
@@ -170,15 +180,25 @@ class TestResourceCreate(object):
         test_resource = TestResourceCreate.FakeFileStorage(test_file,
             'test.html')
 
+        org = factories.Organization()
         dataset = helpers.call_action(
             'package_create',
-            name='package-name',
-            maintainer='Joe Smith',
-            maintainer_email='Joe.Smith@ontario.ca',
-            title_translated={
-                'en': u'A Novel By Tolstoy', 'fr':u'Un novel par Tolstoy'},
-            notes_translated={'en': u'short description', 'fr': u'...'}
-            )
+            name = 'package-name',
+            maintainer_translated = {
+                'en': u'Joe Smith',
+                'fr': u'...'
+            },
+            maintainer_email = 'Joe.Smith@ontario.ca',
+            title_translated = {
+                'en': u'A Novel By Tolstoy',
+                'fr':u'Un novel par Tolstoy'
+            },
+            notes_translated = {
+                'en': u'short description',
+                'fr': u'...'
+            },
+            owner_org = org['name'] # depends on config.
+        )
         assert_equals(dataset['name'], 'package-name')
 
         context = {}
@@ -227,15 +247,25 @@ class TestResourceCreate(object):
         test_resource = TestResourceCreate.FakeFileStorage(test_file,
             'test.exe')
 
+        org = factories.Organization()
         dataset = helpers.call_action(
             'package_create',
-            name='package-name',
-            maintainer='Joe Smith',
-            maintainer_email='Joe.Smith@ontario.ca',
-            title_translated={
-                'en': u'A Novel By Tolstoy', 'fr':u'Un novel par Tolstoy'},
-            notes_translated={'en': u'short description', 'fr': u'...'}
-            )
+            name = 'package-name',
+            maintainer_translated = {
+                'en': u'Joe Smith',
+                'fr': u'...'
+            },
+            maintainer_email = 'Joe.Smith@ontario.ca',
+            title_translated = {
+                'en': u'A Novel By Tolstoy',
+                'fr':u'Un novel par Tolstoy'
+            },
+            notes_translated = {
+                'en': u'short description',
+                'fr': u'...'
+            },
+            owner_org = org['name'] # depends on config.
+        )
         assert_equals(dataset['name'], 'package-name')
 
         context = {}

--- a/ckanext/ontario_theme/tests/test_update_dataset.py
+++ b/ckanext/ontario_theme/tests/test_update_dataset.py
@@ -54,135 +54,117 @@ class TestUpdateDataset(object):
     def test_package_update_with_minimum_values(self):
         '''If dataset is given it's basic fields it is updated.
         '''
+        org = factories.Organization()
         user = factories.User()
-        dataset = factories.Dataset(user=user,
-                                    maintainer='Joe Smith',
-                                    maintainer_email='Joe.Smith@ontario.ca',
-                                    title_translated={'en': u'A Novel By Tolstoy',
-                                                      'fr':u'Un novel par Tolstoy'},
-                                    notes_translated={'en': u'short description',
-                                                       'fr': u'...'})
+        dataset = factories.Dataset(
+            user = user,
+            name = 'package-name',
+            maintainer_translated = {
+                'en': u'Joe Smith',
+                'fr': u'...'
+            },
+            maintainer_email = 'Joe.Smith@ontario.ca',
+            title_translated = {
+                'en': u'A Novel By Tolstoy',
+                'fr':u'Un novel par Tolstoy'
+            },
+            notes_translated = {
+                'en': u'short description',
+                'fr': u'...'
+            },
+            owner_org = org['name'] # depends on config.
+        )
 
         # All required fields needed here as this is update not patch.
         dataset_ = helpers.call_action(
             'package_update',
-            id=dataset['id'],
-            name='new-name',
-            maintainer='Jane Smith',
-            maintainer_email='Jane.Smith@ontario.ca',
-            title_translated={'en': u'A Novel By Tolstoy',
-                              'fr':u'Un novel par Tolstoy'},
-            notes_translated={'en': 'shorter description', 'fr': 'petit...'}
-            )
+            id = dataset['id'],
+            name = 'new-name',
+            maintainer_translated = {
+                'en': u'Jane Smith',
+                'fr': u'...'
+            },
+            maintainer_email = 'Jane.Smith@ontario.ca',
+            title_translated = {
+                'en': u'A Novel By Tolstoy',
+                'fr':u'Un novel par Tolstoy'
+            },
+            notes_translated = {
+                'en': 'shorter description',
+                'fr': 'petit...'
+            }
+        )
 
         # Make sure update works and returns saved value.
         assert_equals(dataset_['name'], 'new-name')
-        
+
         # Safe measure - query the package again and validate values.
         dataset_ = helpers.call_action('package_show', id=dataset['id'])
         assert_equals(dataset_['name'], 'new-name')
-        assert_equals(dataset_['maintainer'], 'Jane Smith')
+        assert_equals(dataset_['maintainer_translated']['en'], 'Jane Smith')
         assert_equals(dataset_['maintainer_email'], 'Jane.Smith@ontario.ca')
         assert_equals(dataset_['notes_translated']['en'], 'shorter description')
         assert_equals(dataset_['notes_translated']['fr'], 'petit...')
-
-    def test_wrong_node_id_type(self):
-        '''If dataset is given a value for node_id it must be a positive integer.
-        Empty and missing values are allowed.
-        '''
-        user = factories.User()
-        dataset = factories.Dataset(user=user,
-                                    maintainer='Joe Smith',
-                                    maintainer_email='Joe.Smith@ontario.ca',
-                                    title_translated={'en': u'A Novel By Tolstoy',
-                                                      'fr':u'Un novel par Tolstoy'},
-                                    notes_translated={'en': u'short description',
-                                                       'fr': u'...'})
-
-        assert_raises(
-            logic.ValidationError, helpers.call_action,
-            'package_update',
-            id=dataset['id'],
-            node_id='apple',
-            maintainer='Joe Smith',
-            maintainer_email='Joe.Smith@ontario.ca',
-            notes_translated={'en': 'shorter description', 'fr': 'petit...'},
-            title_translated={'en': u'A Novel By Tolstoy',
-                              'fr':u'Un novel par Tolstoy'}
-        )
 
     def test_package_update_with_validated_values(self):
         '''If dataset is given wider range input with valid values
         a dataset is updated.
         '''
+        org = factories.Organization()
         user = factories.User()
-        dataset = factories.Dataset(user=user,
-                                    maintainer='Joe Smith',
-                                    maintainer_email='Joe.Smith@ontario.ca',
-                                    title_translated={'en': u'A Novel By Tolstoy',
-                                                      'fr':u'Un novel par Tolstoy'},
-                                    notes_translated={'en': u'short description',
-                                                       'fr': u'...'})
+        dataset = factories.Dataset(
+            user = user,
+            name = 'package-name',
+            maintainer_translated = {
+                'en': u'Joe Smith',
+                'fr': u'...'
+            },
+            maintainer_email = 'Joe.Smith@ontario.ca',
+            title_translated = {
+                'en': u'A Novel By Tolstoy',
+                'fr':u'Un novel par Tolstoy'
+            },
+            notes_translated = {
+                'en': u'short description',
+                'fr': u'...'
+            },
+            owner_org = org['name'] # depends on config.
+        )
 
         assert_equals(dataset['notes_translated']['en'], 'short description')
 
         dataset_ = helpers.call_action(
             'package_update',
-            id=dataset['id'],
-            name='package-name',
-            maintainer='Jane Smith',
-            maintainer_email='Jane.Smith@ontario.ca',
-            node_id='123',
-            title_translated={'en': u'A Novel By Tolstoy',
-                              'fr':u'Un novel par Tolstoy'},
-            notes_translated={'en': 'shorter description', 'fr': 'petit...'},
-            current_as_of='',
-            update_frequency='as_required',
-            access_level='open',
-            exemption='' # Defaults to none when key provided and value is empty.
+            id = dataset['id'],
+            name = 'package-name',
+            maintainer_translated = {
+                'en': u'Jane Smith',
+                'fr': u'...'
+            },
+            maintainer_email = 'Jane.Smith@ontario.ca',
+            node_id = '123',
+            title_translated = {
+                'en': u'A Novel By Tolstoy',
+                'fr':u'Un novel par Tolstoy'
+            },
+            notes_translated = {
+                'en': 'shorter description',
+                'fr': 'petit...'
+            },
+            current_as_of = '',
+            update_frequency = 'as_required',
+            access_level ='open',
+            exemption = '' # Defaults to none when key provided and value is empty.
         )
-        
+
         assert_equals(dataset_['node_id'], '123')
 
         package_show = helpers.call_action('package_show', id=dataset['id'])
         assert_equals(package_show['node_id'], '123')
-        assert_equals(dataset_['maintainer'], 'Jane Smith')
+        assert_equals(dataset_['maintainer_translated']['en'], 'Jane Smith')
         assert_equals(dataset_['maintainer_email'], 'Jane.Smith@ontario.ca')
         assert_equals(package_show['notes_translated']['en'], 'shorter description')
         assert 'current_as_of' not in package_show
         assert_equals(package_show['update_frequency'], 'as_required')
         assert_equals(package_show['access_level'], 'open')
         assert_equals(package_show['exemption'], 'none') # Confirms modified in validation.
-
-    def test_package_update_with_empty_node_id(self):
-        '''If dataset is given node_id key but no value, record should save.
-        Used in webform.
-        '''
-        user = factories.User()
-        dataset = factories.Dataset(user=user,
-                                    maintainer='Joe Smith',
-                                    maintainer_email='Joe.Smith@ontario.ca',
-                                    title_translated={'en': u'A Novel By Tolstoy',
-                                                      'fr':u'Un novel par Tolstoy'},
-                                    notes_translated={'en': u'short description',
-                                                       'fr': u'...'},
-                                    current_as_of='2018-11-30')
-
-        assert_equals(dataset["current_as_of"], '2018-11-30')
-
-        dataset_ = helpers.call_action(
-            'package_update',
-            id=dataset['id'],
-            name='package-name',
-            maintainer='Joe Smith',
-            maintainer_email='Joe.Smith@ontario.ca',
-            node_id='', # Validator returns None for this.
-            notes_translated={'en': 'shorter description', 'fr': 'petit...'},
-            title_translated={'en': u'A Novel By Tolstoy',
-                              'fr':u'Un novel par Tolstoy'},
-            current_as_of='' # ensure you can pass empty dates to remove them.
-        )
-
-        package_show = helpers.call_action('package_show', id=dataset['id'])
-        assert 'node_id' not in package_show
-        assert 'current_as_of' not in package_show

--- a/test.ini
+++ b/test.ini
@@ -14,7 +14,21 @@ use = config:../../test-core.ini
 # Insert any custom config settings to be used when running your extension's
 # tests here.
 
-licenses_group_url = file:///usr/lib/ckan/default/src/ckan/ckanext/ckanext-ontario_theme/ckanext/ontario_theme/licences.json
+ckan.plugins = scheming_organizations scheming_datasets fluent
+
+# Needs to be here for tests even though in plugin.py
+licenses_group_url = file:///usr/lib/ckan/default/src/ckan/ckanext/ckanext-ontario_theme/ckanext/ontario_theme/schemas/licences.json
+
+scheming.dataset_schemas = ckanext.ontario_theme:schemas/internal/ontario_theme_dataset.json
+
+scheming.presets =  ckanext.scheming:presets.json
+    ckanext.fluent:presets.json
+
+scheming.organization_schemas = ckanext.ontario_theme:schemas/ontario_theme_organization.json
+
+ckan.tracking_enabled = true
+ckan.extra_resource_fields = type data_last_updated
+
 
 # Logging configuration
 [loggers]


### PR DESCRIPTION
**TL;DR:** Tests were failing. Schema's had changed alot since some of 
these tests were written and they weren't updated with the schemas.

At start, Ran 12 tests, FAILED (errors=14).

**Errors:**

- AttributeError: 'OntarioThemePlugin' object has no attribute 'create_package_schema'
- SchemingException: preset 'fluent_core_translated' not defined
- IOError: [Errno 2] No such file or directory: '/home/cody/ckan/lib/default/src/ckan/ckanext/ckanext-ontario_theme/ckanext/ontario_theme/tests/../licences.json'
- Exception: Cannot unload plugin `ontario_theme`

**Changes:**

Remove IDataSetForm from plugin as this is no longer used (or could have set to inherit=True or create empty method).
Add config settings to test.ini to fix the SchemingException, load things in differently than before and update README.
Change licences.json path to new path.

Update package dict for test_create_dataset.py.
Remove obsolete tests for test_create_dataset.py.

Update package dict for test_helpers.py.

Update package dict for test_resource_upload.py.

Update package dict for test_updated_dataset.py.
Remove obsolete tests for test_update_dataset.py.

At end, Ran 18 tests, OK