### PR TITLE
Accessibility contrast repair

### DIFF
--- a/ckanext/ontario_theme/fanstatic/external/colours.less
+++ b/ckanext/ontario_theme/fanstatic/external/colours.less
@@ -1,13 +1,13 @@
-@primary-colour: #00B2E3; //
-@primary-darker: #1080A6; //
+@primary-colour: #00B2E3;
+@primary-darker: #1080A6;
 @primary-darkest: #094a60;
-@secondary-colour: #FCAF17; //
-@secondary-darker: #8A600D; //
+@secondary-colour: #FCAF17;
+@secondary-darker: #8A600D; 
 @secondary-darkest: #442f06;
 @ontario-link-colour: #06c;
-@grey: #4d4d4d;
+@grey: #666666;
 @black: #1A1A1A;
-@background-grey: #f5f5f5;
+@background-grey: #CCCCCC;
 @header-grey: #333;
 @button-grey-colour: #666;
 @button-grey-darker: #444;

--- a/ckanext/ontario_theme/fanstatic/external/ontario_theme.css
+++ b/ckanext/ontario_theme/fanstatic/external/ontario_theme.css
@@ -140,6 +140,8 @@ a.skip-main {
   overflow: hidden;
   z-index: -999;
   display: inline;
+  color: black;
+  background-color: white;
 }
 a.skip-main:focus,
 a.skip-main:active {
@@ -174,8 +176,7 @@ a.skip-main:active {
   color: #fff;
 }
 .btn-secondary {
-  color: #fff;
-  text-shadow: 0 0 4px #8A600D;
+  color: #1a1a1a;
 }
 .btn-secondary:focus,
 .btn-secondary.focus,
@@ -184,7 +185,7 @@ a.skip-main:active {
 .btn-secondary:hover,
 .btn-secondary:active,
 .btn-secondary.active {
-  color: #fff;
+  color: #1a1a1a;
 }
 .btn-primary {
   background-color: #1080a6;
@@ -371,7 +372,7 @@ a.skip-main:active {
   white-space: normal;
 }
 a.card div {
-  background-color: #f5f5f5;
+  background-color: #cccccc;
   transition: 1s;
   transition: box-shadow 135ms cubic-bezier(0.4, 0, 0.2, 1), width 235ms cubic-bezier(0.4, 0, 0.2, 1);
   box-shadow: 0 2px 4px #666;
@@ -386,7 +387,7 @@ a.card img {
   width: 100%;
 }
 a.card p {
-  color: #4d4d4d;
+  color: #666666;
 }
 a.card:hover {
   text-decoration: none;
@@ -404,7 +405,7 @@ div.card img {
   width: 100%;
 }
 div.card p {
-  color: #4d4d4d;
+  color: #666666;
 }
 .col-xs-2-10,
 .col-sm-2-10 {
@@ -563,7 +564,7 @@ div.card p {
 }
 .label-default {
   background-color: #fcaf17;
-  text-shadow: 0 0 2px #8a600d;
+  color: #1a1a1a;
 }
 .stats .number {
   display: block;
@@ -582,7 +583,7 @@ div.card p {
   font-family: Raleway, Open Sans, sans-serif;
   border-radius: 50%;
   color: #fff;
-  background-color: #00b2e3;
+  background-color: #1080a6;
   display: inline-block;
   font-weight: 700;
   margin-bottom: 0.5rem;
@@ -596,8 +597,8 @@ div.card p {
   line-height: 1.7;
   font-size: 2rem;
   text-align: center;
-  background: #fcaf17;
-  text-shadow: 0 0 2px #8a600d;
+  background-color: #fcaf17;
+  color: #1a1a1a;
 }
 .c-small-text {
   padding-top: 0.5rem;
@@ -672,14 +673,14 @@ h2 {
 h3 {
   font-size: 20px;
 }
-#landing-page-body h3 {
+.landing-page-body h3 {
   font-size: 40px;
   text-align: left;
 }
 h4 {
   font-size: 17px;
 }
-#landing-page-body h4 {
+.landing-page-body h4 {
   font-size: 20px;
   text-align: left;
 }
@@ -821,7 +822,7 @@ li.resource-item div.btn-wrapper {
 .hero {
   min-height: 400px;
   line-height: 400px;
-  background-color: #00b2e3;
+  background-color: #1080a6;
   background-image: url(/images/co-homepage-supergraphic.svg);
   background-position-x: 49vw;
   background-position-y: top;
@@ -845,8 +846,19 @@ li.resource-item div.btn-wrapper {
 }
 .hero .hero-container .welcome {
   text-align: left;
+  line-height: 1rem;
+}
+.hero .hero-container .welcome span.greeting {
+  background: #1080a6;
+  font-size: 4.5rem;
+  letter-spacing: .04rem;
+  line-height: 1.29;
+  font-weight: bold;
+  margin-top: 20px;
+  margin-bottom: 10px;
 }
 .hero .hero-container .welcome p {
+  background: #1080a6;
   font-size: 2.375rem;
   line-height: 1.4;
 }
@@ -861,22 +873,23 @@ li.resource-item div.btn-wrapper {
   font-size: 7rem;
   font-weight: bold;
   vertical-align: bottom;
-  line-height: 0.5;
+  line-height: 0;
 }
 .hero .hero-container .stats a {
   text-decoration: none;
 }
-.hero .hero-container .stats a,
-.hero .hero-container .stats a:visited {
-  text-shadow: 0 0 4px #8A600D;
-  color: white;
-}
 .hero .hero-container .stats span.above-stat {
-  font-size: 2rem;
-  line-height: 5rem;
+  font-size: 1.6rem;
+  line-height: 8rem;
+}
+.hero .hero-container .stats span.stat {
+  line-height: 1rem;
 }
 .hero .hero-container .stats span.below-stat {
-  font-size: 2.8rem;
+  font-size: 2rem;
+  line-height: 2rem;
+  display: inline-block;
+  margin-top: 3rem;
 }
 .fill-sky {
   fill: #00B2E3;
@@ -895,8 +908,14 @@ li.resource-item div.btn-wrapper {
   padding-top: 20px;
   padding-left: 30px;
   padding-right: 30px;
+  padding-bottom: 20px;
   font-size: 2.375rem;
   line-height: 1.4;
+}
+@media (max-width: 768px) {
+  .contact-us div.container div.message p {
+    padding: 0;
+  }
 }
 .ie8 .hero,
 .ie7 .hero {
@@ -919,7 +938,7 @@ li.resource-item div.btn-wrapper {
   width: 100%;
 }
 .wrapper header.page-header ul.nav.nav-tabs li a {
-  color: #4d4d4d;
+  color: #666666;
   border: none;
 }
 .wrapper header.page-header ul.nav.nav-tabs li a:hover {
@@ -927,8 +946,8 @@ li.resource-item div.btn-wrapper {
 }
 .wrapper header.page-header ul.nav.nav-tabs li.active a {
   border: none;
-  border-bottom: solid 2px #00b2e3;
-  color: #00b2e3;
+  border-bottom: solid 2px #1080a6;
+  color: #1080a6;
 }
 .module-heading {
   border-top: none;
@@ -954,7 +973,7 @@ li.resource-item div.btn-wrapper {
   box-shadow: none;
 }
 .well a.tag {
-  background-color: #00b2e3;
+  background-color: #1080a6;
   color: #fff;
   font-weight: bold;
   border: none;
@@ -1010,7 +1029,7 @@ section.additional-info table.table tbody tr td.dataset-details {
   border: none;
 }
 .banner-section {
-  background: #00b2e3;
+  background: #1080a6;
   width: 100%;
 }
 .banner-section a {
@@ -1035,6 +1054,26 @@ section.additional-info table.table tbody tr td.dataset-details {
 .page_primary_action .add-organization,
 .page_primary_action .add-group {
   text-align: right;
+}
+.simple-input .field .btn-search {
+  color: #1a1a1a;
+}
+.empty {
+  color: #666666;
+}
+.pagination > .disabled > span,
+.pagination > .disabled > span:hover,
+.pagination > .disabled > span:focus,
+.pagination > .disabled > a,
+.pagination > .disabled > a:hover,
+.pagination > .disabled > a:focus,
+.media-item span.count,
+.text-muted {
+  color: #666666;
+}
+.nav-item.active > a,
+.nav-aside li.active a {
+  background-color: #1080a6;
 }
 /* =====================================================
    Sub page left panel border removal
@@ -1147,14 +1186,14 @@ footer.site-footer {
   margin-top: 1em;
   padding: 2em 0 1.5em;
   border-top: 1px solid #d9d9d9;
-  color: #4d4d4d;
+  color: #666666;
 }
 footer.site-footer a.btn i.material-icons {
   color: white;
 }
 footer.site-footer a:not(.btn),
 footer.site-footer a:visited:not(.btn) {
-  color: #4d4d4d;
+  color: #666666;
   text-decoration: underline;
 }
 footer.site-footer div.footer-swoosh {

--- a/ckanext/ontario_theme/fanstatic/internal/accessibility.less
+++ b/ckanext/ontario_theme/fanstatic/internal/accessibility.less
@@ -7,6 +7,8 @@
   overflow:hidden;
   z-index:-999;  
   display: inline;
+  color: black;
+  background-color: white;
 }
 
 .toolbar .home span,

--- a/ckanext/ontario_theme/fanstatic/internal/buttons.less
+++ b/ckanext/ontario_theme/fanstatic/internal/buttons.less
@@ -16,8 +16,7 @@
 }
 
 .btn-secondary {
-  color: #fff;
-  text-shadow: 0 0 4px #8A600D;
+  color: #1a1a1a;
   &:focus,
   &.focus,
   &:visited,
@@ -25,7 +24,7 @@
   &:hover,
   &:active,
   &.active {
-    color: #fff;
+    color: #1a1a1a;
   }
 }
 

--- a/ckanext/ontario_theme/fanstatic/internal/colours.less
+++ b/ckanext/ontario_theme/fanstatic/internal/colours.less
@@ -1,13 +1,13 @@
-@primary-colour: #00B2E3; //
-@primary-darker: #1080A6; //
+@primary-colour: #00B2E3;
+@primary-darker: #1080A6;
 @primary-darkest: #094a60;
-@secondary-colour: #FCAF17; //
-@secondary-darker: #8A600D; //
+@secondary-colour: #FCAF17;
+@secondary-darker: #8A600D; 
 @secondary-darkest: #442f06;
 @ontario-link-colour: #06c;
-@grey: #4d4d4d;
+@grey: #666666;
 @black: #1A1A1A;
-@background-grey: #f5f5f5;
+@background-grey: #CCCCCC;
 @header-grey: #333;
 @button-grey-colour: #666;
 @button-grey-darker: #444;

--- a/ckanext/ontario_theme/fanstatic/internal/general_styles.less
+++ b/ckanext/ontario_theme/fanstatic/internal/general_styles.less
@@ -43,7 +43,7 @@ h2 {
 h3 { 
   font-size: 20px;
 }
-#landing-page-body h3 {
+.landing-page-body h3 {
   font-size: 40px;
   text-align: left;
 }
@@ -52,7 +52,7 @@ h4 {
   font-size: 17px
 }
 
-#landing-page-body h4 {
+.landing-page-body h4 {
   font-size: 20px;
   text-align: left;
 }
@@ -203,7 +203,7 @@ li.resource-item div.btn-wrapper {
 .hero {
   min-height: 400px;
   line-height: 400px;
-  background-color: @primary-colour;
+  background-color: @primary-darker;
   background-image: url(/images/co-homepage-supergraphic.svg);
   background-position-x: 49vw;
   background-position-y: top;
@@ -222,7 +222,18 @@ li.resource-item div.btn-wrapper {
     }
     .welcome {
       text-align: left;
+      line-height: 1rem;
+      span.greeting {
+        background: @primary-darker;
+        font-size: 4.5rem;
+        letter-spacing: .04rem;
+        line-height: 1.29;
+        font-weight: bold;
+        margin-top: 20px;
+        margin-bottom: 10px;
+      }
       p {
+        background: @primary-darker;
         font-size: 2.375rem;
         line-height: 1.4;
       }
@@ -238,20 +249,24 @@ li.resource-item div.btn-wrapper {
       font-size: 7rem;
       font-weight: bold;
       vertical-align: bottom;
-      line-height: 0.5; 
+      line-height: 0;
       a {
         text-decoration: none;
       } 
       a, a:visited {
-        text-shadow: 0 0 4px #8A600D; 
-        color: white;
       }
       span.above-stat {
-        font-size: 2rem;
-        line-height: 5rem;
+        font-size: 1.6rem;
+        line-height: 8rem;
+      }
+      span.stat {
+        line-height: 1rem; 
       }
       span.below-stat {
-        font-size: 2.8rem;
+        font-size: 2rem;
+        line-height: 2rem;
+        display: inline-block;
+        margin-top: 3rem;
       }
     }
   }
@@ -275,12 +290,17 @@ li.resource-item div.btn-wrapper {
       padding-top: 20px; 
       padding-left: 30px; 
       padding-right: 30px; 
+      padding-bottom: 20px;
       font-size:2.375rem; 
       line-height: 1.4;
     }
   }  
 }
-
+@media (max-width: 768px) {
+  .contact-us div.container div.message p {
+    padding: 0;
+  }
+}
 .ie8 .hero,
 .ie7 .hero {
   background-image: none;
@@ -309,8 +329,8 @@ li.resource-item div.btn-wrapper {
       }
       li.active a {
         border: none;
-        border-bottom: solid 2px @primary-colour;
-        color: @primary-colour;
+        border-bottom: solid 2px @primary-darker;
+        color: @primary-darker;
       }
     }
   }
@@ -344,7 +364,7 @@ li.resource-item div.btn-wrapper {
   background: none;
   box-shadow: none;
   a.tag {
-    background-color: @primary-colour;
+    background-color: @primary-darker;
     color: #fff;
     font-weight: bold;
     border: none;
@@ -410,7 +430,7 @@ section.additional-info table.table {
 }
 
 .banner-section {
-  background: @primary-colour; 
+  background: @primary-darker; 
   width: 100%;
   a {
     color: white;
@@ -433,6 +453,22 @@ section.additional-info table.table {
 
 .page_primary_action .add-dataset, .page_primary_action .add-organization, .page_primary_action .add-group {
   text-align: right; 
+}
+
+.simple-input .field .btn-search {
+  color: @black;
+}
+
+.empty {
+  color: @grey;
+}
+
+.pagination>.disabled>span, .pagination>.disabled>span:hover, .pagination>.disabled>span:focus, .pagination>.disabled>a, .pagination>.disabled>a:hover, .pagination>.disabled>a:focus, .media-item span.count, .text-muted {
+  color: @grey;
+}
+
+.nav-item.active>a, .nav-aside li.active a {
+  background-color: @primary-darker;
 }
 
 /* =====================================================

--- a/ckanext/ontario_theme/fanstatic/internal/labels.less
+++ b/ckanext/ontario_theme/fanstatic/internal/labels.less
@@ -105,8 +105,7 @@
 .label-english_and_french {
   background-color: #e6fad2;
 }
-
 .label-default {
   background-color: @secondary-colour;
-  text-shadow: 0 0 2px @secondary-darker;
+  color: @black;
 }

--- a/ckanext/ontario_theme/fanstatic/internal/ontario_theme.css
+++ b/ckanext/ontario_theme/fanstatic/internal/ontario_theme.css
@@ -106,10 +106,10 @@
    Generic classes for Colby colours
    ===================================================== */
 .primary-bg {
-  background-color: #00b2e3;
+  background-color: #1080a6;
 }
 .secondary-bg {
-  background-color: #fcaf17;
+  background-color: #8a600d;
 }
 .recent-activity .module-content {
   padding: 0px;
@@ -175,7 +175,6 @@ a.skip-main:active {
 }
 .btn-secondary {
   color: #fff;
-  text-shadow: 0 0 4px #8A600D;
 }
 .btn-secondary:focus,
 .btn-secondary.focus,
@@ -192,18 +191,18 @@ a.skip-main:active {
 }
 .btn-primary:hover {
   background-color: #094a60;
-  border-color: #00b2e3;
+  border-color: #1080a6;
 }
 .btn-primary:focus,
 .btn-primary.focus {
   background-color: #1080a6;
-  border-color: #00b2e3;
+  border-color: #1080a6;
 }
 .btn-primary:active,
 .btn-primary.active,
 .btn-primary .open > .dropdown-toggle.btn-primary {
   background-color: #094a60;
-  border-color: #00b2e3;
+  border-color: #1080a6;
   background-image: none;
 }
 .btn-primary:active:hover,
@@ -216,7 +215,7 @@ a.skip-main:active {
 .btn-primary.active.focus,
 .btn-primary .open > .dropdown-toggle.btn-primary.focus {
   background-color: #094a60;
-  border-color: #00b2e3;
+  border-color: #1080a6;
 }
 .btn-primary.disabled:hover,
 .btn-primary[disabled]:hover,
@@ -227,7 +226,7 @@ a.skip-main:active {
 .btn-primary.disabled.focus,
 .btn-primary[disabled].focus,
 .btn-primary fieldset[disabled] .btn-primary.focus {
-  background-color: #00b2e3;
+  background-color: #1080a6;
   border-color: #094a60;
 }
 .btn-primary.badge {
@@ -235,7 +234,7 @@ a.skip-main:active {
   background-color: #ffffff;
 }
 .btn-secondary {
-  background-color: #fcaf17;
+  background-color: #8a600d;
   border-color: #8a600d;
 }
 .btn-secondary:hover {
@@ -275,11 +274,11 @@ a.skip-main:active {
 .btn-secondary.disabled.focus,
 .btn-secondary[disabled].focus,
 .btn-secondary fieldset[disabled] .btn-secondary.focus {
-  background-color: #fcaf17;
+  background-color: #8a600d;
   border-color: #8a600d;
 }
 .btn-secondary.badge {
-  color: #fcaf17;
+  color: #8a600d;
   background-color: #ffffff;
 }
 .btn-grey {
@@ -458,7 +457,7 @@ div.card p {
   margin: 0 10px 0 0;
 }
 .module.search .tags a.tag {
-  background-color: #00b2e3;
+  background-color: #1080a6;
   color: #fff;
   font-weight: bold;
   border: none;
@@ -561,9 +560,12 @@ div.card p {
 .label-english_and_french {
   background-color: #e6fad2;
 }
+.label-white {
+  background-color: #fff;
+  color: #094a60;
+}
 .label-default {
-  background-color: #fcaf17;
-  text-shadow: 0 0 2px #8a600d;
+  background-color: #8a600d;
 }
 .stats .number {
   display: block;
@@ -582,7 +584,7 @@ div.card p {
   font-family: Raleway, Open Sans, sans-serif;
   border-radius: 50%;
   color: #fff;
-  background-color: #00b2e3;
+  background-color: #1080a6;
   display: inline-block;
   font-weight: 700;
   margin-bottom: 0.5rem;
@@ -596,8 +598,8 @@ div.card p {
   line-height: 1.7;
   font-size: 2rem;
   text-align: center;
-  background: #fcaf17;
-  text-shadow: 0 0 2px #8a600d;
+  background-color: #fff;
+  color: #094a60;
 }
 .c-small-text {
   padding-top: 0.5rem;
@@ -624,7 +626,7 @@ div#topics div i {
   color: #1080a6;
 }
 div#topics div i:hover {
-  color: #00b2e3;
+  color: #1080a6;
 }
 div#topics div.row {
   margin-bottom: 20px;
@@ -672,14 +674,14 @@ h2 {
 h3 {
   font-size: 20px;
 }
-#landing-page-body h3 {
+.landing-page-body h3 {
   font-size: 40px;
   text-align: left;
 }
 h4 {
   font-size: 17px;
 }
-#landing-page-body h4 {
+.landing-page-body h4 {
   font-size: 20px;
   text-align: left;
 }
@@ -821,7 +823,7 @@ li.resource-item div.btn-wrapper {
 .hero {
   min-height: 400px;
   line-height: 400px;
-  background-color: #00b2e3;
+  background-color: #1080a6;
   background-image: url(/images/co-homepage-supergraphic.svg);
   background-position-x: 49vw;
   background-position-y: top;
@@ -865,11 +867,6 @@ li.resource-item div.btn-wrapper {
 }
 .hero .hero-container .stats a {
   text-decoration: none;
-}
-.hero .hero-container .stats a,
-.hero .hero-container .stats a:visited {
-  text-shadow: 0 0 4px #8A600D;
-  color: white;
 }
 .hero .hero-container .stats span.above-stat {
   font-size: 2rem;
@@ -927,8 +924,8 @@ li.resource-item div.btn-wrapper {
 }
 .wrapper header.page-header ul.nav.nav-tabs li.active a {
   border: none;
-  border-bottom: solid 2px #00b2e3;
-  color: #00b2e3;
+  border-bottom: solid 2px #1080a6;
+  color: #1080a6;
 }
 .module-heading {
   border-top: none;
@@ -954,7 +951,7 @@ li.resource-item div.btn-wrapper {
   box-shadow: none;
 }
 .well a.tag {
-  background-color: #00b2e3;
+  background-color: #1080a6;
   color: #fff;
   font-weight: bold;
   border: none;
@@ -1010,7 +1007,7 @@ section.additional-info table.table tbody tr td.dataset-details {
   border: none;
 }
 .banner-section {
-  background: #00b2e3;
+  background: #1080a6;
   width: 100%;
 }
 .banner-section a {

--- a/ckanext/ontario_theme/fanstatic/internal/smarties.less
+++ b/ckanext/ontario_theme/fanstatic/internal/smarties.less
@@ -17,7 +17,7 @@
   font-family: Raleway, Open Sans, sans-serif;
   border-radius: 50%;
   color: #fff;
-  background-color: @primary-colour;
+  background-color: @primary-darker;
   display: inline-block;
   font-weight: 700;
   margin-bottom: 0.5rem;
@@ -30,8 +30,8 @@
     line-height: 1.7;
     font-size: 2rem;
     text-align: center;
-    background: @secondary-colour;
-    text-shadow: 0 0 2px @secondary-darker;
+    background-color: @secondary-colour;
+    color: @black;
   }  
 }
 

--- a/ckanext/ontario_theme/templates/external/home/snippets/ontario_theme_intro.html
+++ b/ckanext/ontario_theme/templates/external/home/snippets/ontario_theme_intro.html
@@ -3,9 +3,9 @@
 Renders a hard coded site description/introduction.
 
 #}
-<h1>
-  {{ _("Welcome!") }}
-</h1> 
+<div>
+<span class="greeting">{{ _("Welcome") }}!</span>
+</div>
 <p>
 {% trans %}Here you will find thousands of datasets that are maintained by the Ontario Government.{% endtrans %} 
 {% trans %}<a href="/about">Learn more</a> about what is covered and how to use data.{% endtrans %}

--- a/ckanext/ontario_theme/templates/internal/header.html
+++ b/ckanext/ontario_theme/templates/internal/header.html
@@ -73,8 +73,8 @@
     {% endif %} {% endblock %}
     <div class="container">
       <div class="navbar-right">
-        <button data-target="#main-navigation-toggle" data-toggle="collapse" class="navbar-toggle collapsed" type="button">
-          <span class="fa fa-bars" aria-hidden="true"></span><span class="accessibly-hidden">{{ _("Menu") }}</span>
+        <button data-target="#main-navigation-toggle" data-toggle="collapse" class="navbar-toggle collapsed" type="button" aria-label="{{ _('Menu') }}">
+          <span class="fa fa-bars" aria-hidden="true"></span>
         </button>
       </div>
       <hgroup class="{{ g.header_class }} navbar-left">

--- a/ckanext/ontario_theme/templates/internal/header.html
+++ b/ckanext/ontario_theme/templates/internal/header.html
@@ -1,107 +1,123 @@
 {% ckan_extends %}
 
-{% block header_account %}
-  <header class="account-masthead">
-    <div class="container">
-      {# Inserting additional header logo for parent site. #}
-      <hgroup class="{{ g.header_class }} navbar-left">
-        <a class="logo" href="https://ontario.ca/"><img src="/logo-ontario@2x.png" alt="Government of Ontario" /></a>
-      </hgroup>
-      {# End of header logo customization. #}
-      {% block header_account_container_content %} {% if c.userobj %}
-        <div class="account avatar authed" data-module="me" data-me="{{ c.userobj.id }}">
-          <ul class="list-unstyled">
-            {% block header_account_logged %} {% if c.userobj.sysadmin %}
-            <li>
-              <a href="{{ h.url_for(controller='admin', action='index') }}" title="{{ _('Sysadmin settings') }}">
-                <i class="fa fa-gavel" aria-hidden="true"></i>
-                <span class="text">{{ _('Admin') }}</span>
-              </a>
-            </li>
-            {% endif %}
-            <li>
-              <a href="{{ h.url_for('user.read', id=c.userobj.name) }}" class="image" title="{{ _('View profile') }}">
-                      {{ h.gravatar((c.userobj.email_hash if c and c.userobj else ''), size=22) }}
-                      <span class="username">{{ c.userobj.display_name }}</span>
-                    </a>
-            </li>
-            {% set new_activities = h.new_activities() %}
-            <li class="notifications {% if new_activities > 0 %}notifications-important{% endif %}">
-              {% set notifications_tooltip = ngettext('Dashboard (%(num)d new item)', 'Dashboard (%(num)d new items)', new_activities)
-              %}
-              {# Changed dashboard.index to dashboard.datasets #}
-              <a href="{{ h.url_for('dashboard.datasets') }}" title="{{
-              notifications_tooltip }}">
-                <i class="fa fa-tachometer" aria-hidden="true"></i>
-                <span class="text">{{ _('Dashboard') }}</span>
-                <span class="badge">{{ new_activities }}</span>
-              </a>
-            </li>
-            {% block header_account_settings_link %}
-              {{ super() }}
-            {% endblock %} {% block header_account_log_out_link %}
-              {{ super () }}
-            {% endblock %} {% endblock %}
-            {# Adding custom language selector. #}
-            <li>
-              {% snippet 'snippets/ontario_theme_language_selector.html' %}
-            </li>
-          </ul>
-        </div>
-        {% else %}
-        <nav class="account not-authed">
-          <ul class="list-unstyled">
-            {% block header_account_notlogged %}
-              {% if h.check_access('user_create') %}
-                <li>{% link_for _('Register'), named_route='user.register', class_='sub' %}</li>
+{% block header_wrapper %}
+  {% block header_account %}
+    <header class="account-masthead">
+      <div class="container">
+        {# Inserting additional header logo for parent site. #}
+        <hgroup class="{{ g.header_class }} navbar-left">
+          <a class="logo" href="https://ontario.ca/"><img src="/logo-ontario@2x.png" alt="Government of Ontario" /></a>
+        </hgroup>
+        {# End of header logo customization. #}
+        {% block header_account_container_content %} {% if c.userobj %}
+          <div class="account avatar authed" data-module="me" data-me="{{ c.userobj.id }}">
+            <ul class="list-unstyled">
+              {% block header_account_logged %} {% if c.userobj.sysadmin %}
+              <li>
+                <a href="{{ h.url_for(controller='admin', action='index') }}" title="{{ _('Sysadmin settings') }}">
+                  <i class="fa fa-gavel" aria-hidden="true"></i>
+                  <span class="text">{{ _('Admin') }}</span>
+                </a>
+              </li>
               {% endif %}
+              <li>
+                <a href="{{ h.url_for('user.read', id=c.userobj.name) }}" class="image" title="{{ _('View profile') }}">
+                        {{ h.gravatar((c.userobj.email_hash if c and c.userobj else ''), size=22) }}
+                        <span class="username">{{ c.userobj.display_name }}</span>
+                      </a>
+              </li>
+              {% set new_activities = h.new_activities() %}
+              <li class="notifications {% if new_activities > 0 %}notifications-important{% endif %}">
+                {% set notifications_tooltip = ngettext('Dashboard (%(num)d new item)', 'Dashboard (%(num)d new items)', new_activities)
+                %}
+                {# Changed dashboard.index to dashboard.datasets #}
+                <a href="{{ h.url_for('dashboard.datasets') }}" title="{{
+                notifications_tooltip }}">
+                  <i class="fa fa-tachometer" aria-hidden="true"></i>
+                  <span class="text">{{ _('Dashboard') }}</span>
+                  <span class="badge">{{ new_activities }}</span>
+                </a>
+              </li>
+              {% block header_account_settings_link %}
+                {{ super() }}
+              {% endblock %} {% block header_account_log_out_link %}
+                {{ super () }}
+              {% endblock %} {% endblock %}
               {# Adding custom language selector. #}
               <li>
                 {% snippet 'snippets/ontario_theme_language_selector.html' %}
               </li>
-            {% endblock %}
-          </ul>
-        </nav>
-      {% endif %} {% endblock %}
+            </ul>
+          </div>
+          {% else %}
+          <nav class="account not-authed">
+            <ul class="list-unstyled">
+              {% block header_account_notlogged %}
+                {% if h.check_access('user_create') %}
+                  <li>{% link_for _('Register'), named_route='user.register', class_='sub' %}</li>
+                {% endif %}
+                {# Adding custom language selector. #}
+                <li>
+                  {% snippet 'snippets/ontario_theme_language_selector.html' %}
+                </li>
+              {% endblock %}
+            </ul>
+          </nav>
+        {% endif %} {% endblock %}
+      </div>
+    </header>
+  {% endblock %}
+  <header class="navbar navbar-static-top masthead">
+    {% block header_debug %} {% if g.debug and not g.debug_supress_header %}
+    <div class="debug">Controller : {{ c.controller }}<br/>Action : {{ c.action }}</div>
+    {% endif %} {% endblock %}
+    <div class="container">
+      <div class="navbar-right">
+        <button data-target="#main-navigation-toggle" data-toggle="collapse" class="navbar-toggle collapsed" type="button">
+          <span class="fa fa-bars"></span>
+        </button>
+      </div>
+      <hgroup class="{{ g.header_class }} navbar-left">
+        {% block header_logo %}
+          {% if g.site_logo %}
+            <a class="logo" href="{{ h.url_for('home.index') }}"><img src="{{ h.url_for_static_or_external(g.site_logo) }}" alt="{{ g.site_title }}" title="{{ g.site_title }}" /></a>
+          {% else %}
+            {# Add alpha styling. #}
+            <h1>
+              <a href="{{ h.url_for('home.index') }}">{{ g.site_title }} <sup>alpha</sup></a>
+            </h1>
+            {# End customization. #}
+            {% if g.site_description %}<h2>{{ g.site_description }}</h2>{% endif %}
+          {% endif %}
+        {% endblock %}
+      </hgroup>
+
+      <div class="collapse navbar-collapse" id="main-navigation-toggle">
+        {% block header_site_navigation %}
+          <nav class="section navigation">
+            <ul class="list-inline">
+              {% block header_site_navigation_tabs %}
+                {{ h.build_nav_main(
+                  ('search', _('Datasets')),
+                  ('organizations_index', _('Organizations')),
+                  ('group_index', _('Groups')),          
+                  ('home.about', _('About')),
+                  ('ontario_theme.help', _('Help'))
+                ) }}
+              {% endblock %}
+            </ul>
+          </nav>
+        {% endblock %} 
+        {% block header_site_search %}
+          <form class="section site-search simple-input" action="{% url_for controller='package', action='search' %}" method="get">
+            <div class="field">
+              <label for="field-sitewide-search">{% block header_site_search_label %}{{ _('Search Datasets') }}{% endblock %}</label>
+              <input id="field-sitewide-search" type="text" class="form-control" name="q" placeholder="{{ _('Search') }}" />
+              <button class="btn-search" type="submit"><i class="fa fa-search" aria-hidden="true"></i><span>Submit Search</span></button>
+            </div>
+          </form>
+        {% endblock %}
+      </div>
     </div>
   </header>
-{% endblock %}
-
-{% block header_logo %}
-  {% if g.site_logo %}
-    <a class="logo" href="{{ h.url_for('home.index') }}"><img src="{{ h.url_for_static_or_external(g.site_logo) }}" alt="{{ g.site_title }}" title="{{ g.site_title }}" /></a>
-  {% else %}
-    {# Add alpha styling. #}
-    <h1>
-      <a href="{{ h.url_for('home.index') }}">{{ g.site_title }} <sup>alpha</sup></a>
-    </h1>
-    {# End customization. #}
-    {% if g.site_description %}<h2>{{ g.site_description }}</h2>{% endif %}
-  {% endif %}
-{% endblock %}
-
-{% block header_site_navigation %}
-  <nav class="section navigation">
-    <ul class="list-inline">
-      {% block header_site_navigation_tabs %}
-        {{ h.build_nav_main(
-          ('search', _('Datasets')),
-          ('organizations_index', _('Organizations')),
-          ('group_index', _('Groups')),          
-          ('home.about', _('About')),
-          ('ontario_theme.help', _('Help'))
-        ) }}
-      {% endblock %}
-    </ul>
-  </nav>
-{% endblock %}
-
-{% block header_site_search %}
-  <form class="section site-search simple-input" action="{% url_for controller='package', action='search' %}" method="get">
-    <div class="field">
-      <label for="field-sitewide-search">{% block header_site_search_label %}{{ _('Search Datasets') }}{% endblock %}</label>
-      <input id="field-sitewide-search" type="text" class="form-control" name="q" placeholder="{{ _('Search') }}" />
-      <button class="btn-search" type="submit"><i class="fa fa-search"></i><span>Submit Search</span></button>
-    </div>
-  </form>
 {% endblock %}

--- a/ckanext/ontario_theme/templates/internal/header.html
+++ b/ckanext/ontario_theme/templates/internal/header.html
@@ -74,7 +74,7 @@
     <div class="container">
       <div class="navbar-right">
         <button data-target="#main-navigation-toggle" data-toggle="collapse" class="navbar-toggle collapsed" type="button">
-          <span class="fa fa-bars"></span>
+          <span class="fa fa-bars" aria-hidden="true"></span><span class="accessibly-hidden">{{ _("Menu") }}</span>
         </button>
       </div>
       <hgroup class="{{ g.header_class }} navbar-left">

--- a/ckanext/ontario_theme/templates/internal/home/layout3.html
+++ b/ckanext/ontario_theme/templates/internal/home/layout3.html
@@ -1,6 +1,6 @@
-<div id="landing-page-body">
-<div class="hero">
-  <h2 class="accessibly-hidden">{{ _("Home") }}</h2>
+<div id="content" class="landing-page-body">
+  <div class="hero">
+    <h2 class="accessibly-hidden">{{ _("Home") }}</h2>
     <div class="container">
       <div class="hero-container">
         <div class="row">
@@ -25,53 +25,49 @@
       </div>
     </div>
   </div>
-
-<div role="main">
-  {% snippet 'home/snippets/ontario_theme_sub_intro.html' %}
-  <div class="container" id="topics">
-    <div class="row">
-      <div class="col-md-12">
-        <h3>{{ _("Browse by category") }}</h3>
+  <div role="main">
+    {% snippet 'home/snippets/ontario_theme_sub_intro.html' %}
+    <div class="container" id="topics">
+      <div class="row">
+        <div class="col-md-12">
+          <h3>{{ _("Browse by category") }}</h3>
+        </div>
+      </div>
+      {% snippet 'home/snippets/ontario_theme_categories.html' %}
+    </div>
+    <div class="banner-section">
+      <div id="news" class="container">
+        <div class="row homepage-section">
+          <div class="col-md-12">
+            <h3>{{ _("What's new") }}</h3>
+          </div>
+          {% block featured_content %}
+            {% snippet 'home/snippets/ontario_theme_featured_content.html' %}
+          {% endblock %}
+        </div>   
+        <div class="row homepage-section">
+          <div class="col-md-6 dataset-list">
+                <h4>{{ _("Most popular datasets") }}</h4>
+                {% snippet 'home/snippets/ontario_theme_popular_datasets.html' %}
+          </div>
+          <div class="col-md-6 dataset-list">
+            <h4>{{ _("Recently updated datasets") }}</h4>
+                {% snippet 'home/snippets/ontario_theme_recent_activity.html' %}
+          </div>
+        </div>
       </div>
     </div>
-    {% snippet 'home/snippets/ontario_theme_categories.html' %}
-  </div>
-
-<div class="banner-section">
-  <div id="news" class="container">
-    <div class="row homepage-section">
-      <div class="col-md-12">
-        <h3>{{ _("What's new") }}</h3>
-      </div>
-      {% block featured_content %}
-        {% snippet 'home/snippets/ontario_theme_featured_content.html' %}
-      {% endblock %}
-    </div>   
-    <div class="row homepage-section">
-      <div class="col-md-6 dataset-list">
-            <h4>{{ _("Most popular datasets") }}</h4>
-            {% snippet 'home/snippets/ontario_theme_popular_datasets.html' %}
-      </div>
-      <div class="col-md-6 dataset-list">
-        <h4>{{ _("Recently updated datasets") }}</h4>
-            {% snippet 'home/snippets/ontario_theme_recent_activity.html' %}
-      </div>
+    <div class="container" id="resources_and_information" >
+      {% snippet 'home/snippets/ontario_theme_resources_and_information.html' %}
     </div>
+    <div class="container homepage-section" style="margin-top: 40px">
+      <div class="row">
+        <div class="col-md-12"> 
+          {% block contact_us %}
+            {% snippet 'home/snippets/ontario_theme_contact_us.html' %}
+          {% endblock %}
+        </div>
+      </div>
+    </div> 
   </div>
-</div>
-
-<div class="container" id="resources_and_information" >
-  {% snippet 'home/snippets/ontario_theme_resources_and_information.html' %}
-</div>
-
-<div class="container homepage-section" style="margin-top: 40px">
-  <div class="row">
-    <div class="col-md-12"> 
-      {% block contact_us %}
-        {% snippet 'home/snippets/ontario_theme_contact_us.html' %}
-      {% endblock %}
-    </div>
-  </div>
-</div>  
-</div>
 </div>

--- a/ckanext/ontario_theme/templates/internal/home/snippets/ontario_theme_datasets_stats.html
+++ b/ckanext/ontario_theme/templates/internal/home/snippets/ontario_theme_datasets_stats.html
@@ -8,8 +8,11 @@ Uses get_site_statistics() to parse and display the stat.
 {% set stats = h.get_site_statistics() %}
 
 <a href="/{{ request.environ.CKAN_LANG }}/dataset">
-	<span class="above-stat">{{ _("Explore Ontario's") }}</span><br />
-	{{ stats.dataset_count }} <br>
-	<span class="below-stat">{{ _("data assets") }}</span><br />
-	<button class="btn btn-primary" style="margin-top: 15px">{{ _("View All") }}</button>
+	<span class="circle">
+		<span class="above-stat">{{ _("Explore Ontario's") }}</span><br />
+		<span class="stat">{{ stats.dataset_count }}</span> <br>
+		<span class="below-stat">{{ _("data assets") }}</span><br />
+	</span><br />
+	<button class="btn btn-primary">{{ _("View All") }}</button>
 </a>
+

--- a/ckanext/ontario_theme/templates/internal/home/snippets/ontario_theme_intro.html
+++ b/ckanext/ontario_theme/templates/internal/home/snippets/ontario_theme_intro.html
@@ -7,7 +7,7 @@ can be used.
 #}
 <div class="row">
   <div class="col-md-12">
-    <h1>Welcome!</h1>
+    <span class="greeting">{{ _("Welcome") }}!</span>
     <p>
     {% trans %}
       Here you'll find thousands of datasets that are maintained by the Ontario Government for OPS use. <a href="/about">Learn more about Colby</a>

--- a/ckanext/ontario_theme/templates/internal/snippets/search_form.html
+++ b/ckanext/ontario_theme/templates/internal/snippets/search_form.html
@@ -4,6 +4,7 @@
 <span class="input-group-btn">
   <button class="btn btn-default btn-lg" type="submit" value="search">
     <i class="fa fa-search"></i>
+    <span class="accessibly-hidden">{{ _("Search") }}</span>
   </button>
 </span>
 {% endblock %}

--- a/ckanext/ontario_theme/templates/internal/snippets/search_form.html
+++ b/ckanext/ontario_theme/templates/internal/snippets/search_form.html
@@ -2,9 +2,8 @@
 
 {% block search_input_button %}
 <span class="input-group-btn">
-  <button class="btn btn-default btn-lg" type="submit" value="search">
-    <i class="fa fa-search"></i>
-    <span class="accessibly-hidden">{{ _("Search") }}</span>
+  <button class="btn btn-default btn-lg" type="submit" value="search" aria-label="{{ _('Search') }}">
+    <i class="fa fa-search" aria-hidden="true"></i>
   </button>
 </span>
 {% endblock %}

--- a/ckanext/ontario_theme/templates/internal/snippets/search_form.html
+++ b/ckanext/ontario_theme/templates/internal/snippets/search_form.html
@@ -1,5 +1,13 @@
 {% ckan_extends %}
 
+{% block search_input_button %}
+<span class="input-group-btn">
+  <button class="btn btn-default btn-lg" type="submit" value="search">
+    <i class="fa fa-search"></i>
+  </button>
+</span>
+{% endblock %}
+
 {% block search_facets %}
   {% if facets %}
     <p class="filter-list">


### PR DESCRIPTION
This PR consists of 9 commits to make the following accessibility improvements:

* update colours (including system greys) to design system recommendations
* add aria-label attributes for "empty buttons"
* add other features to improve contrast (smarties)
* repair 'skip to content' link
* repair header order on homepage