### PR TITLE
Accessibility repair

### DIFF
--- a/ckanext/ontario_theme/fanstatic/external/colours.less
+++ b/ckanext/ontario_theme/fanstatic/external/colours.less
@@ -1,13 +1,13 @@
-@primary-colour: #00B2E3; //
-@primary-darker: #1080A6; //
+@primary-colour: #00B2E3;
+@primary-darker: #1080A6;
 @primary-darkest: #094a60;
-@secondary-colour: #FCAF17; //
-@secondary-darker: #8A600D; //
+@secondary-colour: #FCAF17;
+@secondary-darker: #8A600D;
 @secondary-darkest: #442f06;
 @ontario-link-colour: #06c;
-@grey: #4d4d4d;
+@grey: #666666;
 @black: #1A1A1A;
-@background-grey: #f5f5f5;
+@background-grey: #CCCCCC;
 @header-grey: #333;
 @button-grey-colour: #666;
 @button-grey-darker: #444;

--- a/ckanext/ontario_theme/fanstatic/external/ontario_theme.css
+++ b/ckanext/ontario_theme/fanstatic/external/ontario_theme.css
@@ -577,7 +577,7 @@ div.card p {
 .circle {
   font-family: Raleway, Open Sans, sans-serif;
   border-radius: 50%;
-  color: #1a1a1a;
+  color: white;
   background-color: #1080a6;
   display: inline-block;
   font-weight: 700;
@@ -592,6 +592,7 @@ div.card p {
   line-height: 1.7;
   font-size: 2rem;
   text-align: center;
+  color: #1a1a1a;
   background: #fcaf17;
 }
 .c-small-text {
@@ -667,14 +668,14 @@ h2 {
 h3 {
   font-size: 20px;
 }
-#landing-page-body h3 {
+#landing-page-body h2 {
   font-size: 40px;
   text-align: left;
 }
 h4 {
   font-size: 17px;
 }
-#landing-page-body h4 {
+#landing-page-body h3 {
   font-size: 20px;
   text-align: left;
 }
@@ -840,24 +841,28 @@ li.resource-item div.btn-wrapper {
 }
 .hero .hero-container .welcome {
   text-align: left;
+  line-height: 1rem;
+}
+.hero .hero-container .welcome span.greeting {
+  background: #1080a6;
+  font-size: 4.5rem;
+  letter-spacing: .04rem;
+  line-height: 1.29;
+  font-weight: bold;
+  margin-top: 20px;
+  margin-bottom: 10px;
 }
 .hero .hero-container .welcome p {
   background: #1080a6;
   font-size: 2.375rem;
   line-height: 1.4;
 }
-.hero .hero-container h2 {
-  font-size: 4.5rem;
-  letter-spacing: .04rem;
-  line-height: 1.29;
-  font-weight: bold;
-}
 .hero .hero-container .stats {
   text-align: center;
   font-size: 7rem;
   font-weight: bold;
   vertical-align: bottom;
-  line-height: 0.5;
+  line-height: 0;
 }
 .hero .hero-container .stats a {
   text-decoration: none;
@@ -867,11 +872,17 @@ li.resource-item div.btn-wrapper {
   color: white;
 }
 .hero .hero-container .stats span.above-stat {
-  font-size: 2rem;
-  line-height: 5rem;
+  font-size: 1.6rem;
+  line-height: 8rem;
+}
+.hero .hero-container .stats span.stat {
+  line-height: 1rem;
 }
 .hero .hero-container .stats span.below-stat {
-  font-size: 2.8rem;
+  font-size: 2rem;
+  line-height: 2rem;
+  display: inline-block;
+  margin-top: 3rem;
 }
 .fill-sky {
   fill: #00B2E3;
@@ -890,8 +901,14 @@ li.resource-item div.btn-wrapper {
   padding-top: 20px;
   padding-left: 30px;
   padding-right: 30px;
+  padding-bottom: 20px;
   font-size: 2.375rem;
   line-height: 1.4;
+}
+@media (max-width: 768px) {
+  .contact-us div.container div.message p {
+    padding: 0;
+  }
 }
 .ie8 .hero,
 .ie7 .hero {

--- a/ckanext/ontario_theme/fanstatic/external/ontario_theme.css
+++ b/ckanext/ontario_theme/fanstatic/external/ontario_theme.css
@@ -127,19 +127,9 @@
   left: 0px;
   position: relative;
 }
-.accessibly-hidden,
-.toolbar .home span,
-.simple-input label,
-.simple-input button span,
-a.skip-main {
-  left: -999px;
-  position: absolute;
-  top: auto;
-  width: 1px;
-  height: 1px;
-  overflow: hidden;
-  z-index: -999;
-  display: inline;
+.sr-only {
+  background-color: #ffffff;
+  color: #1a1a1a;
 }
 a.skip-main:focus,
 a.skip-main:active {
@@ -581,7 +571,7 @@ div.card p {
 .circle {
   font-family: Raleway, Open Sans, sans-serif;
   border-radius: 50%;
-  color: #000;
+  color: #1a1a1a;
   background-color: #1080a6;
   display: inline-block;
   font-weight: 700;

--- a/ckanext/ontario_theme/fanstatic/external/ontario_theme.css
+++ b/ckanext/ontario_theme/fanstatic/external/ontario_theme.css
@@ -127,7 +127,11 @@
   left: 0px;
   position: relative;
 }
-.sr-only {
+.sr-only,
+.toolbar .home span,
+.simple-input label,
+.simple-input button span,
+a.skip-main {
   background-color: #ffffff;
   color: #1a1a1a;
 }
@@ -147,6 +151,8 @@ a.skip-main:active {
   text-align: center;
   font-size: 1.2em;
   z-index: 999;
+  position: absolute;
+  display: inline;
 }
 /* =====================================================
    Button overrides

--- a/ckanext/ontario_theme/fanstatic/external/ontario_theme.css
+++ b/ckanext/ontario_theme/fanstatic/external/ontario_theme.css
@@ -3,9 +3,9 @@
 }
 .new-alert {
   border-color: rgba(0, 0, 0, 0.1);
-  border-width: 0 0 0 0.9375rem;
+  border-width: 0 0 0 .9375rem;
   border-style: solid;
-  padding: 0.9375rem 2rem 0.9375rem 0.9375rem;
+  padding: .9375rem 2rem .9375rem .9375rem;
   color: #333;
   border-radius: 0px;
   min-height: 50px;
@@ -97,7 +97,7 @@
 .new-alert.alert-contact {
   background: #E2F0F4;
   border-color: #1080A6;
-  padding: 0.9375rem 2rem 0.9375rem 0.9375rem;
+  padding: .9375rem 2rem .9375rem .9375rem;
 }
 .new-alert.alert-clear {
   margin-bottom: 30px;
@@ -106,10 +106,10 @@
    Generic classes for Colby colours
    ===================================================== */
 .primary-bg {
-  background-color: #1080A6;
+  background-color: #00b2e3;
 }
 .secondary-bg {
-  background-color: #FCAF17;
+  background-color: #fcaf17;
 }
 .recent-activity .module-content {
   padding: 0px;
@@ -174,8 +174,7 @@ a.skip-main:active {
   color: #fff;
 }
 .btn-secondary {
-  color: #000;
-  text-shadow: 0 0 4px #8A600D;
+  color: #1a1a1a;
 }
 .btn-secondary:focus,
 .btn-secondary.focus,
@@ -184,26 +183,26 @@ a.skip-main:active {
 .btn-secondary:hover,
 .btn-secondary:active,
 .btn-secondary.active {
-  color: #000;
+  color: #1a1a1a;
 }
 .btn-primary {
-  background-color: #1080A6;
+  background-color: #1080a6;
   border-color: #094a60;
 }
 .btn-primary:hover {
   background-color: #094a60;
-  border-color: #1080A6;
+  border-color: #00b2e3;
 }
 .btn-primary:focus,
 .btn-primary.focus {
-  background-color: #1080A6;
-  border-color: #1080A6;
+  background-color: #1080a6;
+  border-color: #00b2e3;
 }
 .btn-primary:active,
 .btn-primary.active,
 .btn-primary .open > .dropdown-toggle.btn-primary {
   background-color: #094a60;
-  border-color: #1080A6;
+  border-color: #00b2e3;
   background-image: none;
 }
 .btn-primary:active:hover,
@@ -216,7 +215,7 @@ a.skip-main:active {
 .btn-primary.active.focus,
 .btn-primary .open > .dropdown-toggle.btn-primary.focus {
   background-color: #094a60;
-  border-color: #1080A6;
+  border-color: #00b2e3;
 }
 .btn-primary.disabled:hover,
 .btn-primary[disabled]:hover,
@@ -227,30 +226,30 @@ a.skip-main:active {
 .btn-primary.disabled.focus,
 .btn-primary[disabled].focus,
 .btn-primary fieldset[disabled] .btn-primary.focus {
-  background-color: #1080A6;
+  background-color: #00b2e3;
   border-color: #094a60;
 }
 .btn-primary.badge {
-  color: #1080A6;
+  color: #1080a6;
   background-color: #ffffff;
 }
 .btn-secondary {
-  background-color: #FCAF17;
-  border-color: #8A600D;
+  background-color: #fcaf17;
+  border-color: #8a600d;
 }
 .btn-secondary:hover {
-  background-color: #8A600D;
+  background-color: #8a600d;
   border-color: #442f06;
 }
 .btn-secondary:focus,
 .btn-secondary.focus {
-  background-color: #8A600D;
+  background-color: #8a600d;
   border-color: #442f06;
 }
 .btn-secondary:active,
 .btn-secondary.active,
 .btn-secondary .open > .dropdown-toggle.btn-secondary {
-  background-color: #8A600D;
+  background-color: #8a600d;
   border-color: #442f06;
   background-image: none;
 }
@@ -263,7 +262,7 @@ a.skip-main:active {
 .btn-secondary:active.focus,
 .btn-secondary.active.focus,
 .btn-secondary .open > .dropdown-toggle.btn-secondary.focus {
-  background-color: #8A600D;
+  background-color: #8a600d;
   border-color: #442f06;
 }
 .btn-secondary.disabled:hover,
@@ -275,21 +274,21 @@ a.skip-main:active {
 .btn-secondary.disabled.focus,
 .btn-secondary[disabled].focus,
 .btn-secondary fieldset[disabled] .btn-secondary.focus {
-  background-color: #FCAF17;
-  border-color: #8A600D;
+  background-color: #fcaf17;
+  border-color: #8a600d;
 }
 .btn-secondary.badge {
-  color: #FCAF17;
+  color: #fcaf17;
   background-color: #ffffff;
 }
 .btn-grey {
   color: #fff;
-  background-color: #666;
-  border-color: #444;
+  background-color: #666666;
+  border-color: #444444;
 }
 .btn-grey:hover {
-  background-color: #444;
-  border-color: #222;
+  background-color: #444444;
+  border-color: #222222;
 }
 .btn-grey:hover,
 .btn-grey:visited {
@@ -297,14 +296,14 @@ a.skip-main:active {
 }
 .btn-grey:focus,
 .btn-grey.focus {
-  background-color: #444;
-  border-color: #222;
+  background-color: #444444;
+  border-color: #222222;
 }
 .btn-grey:active,
 .btn-grey.active,
 .btn-grey .open > .dropdown-toggle.btn-grey {
-  background-color: #444;
-  border-color: #222;
+  background-color: #444444;
+  border-color: #222222;
   background-image: none;
 }
 .btn-grey:active:hover,
@@ -316,8 +315,8 @@ a.skip-main:active {
 .btn-grey:active.focus,
 .btn-grey.active.focus,
 .btn-grey .open > .dropdown-toggle.btn-grey.focus {
-  background-color: #444;
-  border-color: #222;
+  background-color: #444444;
+  border-color: #222222;
 }
 .btn-grey.disabled:hover,
 .btn-grey[disabled]:hover,
@@ -328,11 +327,11 @@ a.skip-main:active {
 .btn-grey.disabled.focus,
 .btn-grey[disabled].focus,
 .btn-grey fieldset[disabled] .btn-grey.focus {
-  background-color: #666;
-  border-color: #444;
+  background-color: #666666;
+  border-color: #444444;
 }
 .btn-grey.badge {
-  color: #666;
+  color: #666666;
   background-color: #ffffff;
 }
 @font-face {
@@ -340,8 +339,9 @@ a.skip-main:active {
   font-style: normal;
   font-weight: 400;
   src: url(/fonts/material/MaterialIcons-Regular.eot);
-  /* For IE6-8 */
   src: local('Material Icons'), local('MaterialIcons-Regular'), url(/fonts/material/MaterialIcons-Regular.woff2) format('woff2'), url(/fonts/material/MaterialIcons-Regular.woff) format('woff'), url(/fonts/material/MaterialIcons-Regular.ttf) format('truetype');
+  
+  /* For IE6-8 */
 }
 .material-icons {
   font-family: 'Material Icons';
@@ -370,7 +370,7 @@ a.skip-main:active {
   white-space: normal;
 }
 a.card div {
-  background-color: #f5f5f5;
+  background-color: #cccccc;
   transition: 1s;
   transition: box-shadow 135ms cubic-bezier(0.4, 0, 0.2, 1), width 235ms cubic-bezier(0.4, 0, 0.2, 1);
   box-shadow: 0 2px 4px #666;
@@ -385,7 +385,7 @@ a.card img {
   width: 100%;
 }
 a.card p {
-  color: #4d4d4d;
+  color: #666666;
 }
 a.card:hover {
   text-decoration: none;
@@ -403,7 +403,7 @@ div.card img {
   width: 100%;
 }
 div.card p {
-  color: #4d4d4d;
+  color: #666666;
 }
 .col-xs-2-10,
 .col-sm-2-10 {
@@ -457,7 +457,7 @@ div.card p {
   margin: 0 10px 0 0;
 }
 .module.search .tags a.tag {
-  background-color: #1080A6;
+  background-color: #00b2e3;
   color: #fff;
   font-weight: bold;
   border: none;
@@ -562,8 +562,8 @@ div.card p {
   background-color: #e6fad2;
 }
 .label-default {
-  background-color: #FCAF17;
-  color: #000;
+  background-color: #fcaf17;
+  color: #1a1a1a;
 }
 .stats .number {
   display: block;
@@ -582,7 +582,7 @@ div.card p {
   font-family: Raleway, Open Sans, sans-serif;
   border-radius: 50%;
   color: #000;
-  background-color: #1080A6;
+  background-color: #1080a6;
   display: inline-block;
   font-weight: 700;
   margin-bottom: 0.5rem;
@@ -596,7 +596,7 @@ div.card p {
   line-height: 1.7;
   font-size: 2rem;
   text-align: center;
-  background: #FCAF17;
+  background: #fcaf17;
 }
 .c-small-text {
   padding-top: 0.5rem;
@@ -611,7 +611,7 @@ div#topics {
   margin-bottom: 20px;
 }
 div#topics a {
-  color: #1A1A1A;
+  color: #1a1a1a;
 }
 div#topics div {
   text-align: center;
@@ -620,10 +620,10 @@ div#topics div {
 }
 div#topics div i {
   font-size: 64px;
-  color: #1080A6;
+  color: #1080a6;
 }
 div#topics div i:hover {
-  color: #1080A6;
+  color: #00b2e3;
 }
 div#topics div.row {
   margin-bottom: 20px;
@@ -697,7 +697,7 @@ h6 {
   font-family: Raleway, Open Sans, Helvetica Neue, Helvetica, Arial, sans-serif;
 }
 a {
-  color: #06c;
+  color: #0066cc;
 }
 a:hover,
 a:focus {
@@ -820,7 +820,7 @@ li.resource-item div.btn-wrapper {
 .hero {
   min-height: 400px;
   line-height: 400px;
-  background-color: #1080A6;
+  background-color: #1080a6;
   background-image: url(/images/co-homepage-supergraphic.svg);
   background-position-x: 49vw;
   background-position-y: top;
@@ -846,12 +846,13 @@ li.resource-item div.btn-wrapper {
   text-align: left;
 }
 .hero .hero-container .welcome p {
+  background: #1080a6;
   font-size: 2.375rem;
   line-height: 1.4;
 }
 .hero .hero-container h2 {
   font-size: 4.5rem;
-  letter-spacing: 0.04rem;
+  letter-spacing: .04rem;
   line-height: 1.29;
   font-weight: bold;
 }
@@ -867,7 +868,6 @@ li.resource-item div.btn-wrapper {
 }
 .hero .hero-container .stats a,
 .hero .hero-container .stats a:visited {
-  text-shadow: 0 0 4px #8A600D;
   color: white;
 }
 .hero .hero-container .stats span.above-stat {
@@ -918,7 +918,7 @@ li.resource-item div.btn-wrapper {
   width: 100%;
 }
 .wrapper header.page-header ul.nav.nav-tabs li a {
-  color: #4d4d4d;
+  color: #666666;
   border: none;
 }
 .wrapper header.page-header ul.nav.nav-tabs li a:hover {
@@ -926,8 +926,8 @@ li.resource-item div.btn-wrapper {
 }
 .wrapper header.page-header ul.nav.nav-tabs li.active a {
   border: none;
-  border-bottom: solid 2px #1080A6;
-  color: #1080A6;
+  border-bottom: solid 2px #1080a6;
+  color: #1080a6;
 }
 .module-heading {
   border-top: none;
@@ -953,7 +953,7 @@ li.resource-item div.btn-wrapper {
   box-shadow: none;
 }
 .well a.tag {
-  background-color: #1080A6;
+  background-color: #1080a6;
   color: #fff;
   font-weight: bold;
   border: none;
@@ -1009,7 +1009,7 @@ section.additional-info table.table tbody tr td.dataset-details {
   border: none;
 }
 .banner-section {
-  background: #1080A6;
+  background: #1080a6;
   width: 100%;
 }
 .banner-section a {
@@ -1034,6 +1034,26 @@ section.additional-info table.table tbody tr td.dataset-details {
 .page_primary_action .add-organization,
 .page_primary_action .add-group {
   text-align: right;
+}
+.simple-input .field .btn-search {
+  color: #1a1a1a;
+}
+.empty {
+  color: #666666;
+}
+.pagination > .disabled > span,
+.pagination > .disabled > span:hover,
+.pagination > .disabled > span:focus,
+.pagination > .disabled > a,
+.pagination > .disabled > a:hover,
+.pagination > .disabled > a:focus,
+.media-item span.count,
+.text-muted {
+  color: #666666;
+}
+.nav-item.active > a,
+.nav-aside li.active a {
+  background-color: #1080a6;
 }
 /* =====================================================
    Sub page left panel border removal
@@ -1078,7 +1098,7 @@ section.additional-info table.table tbody tr td.dataset-details {
    The main masthead bar that contains the site logo, nav links, and search
    ======================================================================== */
 .masthead {
-  background-color: #1080A6;
+  background-color: #1080a6;
 }
 .masthead a,
 .masthead a:focus,
@@ -1129,7 +1149,7 @@ section.additional-info table.table tbody tr td.dataset-details {
   top: 1px;
 }
 .toolbar .breadcrumb a {
-  color: #8A600D;
+  color: #8a600d;
   font-size: 15px;
 }
 .logo img {
@@ -1146,14 +1166,14 @@ footer.site-footer {
   margin-top: 1em;
   padding: 2em 0 1.5em;
   border-top: 1px solid #d9d9d9;
-  color: #4d4d4d;
+  color: #666666;
 }
 footer.site-footer a.btn i.material-icons {
   color: white;
 }
 footer.site-footer a:not(.btn),
 footer.site-footer a:visited:not(.btn) {
-  color: #4d4d4d;
+  color: #666666;
   text-decoration: underline;
 }
 footer.site-footer div.footer-swoosh {

--- a/ckanext/ontario_theme/fanstatic/internal/accessibility.less
+++ b/ckanext/ontario_theme/fanstatic/internal/accessibility.less
@@ -1,12 +1,6 @@
-.accessibly-hidden {
-  left:-999px;
-  position:absolute;
-  top:auto;
-  width:1px;
-  height:1px;
-  overflow:hidden;
-  z-index:-999;  
-  display: inline;
+.sr-only {
+  background-color: #ffffff;
+  color: @black;
 }
 
 .toolbar .home span,

--- a/ckanext/ontario_theme/fanstatic/internal/accessibility.less
+++ b/ckanext/ontario_theme/fanstatic/internal/accessibility.less
@@ -7,7 +7,7 @@
 .simple-input label, 
 .simple-input button span,
 a.skip-main {
-  &:extend(.accessibly-hidden);
+  &:extend(.sr-only);
 }
 
 a.skip-main:focus, a.skip-main:active {
@@ -25,4 +25,6 @@ a.skip-main:focus, a.skip-main:active {
   text-align:center;
   font-size:1.2em;
   z-index:999;
+  position:absolute;
+  display: inline;
 }

--- a/ckanext/ontario_theme/fanstatic/internal/buttons.less
+++ b/ckanext/ontario_theme/fanstatic/internal/buttons.less
@@ -16,8 +16,7 @@
 }
 
 .btn-secondary {
-  color: #000;
-  text-shadow: 0 0 4px #8A600D;
+  color: @black;
   &:focus,
   &.focus,
   &:visited,
@@ -25,7 +24,7 @@
   &:hover,
   &:active,
   &.active {
-    color: #000;
+    color: @black;
   }
 }
 

--- a/ckanext/ontario_theme/fanstatic/internal/colours.less
+++ b/ckanext/ontario_theme/fanstatic/internal/colours.less
@@ -1,13 +1,13 @@
-@primary-colour: #00B2E3; //
-@primary-darker: #1080A6; //
+@primary-colour: #00B2E3;
+@primary-darker: #1080A6;
 @primary-darkest: #094a60;
-@secondary-colour: #FCAF17; //
-@secondary-darker: #8A600D; //
+@secondary-colour: #FCAF17;
+@secondary-darker: #8A600D;
 @secondary-darkest: #442f06;
 @ontario-link-colour: #06c;
-@grey: #4d4d4d;
+@grey: #666666;
 @black: #1A1A1A;
-@background-grey: #f5f5f5;
+@background-grey: #CCCCCC;
 @header-grey: #333;
 @button-grey-colour: #666;
 @button-grey-darker: #444;

--- a/ckanext/ontario_theme/fanstatic/internal/general_styles.less
+++ b/ckanext/ontario_theme/fanstatic/internal/general_styles.less
@@ -43,7 +43,7 @@ h2 {
 h3 { 
   font-size: 20px;
 }
-#landing-page-body h3 {
+#landing-page-body h2 {
   font-size: 40px;
   text-align: left;
 }
@@ -52,7 +52,7 @@ h4 {
   font-size: 17px
 }
 
-#landing-page-body h4 {
+#landing-page-body h3 {
   font-size: 20px;
   text-align: left;
 }
@@ -222,24 +222,28 @@ li.resource-item div.btn-wrapper {
     }
     .welcome {
       text-align: left;
+      line-height: 1rem;
+      span.greeting {
+        background: @primary-darker;
+        font-size: 4.5rem;
+        letter-spacing: .04rem;
+        line-height: 1.29;
+        font-weight: bold;
+        margin-top: 20px;
+        margin-bottom: 10px;
+      }
       p {
         background: @primary-darker;
         font-size: 2.375rem;
         line-height: 1.4;
       }
     }
-    h2 {
-      font-size: 4.5rem;
-      letter-spacing: .04rem;
-      line-height: 1.29;
-      font-weight: bold;
-    }
     .stats {
       text-align: center;
       font-size: 7rem;
       font-weight: bold;
       vertical-align: bottom;
-      line-height: 0.5; 
+      line-height: 0; 
       a {
         text-decoration: none;
       } 
@@ -247,11 +251,17 @@ li.resource-item div.btn-wrapper {
         color: white;
       }
       span.above-stat {
-        font-size: 2rem;
-        line-height: 5rem;
+        font-size: 1.6rem;
+        line-height: 8rem;
+      }
+      span.stat {
+        line-height: 1rem; 
       }
       span.below-stat {
-        font-size: 2.8rem;
+        font-size: 2rem;
+        line-height: 2rem;
+        display: inline-block;
+        margin-top: 3rem;
       }
     }
   }
@@ -275,10 +285,17 @@ li.resource-item div.btn-wrapper {
       padding-top: 20px; 
       padding-left: 30px; 
       padding-right: 30px; 
+      padding-bottom: 20px;
       font-size:2.375rem; 
       line-height: 1.4;
     }
   }  
+}
+
+@media (max-width: 768px) {
+  .contact-us div.container div.message p {
+    padding: 0;
+  }
 }
 
 .ie8 .hero,

--- a/ckanext/ontario_theme/fanstatic/internal/general_styles.less
+++ b/ckanext/ontario_theme/fanstatic/internal/general_styles.less
@@ -203,7 +203,7 @@ li.resource-item div.btn-wrapper {
 .hero {
   min-height: 400px;
   line-height: 400px;
-  background-color: @primary-colour;
+  background-color: @primary-darker;
   background-image: url(/images/co-homepage-supergraphic.svg);
   background-position-x: 49vw;
   background-position-y: top;
@@ -223,6 +223,7 @@ li.resource-item div.btn-wrapper {
     .welcome {
       text-align: left;
       p {
+        background: @primary-darker;
         font-size: 2.375rem;
         line-height: 1.4;
       }
@@ -243,7 +244,6 @@ li.resource-item div.btn-wrapper {
         text-decoration: none;
       } 
       a, a:visited {
-        text-shadow: 0 0 4px #8A600D; 
         color: white;
       }
       span.above-stat {
@@ -309,8 +309,8 @@ li.resource-item div.btn-wrapper {
       }
       li.active a {
         border: none;
-        border-bottom: solid 2px @primary-colour;
-        color: @primary-colour;
+        border-bottom: solid 2px @primary-darker;
+        color: @primary-darker;
       }
     }
   }
@@ -344,7 +344,7 @@ li.resource-item div.btn-wrapper {
   background: none;
   box-shadow: none;
   a.tag {
-    background-color: @primary-colour;
+    background-color: @primary-darker;
     color: #fff;
     font-weight: bold;
     border: none;
@@ -410,7 +410,7 @@ section.additional-info table.table {
 }
 
 .banner-section {
-  background: @primary-colour; 
+  background: @primary-darker; 
   width: 100%;
   a {
     color: white;
@@ -433,6 +433,22 @@ section.additional-info table.table {
 
 .page_primary_action .add-dataset, .page_primary_action .add-organization, .page_primary_action .add-group {
   text-align: right; 
+}
+
+.simple-input .field .btn-search {
+  color: @black;
+}
+
+.empty {
+  color: @grey;
+}
+
+.pagination>.disabled>span, .pagination>.disabled>span:hover, .pagination>.disabled>span:focus, .pagination>.disabled>a, .pagination>.disabled>a:hover, .pagination>.disabled>a:focus, .media-item span.count, .text-muted {
+  color: @grey;
+}
+
+.nav-item.active>a, .nav-aside li.active a {
+  background-color: @primary-darker;
 }
 
 /* =====================================================

--- a/ckanext/ontario_theme/fanstatic/internal/labels.less
+++ b/ckanext/ontario_theme/fanstatic/internal/labels.less
@@ -109,5 +109,5 @@
 
 .label-default {
   background-color: @secondary-colour;
-  color: #000;
+  color: @black;
 }

--- a/ckanext/ontario_theme/fanstatic/internal/ontario_theme.css
+++ b/ckanext/ontario_theme/fanstatic/internal/ontario_theme.css
@@ -577,7 +577,7 @@ div.card p {
 .circle {
   font-family: Raleway, Open Sans, sans-serif;
   border-radius: 50%;
-  color: #1a1a1a;
+  color: white;
   background-color: #1080a6;
   display: inline-block;
   font-weight: 700;
@@ -592,6 +592,7 @@ div.card p {
   line-height: 1.7;
   font-size: 2rem;
   text-align: center;
+  color: #1a1a1a;
   background: #fcaf17;
 }
 .c-small-text {
@@ -667,14 +668,14 @@ h2 {
 h3 {
   font-size: 20px;
 }
-#landing-page-body h3 {
+#landing-page-body h2 {
   font-size: 40px;
   text-align: left;
 }
 h4 {
   font-size: 17px;
 }
-#landing-page-body h4 {
+#landing-page-body h3 {
   font-size: 20px;
   text-align: left;
 }
@@ -840,24 +841,28 @@ li.resource-item div.btn-wrapper {
 }
 .hero .hero-container .welcome {
   text-align: left;
+  line-height: 1rem;
+}
+.hero .hero-container .welcome span.greeting {
+  background: #1080a6;
+  font-size: 4.5rem;
+  letter-spacing: .04rem;
+  line-height: 1.29;
+  font-weight: bold;
+  margin-top: 20px;
+  margin-bottom: 10px;
 }
 .hero .hero-container .welcome p {
   background: #1080a6;
   font-size: 2.375rem;
   line-height: 1.4;
 }
-.hero .hero-container h2 {
-  font-size: 4.5rem;
-  letter-spacing: .04rem;
-  line-height: 1.29;
-  font-weight: bold;
-}
 .hero .hero-container .stats {
   text-align: center;
   font-size: 7rem;
   font-weight: bold;
   vertical-align: bottom;
-  line-height: 0.5;
+  line-height: 0;
 }
 .hero .hero-container .stats a {
   text-decoration: none;
@@ -867,11 +872,17 @@ li.resource-item div.btn-wrapper {
   color: white;
 }
 .hero .hero-container .stats span.above-stat {
-  font-size: 2rem;
-  line-height: 5rem;
+  font-size: 1.6rem;
+  line-height: 8rem;
+}
+.hero .hero-container .stats span.stat {
+  line-height: 1rem;
 }
 .hero .hero-container .stats span.below-stat {
-  font-size: 2.8rem;
+  font-size: 2rem;
+  line-height: 2rem;
+  display: inline-block;
+  margin-top: 3rem;
 }
 .fill-sky {
   fill: #00B2E3;
@@ -890,8 +901,14 @@ li.resource-item div.btn-wrapper {
   padding-top: 20px;
   padding-left: 30px;
   padding-right: 30px;
+  padding-bottom: 20px;
   font-size: 2.375rem;
   line-height: 1.4;
+}
+@media (max-width: 768px) {
+  .contact-us div.container div.message p {
+    padding: 0;
+  }
 }
 .ie8 .hero,
 .ie7 .hero {

--- a/ckanext/ontario_theme/fanstatic/internal/ontario_theme.css
+++ b/ckanext/ontario_theme/fanstatic/internal/ontario_theme.css
@@ -3,9 +3,9 @@
 }
 .new-alert {
   border-color: rgba(0, 0, 0, 0.1);
-  border-width: 0 0 0 0.9375rem;
+  border-width: 0 0 0 .9375rem;
   border-style: solid;
-  padding: 0.9375rem 2rem 0.9375rem 0.9375rem;
+  padding: .9375rem 2rem .9375rem .9375rem;
   color: #333;
   border-radius: 0px;
   min-height: 50px;
@@ -97,7 +97,7 @@
 .new-alert.alert-contact {
   background: #E2F0F4;
   border-color: #1080A6;
-  padding: 0.9375rem 2rem 0.9375rem 0.9375rem;
+  padding: .9375rem 2rem .9375rem .9375rem;
 }
 .new-alert.alert-clear {
   margin-bottom: 30px;
@@ -106,10 +106,10 @@
    Generic classes for Colby colours
    ===================================================== */
 .primary-bg {
-  background-color: #00B2E3;
+  background-color: #00b2e3;
 }
 .secondary-bg {
-  background-color: #FCAF17;
+  background-color: #fcaf17;
 }
 .recent-activity .module-content {
   padding: 0px;
@@ -174,8 +174,7 @@ a.skip-main:active {
   color: #fff;
 }
 .btn-secondary {
-  color: #000;
-  text-shadow: 0 0 4px #8A600D;
+  color: #1a1a1a;
 }
 .btn-secondary:focus,
 .btn-secondary.focus,
@@ -184,26 +183,26 @@ a.skip-main:active {
 .btn-secondary:hover,
 .btn-secondary:active,
 .btn-secondary.active {
-  color: #000;
+  color: #1a1a1a;
 }
 .btn-primary {
-  background-color: #1080A6;
+  background-color: #1080a6;
   border-color: #094a60;
 }
 .btn-primary:hover {
   background-color: #094a60;
-  border-color: #00B2E3;
+  border-color: #00b2e3;
 }
 .btn-primary:focus,
 .btn-primary.focus {
-  background-color: #1080A6;
-  border-color: #00B2E3;
+  background-color: #1080a6;
+  border-color: #00b2e3;
 }
 .btn-primary:active,
 .btn-primary.active,
 .btn-primary .open > .dropdown-toggle.btn-primary {
   background-color: #094a60;
-  border-color: #00B2E3;
+  border-color: #00b2e3;
   background-image: none;
 }
 .btn-primary:active:hover,
@@ -216,7 +215,7 @@ a.skip-main:active {
 .btn-primary.active.focus,
 .btn-primary .open > .dropdown-toggle.btn-primary.focus {
   background-color: #094a60;
-  border-color: #00B2E3;
+  border-color: #00b2e3;
 }
 .btn-primary.disabled:hover,
 .btn-primary[disabled]:hover,
@@ -227,30 +226,30 @@ a.skip-main:active {
 .btn-primary.disabled.focus,
 .btn-primary[disabled].focus,
 .btn-primary fieldset[disabled] .btn-primary.focus {
-  background-color: #00B2E3;
+  background-color: #00b2e3;
   border-color: #094a60;
 }
 .btn-primary.badge {
-  color: #1080A6;
+  color: #1080a6;
   background-color: #ffffff;
 }
 .btn-secondary {
-  background-color: #FCAF17;
-  border-color: #8A600D;
+  background-color: #fcaf17;
+  border-color: #8a600d;
 }
 .btn-secondary:hover {
-  background-color: #8A600D;
+  background-color: #8a600d;
   border-color: #442f06;
 }
 .btn-secondary:focus,
 .btn-secondary.focus {
-  background-color: #8A600D;
+  background-color: #8a600d;
   border-color: #442f06;
 }
 .btn-secondary:active,
 .btn-secondary.active,
 .btn-secondary .open > .dropdown-toggle.btn-secondary {
-  background-color: #8A600D;
+  background-color: #8a600d;
   border-color: #442f06;
   background-image: none;
 }
@@ -263,7 +262,7 @@ a.skip-main:active {
 .btn-secondary:active.focus,
 .btn-secondary.active.focus,
 .btn-secondary .open > .dropdown-toggle.btn-secondary.focus {
-  background-color: #8A600D;
+  background-color: #8a600d;
   border-color: #442f06;
 }
 .btn-secondary.disabled:hover,
@@ -275,21 +274,21 @@ a.skip-main:active {
 .btn-secondary.disabled.focus,
 .btn-secondary[disabled].focus,
 .btn-secondary fieldset[disabled] .btn-secondary.focus {
-  background-color: #FCAF17;
-  border-color: #8A600D;
+  background-color: #fcaf17;
+  border-color: #8a600d;
 }
 .btn-secondary.badge {
-  color: #FCAF17;
+  color: #fcaf17;
   background-color: #ffffff;
 }
 .btn-grey {
   color: #fff;
-  background-color: #666;
-  border-color: #444;
+  background-color: #666666;
+  border-color: #444444;
 }
 .btn-grey:hover {
-  background-color: #444;
-  border-color: #222;
+  background-color: #444444;
+  border-color: #222222;
 }
 .btn-grey:hover,
 .btn-grey:visited {
@@ -297,14 +296,14 @@ a.skip-main:active {
 }
 .btn-grey:focus,
 .btn-grey.focus {
-  background-color: #444;
-  border-color: #222;
+  background-color: #444444;
+  border-color: #222222;
 }
 .btn-grey:active,
 .btn-grey.active,
 .btn-grey .open > .dropdown-toggle.btn-grey {
-  background-color: #444;
-  border-color: #222;
+  background-color: #444444;
+  border-color: #222222;
   background-image: none;
 }
 .btn-grey:active:hover,
@@ -316,8 +315,8 @@ a.skip-main:active {
 .btn-grey:active.focus,
 .btn-grey.active.focus,
 .btn-grey .open > .dropdown-toggle.btn-grey.focus {
-  background-color: #444;
-  border-color: #222;
+  background-color: #444444;
+  border-color: #222222;
 }
 .btn-grey.disabled:hover,
 .btn-grey[disabled]:hover,
@@ -328,11 +327,11 @@ a.skip-main:active {
 .btn-grey.disabled.focus,
 .btn-grey[disabled].focus,
 .btn-grey fieldset[disabled] .btn-grey.focus {
-  background-color: #666;
-  border-color: #444;
+  background-color: #666666;
+  border-color: #444444;
 }
 .btn-grey.badge {
-  color: #666;
+  color: #666666;
   background-color: #ffffff;
 }
 @font-face {
@@ -340,8 +339,9 @@ a.skip-main:active {
   font-style: normal;
   font-weight: 400;
   src: url(/fonts/material/MaterialIcons-Regular.eot);
-  /* For IE6-8 */
   src: local('Material Icons'), local('MaterialIcons-Regular'), url(/fonts/material/MaterialIcons-Regular.woff2) format('woff2'), url(/fonts/material/MaterialIcons-Regular.woff) format('woff'), url(/fonts/material/MaterialIcons-Regular.ttf) format('truetype');
+  
+  /* For IE6-8 */
 }
 .material-icons {
   font-family: 'Material Icons';
@@ -370,7 +370,7 @@ a.skip-main:active {
   white-space: normal;
 }
 a.card div {
-  background-color: #f5f5f5;
+  background-color: #cccccc;
   transition: 1s;
   transition: box-shadow 135ms cubic-bezier(0.4, 0, 0.2, 1), width 235ms cubic-bezier(0.4, 0, 0.2, 1);
   box-shadow: 0 2px 4px #666;
@@ -385,7 +385,7 @@ a.card img {
   width: 100%;
 }
 a.card p {
-  color: #4d4d4d;
+  color: #666666;
 }
 a.card:hover {
   text-decoration: none;
@@ -403,7 +403,7 @@ div.card img {
   width: 100%;
 }
 div.card p {
-  color: #4d4d4d;
+  color: #666666;
 }
 .col-xs-2-10,
 .col-sm-2-10 {
@@ -457,7 +457,7 @@ div.card p {
   margin: 0 10px 0 0;
 }
 .module.search .tags a.tag {
-  background-color: #00B2E3;
+  background-color: #00b2e3;
   color: #fff;
   font-weight: bold;
   border: none;
@@ -562,8 +562,8 @@ div.card p {
   background-color: #e6fad2;
 }
 .label-default {
-  background-color: #FCAF17;
-  color: #000;
+  background-color: #fcaf17;
+  color: #1a1a1a;
 }
 .stats .number {
   display: block;
@@ -582,7 +582,7 @@ div.card p {
   font-family: Raleway, Open Sans, sans-serif;
   border-radius: 50%;
   color: #000;
-  background-color: #00B2E3;
+  background-color: #1080a6;
   display: inline-block;
   font-weight: 700;
   margin-bottom: 0.5rem;
@@ -596,7 +596,7 @@ div.card p {
   line-height: 1.7;
   font-size: 2rem;
   text-align: center;
-  background: #FCAF17;
+  background: #fcaf17;
 }
 .c-small-text {
   padding-top: 0.5rem;
@@ -611,7 +611,7 @@ div#topics {
   margin-bottom: 20px;
 }
 div#topics a {
-  color: #1A1A1A;
+  color: #1a1a1a;
 }
 div#topics div {
   text-align: center;
@@ -620,10 +620,10 @@ div#topics div {
 }
 div#topics div i {
   font-size: 64px;
-  color: #1080A6;
+  color: #1080a6;
 }
 div#topics div i:hover {
-  color: #00B2E3;
+  color: #00b2e3;
 }
 div#topics div.row {
   margin-bottom: 20px;
@@ -697,7 +697,7 @@ h6 {
   font-family: Raleway, Open Sans, Helvetica Neue, Helvetica, Arial, sans-serif;
 }
 a {
-  color: #06c;
+  color: #0066cc;
 }
 a:hover,
 a:focus {
@@ -820,7 +820,7 @@ li.resource-item div.btn-wrapper {
 .hero {
   min-height: 400px;
   line-height: 400px;
-  background-color: #00B2E3;
+  background-color: #1080a6;
   background-image: url(/images/co-homepage-supergraphic.svg);
   background-position-x: 49vw;
   background-position-y: top;
@@ -846,12 +846,13 @@ li.resource-item div.btn-wrapper {
   text-align: left;
 }
 .hero .hero-container .welcome p {
+  background: #1080a6;
   font-size: 2.375rem;
   line-height: 1.4;
 }
 .hero .hero-container h2 {
   font-size: 4.5rem;
-  letter-spacing: 0.04rem;
+  letter-spacing: .04rem;
   line-height: 1.29;
   font-weight: bold;
 }
@@ -867,7 +868,6 @@ li.resource-item div.btn-wrapper {
 }
 .hero .hero-container .stats a,
 .hero .hero-container .stats a:visited {
-  text-shadow: 0 0 4px #8A600D;
   color: white;
 }
 .hero .hero-container .stats span.above-stat {
@@ -918,7 +918,7 @@ li.resource-item div.btn-wrapper {
   width: 100%;
 }
 .wrapper header.page-header ul.nav.nav-tabs li a {
-  color: #4d4d4d;
+  color: #666666;
   border: none;
 }
 .wrapper header.page-header ul.nav.nav-tabs li a:hover {
@@ -926,8 +926,8 @@ li.resource-item div.btn-wrapper {
 }
 .wrapper header.page-header ul.nav.nav-tabs li.active a {
   border: none;
-  border-bottom: solid 2px #00B2E3;
-  color: #00B2E3;
+  border-bottom: solid 2px #1080a6;
+  color: #1080a6;
 }
 .module-heading {
   border-top: none;
@@ -953,7 +953,7 @@ li.resource-item div.btn-wrapper {
   box-shadow: none;
 }
 .well a.tag {
-  background-color: #00B2E3;
+  background-color: #1080a6;
   color: #fff;
   font-weight: bold;
   border: none;
@@ -1009,7 +1009,7 @@ section.additional-info table.table tbody tr td.dataset-details {
   border: none;
 }
 .banner-section {
-  background: #00B2E3;
+  background: #1080a6;
   width: 100%;
 }
 .banner-section a {
@@ -1034,6 +1034,26 @@ section.additional-info table.table tbody tr td.dataset-details {
 .page_primary_action .add-organization,
 .page_primary_action .add-group {
   text-align: right;
+}
+.simple-input .field .btn-search {
+  color: #1a1a1a;
+}
+.empty {
+  color: #666666;
+}
+.pagination > .disabled > span,
+.pagination > .disabled > span:hover,
+.pagination > .disabled > span:focus,
+.pagination > .disabled > a,
+.pagination > .disabled > a:hover,
+.pagination > .disabled > a:focus,
+.media-item span.count,
+.text-muted {
+  color: #666666;
+}
+.nav-item.active > a,
+.nav-aside li.active a {
+  background-color: #1080a6;
 }
 /* =====================================================
    Sub page left panel border removal
@@ -1078,7 +1098,7 @@ section.additional-info table.table tbody tr td.dataset-details {
    The main masthead bar that contains the site logo, nav links, and search
    ======================================================================== */
 .masthead {
-  background-color: #1080A6;
+  background-color: #1080a6;
 }
 .masthead a,
 .masthead a:focus,
@@ -1129,7 +1149,7 @@ section.additional-info table.table tbody tr td.dataset-details {
   top: 1px;
 }
 .toolbar .breadcrumb a {
-  color: #8A600D;
+  color: #8a600d;
   font-size: 15px;
 }
 .logo img {
@@ -1146,14 +1166,14 @@ footer.site-footer {
   margin-top: 1em;
   padding: 2em 0 1.5em;
   border-top: 1px solid #d9d9d9;
-  color: #4d4d4d;
+  color: #666666;
 }
 footer.site-footer a.btn i.material-icons {
   color: white;
 }
 footer.site-footer a:not(.btn),
 footer.site-footer a:visited:not(.btn) {
-  color: #4d4d4d;
+  color: #666666;
   text-decoration: underline;
 }
 footer.site-footer div.footer-swoosh {

--- a/ckanext/ontario_theme/fanstatic/internal/ontario_theme.css
+++ b/ckanext/ontario_theme/fanstatic/internal/ontario_theme.css
@@ -127,19 +127,9 @@
   left: 0px;
   position: relative;
 }
-.accessibly-hidden,
-.toolbar .home span,
-.simple-input label,
-.simple-input button span,
-a.skip-main {
-  left: -999px;
-  position: absolute;
-  top: auto;
-  width: 1px;
-  height: 1px;
-  overflow: hidden;
-  z-index: -999;
-  display: inline;
+.sr-only {
+  background-color: #ffffff;
+  color: #1a1a1a;
 }
 a.skip-main:focus,
 a.skip-main:active {
@@ -581,7 +571,7 @@ div.card p {
 .circle {
   font-family: Raleway, Open Sans, sans-serif;
   border-radius: 50%;
-  color: #000;
+  color: #1a1a1a;
   background-color: #1080a6;
   display: inline-block;
   font-weight: 700;

--- a/ckanext/ontario_theme/fanstatic/internal/ontario_theme.css
+++ b/ckanext/ontario_theme/fanstatic/internal/ontario_theme.css
@@ -127,7 +127,11 @@
   left: 0px;
   position: relative;
 }
-.sr-only {
+.sr-only,
+.toolbar .home span,
+.simple-input label,
+.simple-input button span,
+a.skip-main {
   background-color: #ffffff;
   color: #1a1a1a;
 }
@@ -147,6 +151,8 @@ a.skip-main:active {
   text-align: center;
   font-size: 1.2em;
   z-index: 999;
+  position: absolute;
+  display: inline;
 }
 /* =====================================================
    Button overrides

--- a/ckanext/ontario_theme/fanstatic/internal/smarties.less
+++ b/ckanext/ontario_theme/fanstatic/internal/smarties.less
@@ -16,7 +16,7 @@
 .circle {
   font-family: Raleway, Open Sans, sans-serif;
   border-radius: 50%;
-  color: #000;
+  color: @black;
   background-color: @primary-darker;
   display: inline-block;
   font-weight: 700;

--- a/ckanext/ontario_theme/fanstatic/internal/smarties.less
+++ b/ckanext/ontario_theme/fanstatic/internal/smarties.less
@@ -17,7 +17,7 @@
   font-family: Raleway, Open Sans, sans-serif;
   border-radius: 50%;
   color: #000;
-  background-color: @primary-colour;
+  background-color: @primary-darker;
   display: inline-block;
   font-weight: 700;
   margin-bottom: 0.5rem;

--- a/ckanext/ontario_theme/fanstatic/internal/smarties.less
+++ b/ckanext/ontario_theme/fanstatic/internal/smarties.less
@@ -16,7 +16,7 @@
 .circle {
   font-family: Raleway, Open Sans, sans-serif;
   border-radius: 50%;
-  color: @black;
+  color: white;
   background-color: @primary-darker;
   display: inline-block;
   font-weight: 700;
@@ -30,6 +30,7 @@
     line-height: 1.7;
     font-size: 2rem;
     text-align: center;
+    color: @black;
     background: @secondary-colour;
   }  
 }

--- a/ckanext/ontario_theme/templates/external/home/snippets/ontario_theme_featured_content.html
+++ b/ckanext/ontario_theme/templates/external/home/snippets/ontario_theme_featured_content.html
@@ -9,33 +9,33 @@ already existing in the system.
 
 <div class="col-md-4">
   <img src="images/external/features/covid.png" alt="{% trans %}Decorative image{% endtrans %} : {% trans %}COVID-19 Data{% endtrans %}" />
-  <h4>
+  <h3>
     <a href="/{{ request.environ.CKAN_LANG }}/group/2019-novel-coronavirus">
       {% trans %}COVID-19 Data{% endtrans %}
     </a>
-  </h4>
+  </h3>
   <p>
     {% trans %}Get data on COVID-19 activity in Ontario.{% endtrans %}
   </p>
 </div>
 <div class="col-md-4">
   <img src="images/external/features/ai.jpg" alt="{% trans %}Decorative image{% endtrans %} : {% trans %}Alpha AI Guidance{% endtrans %}" />
-  <h4>
+  <h3>
     <a href="https://github.com/orgs/ongov/projects/2">
       {% trans %}Alpha AI Guidance{% endtrans %}
     </a>
-  </h4>
+  </h3>
   <p>
     {% trans %}Ontario is committed to ensuring that government use of artificial intelligence and similar technologies has a strong, clear framework for transparent and appropriate use. Let us know what you think.{% endtrans %}
   </p>
 </div>
 <div class="col-md-4">
   <img src="images/external/features/ai_and_algs.jpg" alt="{% trans %}Decorative image{% endtrans %} : {% trans %}Open Data, Open Source{% endtrans %}" />
-  <h4>
+  <h3>
     <a href="https://github.com/ongov">
       {% trans %}Open Data, Open Source{% endtrans %}
     </a>
-  </h4>
+  </h3>
   <p>
     {% trans %}The Government of Ontario is taking steps towards open source software development, and sharing our catalogue work on GitHub is just one of these steps.{% endtrans %}
   </p>

--- a/ckanext/ontario_theme/templates/external/home/snippets/ontario_theme_intro.html
+++ b/ckanext/ontario_theme/templates/external/home/snippets/ontario_theme_intro.html
@@ -3,9 +3,9 @@
 Renders a hard coded site description/introduction.
 
 #}
-<h2>
-  {{ _("Welcome!") }}
-</h2> 
+<div>
+	<span class="greeting">{{ _("Welcome") }}!</span>
+</div>
 <p>
 {% trans %}Here you will find thousands of datasets that are maintained by the Ontario Government.{% endtrans %} 
 {% trans %}<a href="/about">Learn more</a> about what is covered and how to use data.{% endtrans %}

--- a/ckanext/ontario_theme/templates/internal/header.html
+++ b/ckanext/ontario_theme/templates/internal/header.html
@@ -88,9 +88,9 @@
   {% endif %} {% endblock %}
   <div class="container">
     <div class="navbar-right">
-      <button data-target="#main-navigation-toggle" data-toggle="collapse" class="navbar-toggle collapsed" aria-expanded="false" type="button">
-        <span class="sr-only">Toggle navigation</span>
-        <span class="fa fa-bars"></span>
+      <button data-target="#main-navigation-toggle" data-toggle="collapse" class="navbar-toggle collapsed" aria-expanded="false" type="button" aria-label="{{ _('Toggle navigation') }}">
+        <span class="sr-only">{{ _('Toggle navigation') }}</span>
+        <span class="fa fa-bars" aria-hidden="true"></span>
       </button>
     </div>
     <hgroup class="{{ g.header_class }} navbar-left">
@@ -127,7 +127,7 @@
           <div class="field">
             <label for="field-sitewide-search">{% block header_site_search_label %}{{ _('Search Datasets') }}{% endblock %}</label>
             <input id="field-sitewide-search" type="text" class="form-control" name="q" placeholder="{{ _('Search') }}" />
-            <button class="btn-search" type="submit"><i class="fa fa-search"></i><span>Submit Search</span></button>
+            <button class="btn-search" type="submit" aria-label="{{ _('Submit Search') }}"><i class="fa fa-search" aria-hidden="true"></i><span class="sr-only">{{ _('Submit Search') }}</span></button>
           </div>
         </form>
       {% endblock %}

--- a/ckanext/ontario_theme/templates/internal/home/layout3.html
+++ b/ckanext/ontario_theme/templates/internal/home/layout3.html
@@ -31,7 +31,7 @@
   <div class="container" id="topics">
     <div class="row">
       <div class="col-md-12">
-        <h3>{{ _("Browse by category") }}</h3>
+        <h2>{{ _("Browse by category") }}</h2>
       </div>
     </div>
     {% snippet 'home/snippets/ontario_theme_categories.html' %}
@@ -41,7 +41,7 @@
   <div id="news" class="container">
     <div class="row homepage-section">
       <div class="col-md-12">
-        <h3>{{ _("What's new") }}</h3>
+        <h2>{{ _("What's new") }}</h2>
       </div>
       {% block featured_content %}
         {% snippet 'home/snippets/ontario_theme_featured_content.html' %}
@@ -49,12 +49,12 @@
     </div>   
     <div class="row homepage-section">
       <div class="col-md-6 dataset-list">
-            <h4>{{ _("Most popular datasets") }}</h4>
-            {% snippet 'home/snippets/ontario_theme_popular_datasets.html' %}
+        <h3>{{ _("Most popular datasets") }}</h3>
+        {% snippet 'home/snippets/ontario_theme_popular_datasets.html' %}
       </div>
       <div class="col-md-6 dataset-list">
-        <h4>{{ _("Recently updated datasets") }}</h4>
-            {% snippet 'home/snippets/ontario_theme_recent_activity.html' %}
+        <h3>{{ _("Recently updated datasets") }}</h3>
+        {% snippet 'home/snippets/ontario_theme_recent_activity.html' %}
       </div>
     </div>
   </div>

--- a/ckanext/ontario_theme/templates/internal/home/layout3.html
+++ b/ckanext/ontario_theme/templates/internal/home/layout3.html
@@ -1,6 +1,6 @@
 <div id="landing-page-body">
 <div class="hero">
-  <h1 class="accessibly-hidden">{{ _("Home") }}</h1>
+  <h1 class="sr-only">{{ _("Home") }}</h1>
     <div class="container">
       <div class="hero-container">
         <div class="row">

--- a/ckanext/ontario_theme/templates/internal/home/snippets/ontario_theme_datasets_stats.html
+++ b/ckanext/ontario_theme/templates/internal/home/snippets/ontario_theme_datasets_stats.html
@@ -8,8 +8,10 @@ Uses get_site_statistics() to parse and display the stat.
 {% set stats = h.get_site_statistics() %}
 
 <a href="/{{ request.environ.CKAN_LANG }}/dataset">
-	<span class="above-stat">{{ _("Explore Ontario's") }}</span><br />
-	{{ stats.dataset_count }} <br>
-	<span class="below-stat">{{ _("data assets") }}</span><br />
-	<button class="btn btn-primary" style="margin-top: 15px">{{ _("View All") }}</button>
+	<span class="circle">
+		<span class="above-stat">{{ _("Explore Ontario's") }}</span><br />
+		<span class="stat">{{ stats.dataset_count }}</span> <br>
+		<span class="below-stat">{{ _("data assets") }}</span><br />
+	</span><br />
+	<button class="btn btn-primary">{{ _("View All") }}</button>
 </a>

--- a/ckanext/ontario_theme/templates/internal/home/snippets/ontario_theme_intro.html
+++ b/ckanext/ontario_theme/templates/internal/home/snippets/ontario_theme_intro.html
@@ -7,7 +7,9 @@ can be used.
 #}
 <div class="row">
   <div class="col-md-12">
-    <h2>Welcome!</h2>
+    <div>
+	<span class="greeting">{{ _("Welcome") }}!</span>
+	</div>
     <p>
     {% trans %}
       Here you'll find thousands of datasets that are maintained by the Ontario Government for OPS use. <a href="/about">Learn more about Colby</a>

--- a/ckanext/ontario_theme/templates/internal/home/snippets/search.html
+++ b/ckanext/ontario_theme/templates/internal/home/snippets/search.html
@@ -10,8 +10,8 @@ Renders a custom search component for the home page.
   <form class="module-content search-form" method="get" action="{% url_for controller='package', action='search' %}">
     <div class="search-input form-group search-giant">
       <input aria-label="{% block header_site_search_label %}{{ _('Search datasets') }}{% endblock %}" id="field-main-search" type="text" class="form-control" name="q" value="" autocomplete="off" placeholder="{% block search_placeholder %}{{ placeholder }}{% endblock %}" />
-      <button type="submit">
-        <i class="fa fa-search"></i>
+      <button type="submit" aria-label="{{ _('Search') }}">
+        <i class="fa fa-search" aria-hidden="true"></i>
         <span class="sr-only">{{ _('Search') }}</span>
       </button>
     </div>

--- a/ckanext/ontario_theme/templates/internal/page.html
+++ b/ckanext/ontario_theme/templates/internal/page.html
@@ -1,7 +1,7 @@
 {% ckan_extends %}
 
 {% block skip %}
-  <a href="#content" class="skip-main">{{ _('Skip to content') }}</a> 
+  <a href="#content" class="skip-main sr-only sr-only-focusable">{{ _('Skip to content') }}</a> 
 {% endblock %}
 
 {% block main_content %}

--- a/ckanext/ontario_theme/templates/internal/snippets/facet_list.html
+++ b/ckanext/ontario_theme/templates/internal/snippets/facet_list.html
@@ -21,7 +21,7 @@
       {% endif %}               
     {% endif %} 
   </h2>
-  <span class="accessibly-hidden">{{screen_reader_text}}</span>
+  <span class="sr-only">{{screen_reader_text}}</span>
   {% endwith %}
 {% endblock %}
 {% block facet_list_items %}
@@ -39,7 +39,7 @@
           {% set count = count_label(item['count']) if count_label else ('(%d)' % item['count']) %}
             <li class="{{ nav_item_class or 'nav-item' }}{% if item.active %} active{% endif %}">
               {% if item.active %}
-                <span class="accessibly-hidden">Filtered on</span>
+                <span class="sr-only">Filtered on</span>
               {% endif %}                  
               <a href="{{ href }}" title="{{ label if label != label_truncated else '' }}">
                 <span>{{ label_truncated }} {{ count }}</span>

--- a/ckanext/ontario_theme/templates/internal/snippets/search_form.html
+++ b/ckanext/ontario_theme/templates/internal/snippets/search_form.html
@@ -24,7 +24,7 @@
           {% set search_facets_items = facets.search.get(field)['items'] %}
           <span class="facet">
             {% if (not query and not loop.index0==0) or query %}
-              <span class="accessibly-hidden"> and </span>
+              <span class="sr-only"> and </span>
             {% endif %}
             {{ facets.titles.get(field, "Has Resources (data)") }}:
           </span>

--- a/ckanext/ontario_theme/templates/internal/snippets/search_form.html
+++ b/ckanext/ontario_theme/templates/internal/snippets/search_form.html
@@ -2,8 +2,9 @@
 
 {% block search_input_button %}
 <span class="input-group-btn">
-  <button class="btn btn-default btn-lg" type="submit" value="search">
-    <i class="fa fa-search"></i>
+  <button class="btn btn-default btn-lg" type="submit" value="search" aria-label="{{ _('Search') }}">
+    <i class="fa fa-search" aria-hidden="true"></i>
+    <span class="sr-only">{{ _('Search') }}</span>
   </button>
 </span>
 {% endblock %}

--- a/ckanext/ontario_theme/templates/internal/snippets/search_form.html
+++ b/ckanext/ontario_theme/templates/internal/snippets/search_form.html
@@ -1,5 +1,14 @@
 {% ckan_extends %}
 
+{% block search_input_button %}
+<span class="input-group-btn">
+  <button class="btn btn-default btn-lg" type="submit" value="search">
+    <i class="fa fa-search"></i>
+  </button>
+</span>
+{% endblock %}
+
+
 {% block search_facets %}
   {% if facets %}
     <p class="filter-list">


### PR DESCRIPTION
This PR consists of 5 commits to make the following changes:
* update colours to accessible colours from the ontario.ca design system
* shift to use of bootstrap's sr-only class for screen-reader-only text
* addition of aria-label and aria-hidden to some buttons that use icons
* update homepage with correct header order and consistent colour contrasting


To do in a future PR:
- headings order needs to be reviewed on other pages
- potentially review all icon buttons in order to add accessible labels