### PR TITLE
Add new geographic breakdown options to a package.

### DIFF
--- a/ckanext/ontario_theme/schemas/external/ontario_theme_dataset.json
+++ b/ckanext/ontario_theme/schemas/external/ontario_theme_dataset.json
@@ -129,6 +129,48 @@
             "en": "Municipality",
             "fr": "Municipalité"
           }
+        },
+        {
+          "value": "province",
+          "label": {
+            "en": "Province",
+            "fr": "Province"
+          }
+        },
+        {
+          "value": "wmu",
+          "label": {
+            "en": "Wildlife Management Unit",
+            "fr": "Unités de gestion de la faune"
+          }
+        },
+        {
+          "value": "fmu",
+          "label": {
+            "en": "Forest Management Unit",
+            "fr": "Unités de gestion forestière"
+          }
+        },
+        {
+          "value": "county",
+          "label": {
+            "en": "County",
+            "fr": "Comté"
+          }
+        },
+        {
+          "value": "district",
+          "label": {
+            "en": "District",
+            "fr": "District"
+          }
+        },
+        {
+          "value": "fsa",
+          "label": {
+            "en": "Forward Sortation Area",
+            "fr": "régions de tri d’acheminement"
+          }
         }
       ]
     }, 

--- a/ckanext/ontario_theme/schemas/internal/ontario_theme_dataset.json
+++ b/ckanext/ontario_theme/schemas/internal/ontario_theme_dataset.json
@@ -129,6 +129,48 @@
             "en": "Municipality",
             "fr": "Municipalité"
           }
+        },
+        {
+          "value": "province",
+          "label": {
+            "en": "Province",
+            "fr": "Province"
+          }
+        },
+        {
+          "value": "wmu",
+          "label": {
+            "en": "Wildlife Management Unit",
+            "fr": "Unités de gestion de la faune"
+          }
+        },
+        {
+          "value": "fmu",
+          "label": {
+            "en": "Forest Management Unit",
+            "fr": "Unités de gestion forestière"
+          }
+        },
+        {
+          "value": "county",
+          "label": {
+            "en": "County",
+            "fr": "Comté"
+          }
+        },
+        {
+          "value": "district",
+          "label": {
+            "en": "District",
+            "fr": "District"
+          }
+        },
+        {
+          "value": "fsa",
+          "label": {
+            "en": "Forward Sortation Area",
+            "fr": "régions de tri d’acheminement"
+          }
         }
       ]
     }, 


### PR DESCRIPTION
This PR consists of 1 commit to make 1 change: Add missing geographic breakdowns: Province, Wildlife Management Unit, Forest Management Unit, County, District, and Forward Sortation Area. These are all geographic breakdowns of existing datasets in the catalogue.