### PR TITLE
Fluent groups

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -72,10 +72,10 @@ Update the development.ini (or production.ini) plugins::
     # Note: This extension needs to be before scheming and fluent in the *.ini config file to let the form overrides work.
     
     # For external catalogue
-    ckan.plugins = [...] ontario_theme_external ontario_theme scheming_datasets scheming_organizations fluent [...]
+    ckan.plugins = [...] ontario_theme_external ontario_theme scheming_datasets scheming_organizations scheming_groups fluent [...]
 
     # For internal catalogue
-    ckan.plugins = [...] ontario_theme scheming_datasets scheming_organizations fluent [...]
+    ckan.plugins = [...] ontario_theme scheming_datasets scheming_organizations scheming_groups fluent [...]
 
     # For both, add licenses:
     licenses_group_url = file:///<path to this extension>/ckanext/ontario_theme/schemas/licences.json

--- a/ckanext/ontario_theme/plugin.py
+++ b/ckanext/ontario_theme/plugin.py
@@ -208,6 +208,13 @@ def csv_dump():
         (b'attachment; filename="output.csv"')
     return resp
 
+def get_group(group_id):
+    '''Helper to return 3 freshest datasets
+    '''
+    group_dict = toolkit.get_action('group_show')(
+        data_dict={'id': group_id})
+    return group_dict
+
 def get_recently_updated_datasets():
     '''Helper to return 3 freshest datasets
     '''
@@ -395,6 +402,7 @@ type data_last_updated
         return {'ontario_theme_get_license': get_license,
                 'ontario_theme_get_translated_lang': get_translated_lang,
                 'ontario_theme_get_popular_datasets': get_popular_datasets,
+                'ontario_theme_get_group': get_group,
                 'ontario_theme_get_recently_updated_datasets': get_recently_updated_datasets,
                 'extrafields_default_locale': default_locale,
                 'ontario_theme_get_package_keywords': get_package_keywords}

--- a/ckanext/ontario_theme/plugin.py
+++ b/ckanext/ontario_theme/plugin.py
@@ -208,7 +208,6 @@ def csv_dump():
         (b'attachment; filename="output.csv"')
     return resp
 
-
 def get_recently_updated_datasets():
     '''Helper to return 3 freshest datasets
     '''
@@ -350,6 +349,9 @@ ckanext.fluent:presets.json
 """
         config_['scheming.organization_schemas'] = """
 ckanext.ontario_theme:schemas/ontario_theme_organization.json
