### PR TITLE
Fix organization display name

### DIFF
--- a/ckanext/ontario_theme/templates/internal/scheming/form_snippets/organization.html
+++ b/ckanext/ontario_theme/templates/internal/scheming/form_snippets/organization.html
@@ -7,7 +7,7 @@
   {% block organization_option scoped %}
     <option value="{{ organization.id }}"{%
       if selected_org %} selected="selected"{% endif
-      %}>{{ organization.display_name }}</option>
+      %}>{{ h.get_translated( h.get_organization(organization.name), "title") or organization.display_name }}</option>
   {% endblock %}
 {% endmacro %}
 

--- a/ckanext/ontario_theme/templates/internal/snippets/facet_list.html
+++ b/ckanext/ontario_theme/templates/internal/snippets/facet_list.html
@@ -33,6 +33,7 @@
           {% set scheming_choices = h.scheming_field_by_name(fields, name).choices or None%}
           {% do item.update({'display_name': h.scheming_choices_label(scheming_choices, item.display_name)}) if scheming_choices %}
           {% do item.update({'display_name': h.get_translated( h.ontario_theme_get_license(item.name), "title" )}) if name == "license_id" %}
+          {% do item.update({'display_name': h.get_translated( h.get_organization(item.name), "title") or item.display_name}) if name == "organization" %}
           {% set href = h.remove_url_param(name, item.name, extras=extras, alternative_url=alternative_url) if item.active else h.add_url_param(new_params={name: item.name}, extras=extras, alternative_url=alternative_url) %}
           {% set label = label_function(item) if label_function else item.display_name %}
           {% set label_truncated = h.truncate(label, 22) if not label_function else label %}


### PR DESCRIPTION
This PR consists of 2 commits to fix cases where display_name is still being used to display an organization's name (instead of get_translated).