### PR TITLE
Bug: Uncomment setting choices.

### DIFF
--- a/ckanext/ontario_theme/templates/internal/snippets/facet_list.html
+++ b/ckanext/ontario_theme/templates/internal/snippets/facet_list.html
@@ -32,7 +32,7 @@
     <nav>
       <ul class="{{ nav_class or 'list-unstyled nav nav-simple nav-facet' }}">
         {% for item in items %}
-          {# set scheming_choices = scheming_choices or h.scheming_field_by_name(fields, name).choices or None #}
+          {% set scheming_choices = scheming_choices or h.scheming_field_by_name(fields, name).choices or None %}
           {% do item.update({'display_name': h.scheming_choices_label(scheming_choices, item.display_name)}) if scheming_choices %}
           {% do item.update({'display_name': h.get_translated( h.ontario_theme_get_license(item.name), "title" )}) if name == "license_id" %}
           {% do item.update({'display_name': h.get_translated( h.get_organization(item.name), "title") or item.display_name}) if name == "organization" %}


### PR DESCRIPTION
Ensure choices are set so that the proper display name
is set and displayed for the user. This was commented in PR #162
accidentally.