+"""
+        config_['scheming.group_schemas'] = """
+ckanext.ontario_theme:schemas/ontario_theme_group.json
 """
 
 class OntarioThemePlugin(plugins.SingletonPlugin, DefaultTranslation):

--- a/ckanext/ontario_theme/plugin.py
+++ b/ckanext/ontario_theme/plugin.py
@@ -209,7 +209,10 @@ def csv_dump():
     return resp
 
 def get_group(group_id):
-    '''Helper to return 3 freshest datasets
+    '''Helper to return the group.
+    CKAN core has a get_organization helper but does not have one for groups.
+    This also allows us to access the group with all extras which are needed to 
+    access the scheming/fluent fields.
     '''
     group_dict = toolkit.get_action('group_show')(
         data_dict={'id': group_id})

--- a/ckanext/ontario_theme/schemas/ontario_theme_group.json
+++ b/ckanext/ontario_theme/schemas/ontario_theme_group.json
@@ -1,0 +1,45 @@
+{
+  "scheming_version": 1,
+  "group_type": "group",
+  "form_languages": ["en", "fr"],
+  "about_url": "http://github.com/ckan/ckanext-scheming",
+  "fields": [
+    {
+      "field_name": "title_translated",
+      "label": {
+        "en": "Name",
+        "fr": "Nom"
+      },
+      "preset": "fluent_core_translated",
+      "form_snippet": "extrafields_fluent_title.html",
+      "form_placeholder": "Group name",
+      "classes": ["col-md-12","form-group"]
+    },
+    {
+      "field_name": "name",
+      "label": "URL",
+      "validators": "not_empty unicode name_validator group_name_validator",
+      "form_snippet": "slug.html",
+      "form_placeholder": "group-name",
+      "classes": ["col-md-12","form-group"]
+    },
+    {
+      "field_name": "description_translated",
+      "label": {
+        "en": "Description",
+        "fr": "La description"
+      },
+      "help_inline" : true,
+      "preset": "fluent_core_translated",
+      "form_snippet": "fluent_markdown.html",
+      "form_placeholder": "A little information about my group...",
+      "classes": ["col-md-12","form-group"]
+    },
+    {
+      "field_name": "image_url",
+      "validators": "ignore_missing unicode remove_whitespace",
+      "form_snippet": "ontario_theme_organization_upload.html",
+      "classes": ["col-md-12","form-group"]
+    }
+  ]
+}

--- a/ckanext/ontario_theme/templates/internal/group/snippets/group_item.html
+++ b/ckanext/ontario_theme/templates/internal/group/snippets/group_item.html
@@ -1,0 +1,10 @@
+{% ckan_extends %}
+
+{% block title %}
+  <h3 class="media-heading">{{ group.display_name }}</h3>
+{% endblock %}
+{% block description %}
+  {% if group.description %}
+    <p>{{ h.markdown_extract(group.description, extract_length=80) }}</p>
+  {% endif %}
+{% endblock %}

--- a/ckanext/ontario_theme/templates/internal/group/snippets/group_item.html
+++ b/ckanext/ontario_theme/templates/internal/group/snippets/group_item.html
@@ -1,10 +1,10 @@
 {% ckan_extends %}
 
 {% block title %}
-  <h3 class="media-heading">{{ group.display_name }}</h3>
+  <h3 class="media-heading">{{ h.get_translated(group,"title") }}</h3>
 {% endblock %}
 {% block description %}
-  {% if group.description %}
-    <p>{{ h.markdown_extract(group.description, extract_length=80) }}</p>
+  {% if h.get_translated(group,"description") %}
+    <p>{{ h.markdown_extract(h.get_translated(group,"description"), extract_length=80) }}</p>
   {% endif %}
 {% endblock %}

--- a/ckanext/ontario_theme/templates/internal/group/snippets/info.html
+++ b/ckanext/ontario_theme/templates/internal/group/snippets/info.html
@@ -2,16 +2,16 @@
 
 {% block heading %}
 <h1 class="heading">
-  {{ group.display_name }}
+  {{ h.get_translated(group, "title") }}
   {% if group.state == 'deleted' %}
     [{{ _('Deleted') }}]
   {% endif %}
 </h1>
 {% endblock %}
 {% block description %}
-{% if group.description %}
+{% if h.get_translated(group, "description") %}
   <p>
-    {{ h.markdown_extract(group.description, 180) }}
+    {{ h.markdown_extract(h.get_translated(group, "description"), 180) }}
     {% link_for _('read more'), controller='group', action='about', id=group.name %}
   </p>
 {% endif %}

--- a/ckanext/ontario_theme/templates/internal/group/snippets/info.html
+++ b/ckanext/ontario_theme/templates/internal/group/snippets/info.html
@@ -1,5 +1,22 @@
 {% ckan_extends %}
 
+{% block heading %}
+<h1 class="heading">
+  {{ group.display_name }}
+  {% if group.state == 'deleted' %}
+    [{{ _('Deleted') }}]
+  {% endif %}
+</h1>
+{% endblock %}
+{% block description %}
+{% if group.description %}
+  <p>
+    {{ h.markdown_extract(group.description, 180) }}
+    {% link_for _('read more'), controller='group', action='about', id=group.name %}
+  </p>
+{% endif %}
+{% endblock %}
+
 {% block nums %}
   <div class="nums">
     <dl>

--- a/ckanext/ontario_theme/templates/internal/package/group_list.html
+++ b/ckanext/ontario_theme/templates/internal/package/group_list.html
@@ -1,0 +1,26 @@
+{% extends "package/read_base.html" %}
+{% import 'macros/form.html' as form %}
+
+{% block primary_content_inner %}
+  <h2 class="hide-heading">{{ _('Groups') }}</h2>
+
+  {% if c.group_dropdown %}
+    <form class="add-to-group" method="post">
+      <select id="field-add_group" name="group_added" data-module="autocomplete">
+        {% for option in c.group_dropdown %}
+          <option value="{{ option[0] }}"> {{ option[1] }}</option>
+        {% endfor %}
+      </select>
+      <button type="submit" class="btn btn-primary" title="{{ _('Associate this group with this dataset') }}">{{ _('Add to group') }}</button>
+    </form>
+  {% endif %}
+  {% if c.pkg_dict.groups %}
+    <form method="post">
+      {% snippet 'group/snippets/group_list.html', groups=c.pkg_dict.groups %}
+    </form>
+  {% else %}
+    <p class="empty">{{ _('There are no groups associated with this dataset') }}</p>
+  {% endif %}
+
+{% endblock %}
+

--- a/ckanext/ontario_theme/templates/internal/package/group_list.html
+++ b/ckanext/ontario_theme/templates/internal/package/group_list.html
@@ -8,19 +8,23 @@
     <form class="add-to-group" method="post">
       <select id="field-add_group" name="group_added" data-module="autocomplete">
         {% for option in c.group_dropdown %}
-          <option value="{{ option[0] }}"> {{ option[1] }}</option>
+          {% set group_dict = h.ontario_theme_get_group(option[0]) %}
+          <option value="{{ option[0] }}"> {{ h.get_translated(group_dict,"title") }}</option>
         {% endfor %}
       </select>
       <button type="submit" class="btn btn-primary" title="{{ _('Associate this group with this dataset') }}">{{ _('Add to group') }}</button>
     </form>
   {% endif %}
   {% if c.pkg_dict.groups %}
+    {% set group_dicts = [] %}
+    {% for group in c.pkg_dict.groups %}
+      {% do group_dicts.append(h.ontario_theme_get_group(group['name'])) %}
+    {% endfor %}
     <form method="post">
-      {% snippet 'group/snippets/group_list.html', groups=c.pkg_dict.groups %}
+      {% snippet 'group/snippets/group_list.html', groups=group_dicts %}
     </form>
   {% else %}
     <p class="empty">{{ _('There are no groups associated with this dataset') }}</p>
   {% endif %}
 
 {% endblock %}
-

--- a/ckanext/ontario_theme/templates/internal/scheming/form_snippets/ontario_theme_organization_upload.html
+++ b/ckanext/ontario_theme/templates/internal/scheming/form_snippets/ontario_theme_organization_upload.html
@@ -2,7 +2,7 @@
 
 {% set is_upload = data.image_url and not data.image_url.startswith('http') %}
 {% set is_url = data.image_url and data.image_url.startswith('http') %}
-
+<div class="form-group col-md-12 control-full">
 {{ form.image_upload(
     data,
     errors,
@@ -14,3 +14,4 @@
 
 {# image_upload macro doesn't support call #}
 {%- snippet 'scheming/form_snippets/help_text.html', field=field -%}
+</div>

--- a/ckanext/ontario_theme/templates/internal/scheming/group/about.html
+++ b/ckanext/ontario_theme/templates/internal/scheming/group/about.html
@@ -1,0 +1,10 @@
+{% ckan_extends %}
+
+{% block primary_content_inner %}
+<dl>
+{% for f in c.scheming_fields %}
+<dt>{{ h.scheming_language_text(f.label) }}:</dt>
+<dd>{{ group_dict[f.field_name] or ("&nbsp;"|safe) }}</dd>
+{% endfor %}
+</dl>
+{% endblock %}

--- a/ckanext/ontario_theme/templates/internal/scheming/group/about.html
+++ b/ckanext/ontario_theme/templates/internal/scheming/group/about.html
@@ -1,10 +1,26 @@
 {% ckan_extends %}
 
+{%- set exclude_fields = [
+    'title',
+    'name',
+    'image_url',
+    'description_translated',
+    'title_translated'
+    ] -%}
+
 {% block primary_content_inner %}
+  <h1>{% block page_heading %}{{  h.get_translated(c.group_dict, "title") }}{% endblock %}</h1>
+  {% block organization_description %}
+    {% if h.get_translated(c.group_dict, "description") %}
+      {{ h.render_markdown(h.get_translated(c.group_dict, "description")) }}
+    {% endif %}
+  {% endblock %}
 <dl>
 {% for f in c.scheming_fields %}
-<dt>{{ h.scheming_language_text(f.label) }}:</dt>
-<dd>{{ group_dict[f.field_name] or ("&nbsp;"|safe) }}</dd>
+  {% if f.field_name not in exclude_fields %}
+	<dt>{{ h.scheming_language_text(f.label) }}:</dt>
+	<dd>{{ c.group_dict[f.field_name] or ("&nbsp;"|safe) }}</dd>
+  {% endif %}
 {% endfor %}
 </dl>
 {% endblock %}

--- a/ckanext/ontario_theme/templates/internal/scheming/group/group_form.html
+++ b/ckanext/ontario_theme/templates/internal/scheming/group/group_form.html
@@ -1,0 +1,33 @@
+{% if group_type is not defined %}
+    {% set group_type = c.group_type %}
+{% endif %}
+
+{%- if not group_type -%}
+    <p>
+        group_type not passed to template. your version of CKAN
+        might not be compatible with ckanext-scheming
+    </p>
+{%- endif -%}
+
+<form class="dataset-form form-horizontal" method="post" data-module="basic-form" enctype="multipart/form-data">
+    {%- set schema = h.scheming_get_group_schema(group_type) -%}
+    {%- for field in schema['fields'] -%}
+        {%- if field.form_snippet is not none -%}
+          {%- snippet 'scheming/snippets/form_field.html',
+          field=field, data=data, errors=errors, licenses=licenses,
+          entity_type='group', object_type=group_type -%}
+        {%- endif -%}
+    {%- endfor -%}
+
+    <div class="form-actions">
+        {% block delete_button %}
+        {% if action == 'edit' %}
+          {% if h.check_access('group_delete', {'id': data.id}) and action=='edit'  %}
+            {% set locale = h.dump_json({'content': _('Are you sure you want to delete this Group?')}) %}
+            <a class="btn btn-danger pull-left" href="{% url_for controller='group', action='delete', id=data.id %}" data-module="confirm-action" data-module-i18n="{{ locale }}">{% block delete_button_text %}{{ _('Delete') }}{% endblock %}</a>
+          {% endif %}
+        {% endif %}
+        {% endblock %}
+        <button class="btn btn-primary" name="save" type="submit">{% block save_text %}{{ _('Save Group') }}{% endblock %}</button>
+    </div>
+</form>

--- a/ckanext/ontario_theme/templates/internal/scheming/group/group_form.html
+++ b/ckanext/ontario_theme/templates/internal/scheming/group/group_form.html
@@ -1,29 +1,25 @@
-{% if group_type is not defined %}
-    {% set group_type = c.group_type %}
-{% endif %}
-
-{%- if not group_type -%}
+{%- if not c.group_type -%}
     <p>
         group_type not passed to template. your version of CKAN
         might not be compatible with ckanext-scheming
     </p>
 {%- endif -%}
 
-<form class="dataset-form form-horizontal" method="post" data-module="basic-form" enctype="multipart/form-data">
-    {%- set schema = h.scheming_get_group_schema(group_type) -%}
+<form class="dataset-form" method="post" data-module="basic-form" enctype="multipart/form-data">
+    {%- set schema = h.scheming_get_group_schema(c.group_type) -%}
     {%- for field in schema['fields'] -%}
-        {%- if field.form_snippet is not none -%}
-          {%- snippet 'scheming/snippets/form_field.html',
-          field=field, data=data, errors=errors, licenses=licenses,
-          entity_type='group', object_type=group_type -%}
-        {%- endif -%}
+        <div class="controls row">
+        {%- snippet 'scheming/snippets/form_field.html',
+        field=field, data=data, errors=errors, licenses=licenses,
+        entity_type='group', object_type=c.group_type -%}
+        </div>
     {%- endfor -%}
 
     <div class="form-actions">
         {% block delete_button %}
         {% if action == 'edit' %}
           {% if h.check_access('group_delete', {'id': data.id}) and action=='edit'  %}
-            {% set locale = h.dump_json({'content': _('Are you sure you want to delete this Group?')}) %}
+            {% set locale = h.dump_json({'content': _('Are you sure you want to delete this Collection?')}) %}
             <a class="btn btn-danger pull-left" href="{% url_for controller='group', action='delete', id=data.id %}" data-module="confirm-action" data-module-i18n="{{ locale }}">{% block delete_button_text %}{{ _('Delete') }}{% endblock %}</a>
           {% endif %}
         {% endif %}

--- a/ckanext/ontario_theme/templates/internal/snippets/group.html
+++ b/ckanext/ontario_theme/templates/internal/snippets/group.html
@@ -1,0 +1,27 @@
+{#
+Embeds a group within the sidebar of a page.
+
+group    - The group dict.
+truncate - A max length for the group description. If not provided the description
+           will be full length.
+
+Example:
+
+    {% snippet 'snippets/group, group=c.group_dict %}
+
+#}
+{% with truncate=truncate or 0, url=h.url_for(controller='group', action='read', id=group.name) %}
+  <section class="module module-narrow module-shallow group">
+    <div class="module-content media media-vertical">
+      <a class="media-image" href="{{ url }}">
+        <img src="{{ group.image_display_url or h.url_for_static('/base/images/placeholder-group.png') }}" class="img-responsive" width="200" height="125" alt="{{ group.name }}" />
+      </a>
+      <div class="media-content">
+        <h3 class="media-heading"><a href={{ url }}>{{ group.title or group.name }}</a></h3>
+        {% if group.description %}
+          <p>{{ h.markdown_extract(group.description, truncate) }}</p>
+        {% endif %}
+      </div>
+    </div>
+  </section>
+{% endwith %}

--- a/ckanext/ontario_theme/templates/internal/snippets/group.html
+++ b/ckanext/ontario_theme/templates/internal/snippets/group.html
@@ -17,9 +17,9 @@ Example:
         <img src="{{ group.image_display_url or h.url_for_static('/base/images/placeholder-group.png') }}" class="img-responsive" width="200" height="125" alt="{{ group.name }}" />
       </a>
       <div class="media-content">
-        <h3 class="media-heading"><a href={{ url }}>{{ group.title or group.name }}</a></h3>
-        {% if group.description %}
-          <p>{{ h.markdown_extract(group.description, truncate) }}</p>
+        <h3 class="media-heading"><a href={{ url }}>{{ h.get_translated(group, "title") or group.name }}</a></h3>
+        {% if h.get_translated(group, "description") %}
+          <p>{{ h.markdown_extract(h.get_translated(group, "description"), truncate) }}</p>
         {% endif %}
       </div>
     </div>


### PR DESCRIPTION
This PR consists of 6 commits to implement fluent groups, including:
- groups schema
- addition of a get_group helper (to account for areas where group extras aren't passed into the template)
- layout fixes to the group form
- changes to group templates to handle bilingual values