### PR TITLE
Add classes for GA use to track homepage traffic

### DIFF
--- a/ckanext/ontario_theme/templates/internal/home/snippets/ontario_theme_categories.html
+++ b/ckanext/ontario_theme/templates/internal/home/snippets/ontario_theme_categories.html
@@ -46,7 +46,7 @@
 <div class="row">
   {% for iter2 in [0,1,2,3,4] %}
   {% set i = (iter1+iter2) %}
-  <a href="/{{ request.environ.CKAN_LANG }}/dataset?keywords_{{ request.environ.CKAN_LANG }}={{ _(topics[i]['label'])|replace(' ','+')|replace(',','') }}">
+  <a href="/{{ request.environ.CKAN_LANG }}/dataset?keywords_{{ request.environ.CKAN_LANG }}={{ _(topics[i]['label'])|replace(' ','+')|replace(',','') }}" class="hp_category">
     <div class="col-md-2-10">
       <i class="fa fa-{{topics[i]['fa-icon']}}"></i> <br>
         {{ _(topics[i]['label']) }}

--- a/ckanext/ontario_theme/templates/internal/home/snippets/ontario_theme_popular_datasets.html
+++ b/ckanext/ontario_theme/templates/internal/home/snippets/ontario_theme_popular_datasets.html
@@ -8,7 +8,7 @@
       </div>
     </div>
     <div class="col-md-10 col-sm-10 col-xs-10 c-small-text">
-      <a href="{% url_for controller='package', action='read', id=dataset.name %}">{{ h.get_translated(dataset, "title") }}</a><br />
+      <a href="{% url_for controller='package', action='read', id=dataset.name %}" class="hp_popular">{{ h.get_translated(dataset, "title") }}</a><br />
     </div>
   </div>
   {% endfor %}

--- a/ckanext/ontario_theme/templates/internal/home/snippets/ontario_theme_recent_activity.html
+++ b/ckanext/ontario_theme/templates/internal/home/snippets/ontario_theme_recent_activity.html
@@ -11,7 +11,7 @@ Renders a list of the site's most recent activity.
       <span class="label label-default">{{ h.render_datetime(dataset.current_as_of) }}</span>
     </div>
     <div class="col-md-9 col-sm-9 col-xs-8">
-      <a href="{% url_for controller='package', action='read', id=dataset.name %}">{{ h.get_translated(dataset, "title") }}</a>
+      <a href="{% url_for controller='package', action='read', id=dataset.name %}" class="hp_recently_updated">{{ h.get_translated(dataset, "title") }}</a>
     </div>
   </div>
   {% endfor %}


### PR DESCRIPTION
This PR consists of 1 commit to add 3 classes to links in the homepage to track the use of those categories of links.