### PR TITLE
Add parameters to ontario.ca survey url

### DIFF
--- a/ckanext/ontario_theme/i18n/fr/LC_MESSAGES/ckanext-ontario_theme.po
+++ b/ckanext/ontario_theme/i18n/fr/LC_MESSAGES/ckanext-ontario_theme.po
@@ -82,9 +82,17 @@ msgstr "Aider"
 msgid "Data Catalogue"
 msgstr "Catalogue de données"
 
-#: ckanext/ontario_theme/templates/header.html:116
-msgid "Tell us what you think about our data and how you’re using it. <a href=\"https://www.ontario.ca/form/survey-open-data-catalogue\" target=\"_blank\">Take our survey</a>"
-msgstr "Faites-nous part de vos commentaires au sujet de nos données, et dites-nous de quelle façon vous les utilisez. <a href=\"https://www.ontario.ca/fr/forme/enquete-catalogue-de-donnees-de-lontario\" target=\"_blank\">Veuillez répondre à notre sondage</a>"
+#: ckanext/ontario_theme/templates/header.html:20
+msgid "Tell us what you think about our data and how you’re using it."
+msgstr "Faites-nous part de vos commentaires au sujet de nos données, et dites-nous de quelle façon vous les utilisez."
+
+#: ckanext/ontario_theme/templates/header.html:20
+msgid "https://www.ontario.ca/form/survey-open-data-catalogue"
+msgstr "https://www.ontario.ca/fr/forme/enquete-catalogue-de-donnees-de-lontario"
+
+#: ckanext/ontario_theme/templates/header.html:20
+msgid "Take our survey"
+msgstr "Veuillez répondre à notre sondage"
 
 #: ckanext/ontario_theme/templates/home/help.html:14
 msgid ""

--- a/ckanext/ontario_theme/plugin.py
+++ b/ckanext/ontario_theme/plugin.py
@@ -282,6 +282,16 @@ def get_license(license_id):
     '''
     return Package.get_license_register().get(license_id)
 
+def extract_package_name(url):
+    import re
+    package_pattern = "\/dataset\/([-a-z-0-9A-Z\n\r]*)"
+    find_package = re.compile(package_pattern)
+    get_package_name = find_package.findall(url)
+    if len(get_package_name) > 0:
+        return get_package_name[0]
+    else:
+        return False
+
 def get_translated_lang(data_dict, field, specified_language):
     try:
         return data_dict[field + u'_translated'][specified_language]
@@ -415,6 +425,7 @@ type data_last_updated
 
     def get_helpers(self):
         return {'ontario_theme_get_license': get_license,
+                'ontario_theme_extract_package_name': extract_package_name,
                 'ontario_theme_get_translated_lang': get_translated_lang,
                 'ontario_theme_get_popular_datasets': get_popular_datasets,
                 'ontario_theme_get_group': get_group,

--- a/ckanext/ontario_theme/templates/external/header.html
+++ b/ckanext/ontario_theme/templates/external/header.html
@@ -16,7 +16,10 @@
   <header id="survey">
     <div class="alert alert-warning alert-clear alert-banner">
       <div class="container">
-        {% trans %}Tell us what you think about our data and how you’re using it. <a href="https://www.ontario.ca/form/survey-open-data-catalogue" target="_blank">Take our survey</a>{% endtrans %}
+        {% set survey_params = { "page": h.current_url() }  %}
+        {% set package_name = h.ontario_theme_extract_package_name(h.current_url()) %}
+        {% do survey_params.update({'id': package_name}) if package_name %}
+        {% trans %}Tell us what you think about our data and how you’re using it.{% endtrans %} <a href="{{ _('https://www.ontario.ca/form/survey-open-data-catalogue') }}?{{ survey_params|urlencode }}" target="_blank">{% trans %}Take our survey{% endtrans %}</a>
       </div>
     </div>
 </header>


### PR DESCRIPTION
The ontario.ca survey accepts "id" and "page" parameters that are included in survey results. This PR includes those parameters in the survey url.