### PR TITLE
Task: Display "no supporting files" when no support files are available

### DIFF
--- a/ckanext/ontario_theme/i18n/fr/LC_MESSAGES/ckanext-ontario_theme.po
+++ b/ckanext/ontario_theme/i18n/fr/LC_MESSAGES/ckanext-ontario_theme.po
@@ -2760,6 +2760,10 @@ msgstr "Pour la période de"
 msgid "Supporting Files"
 msgstr "Autres fichiers"
 
+#: ckanext/ontario_theme/templates/package/snippets/resources_list.html:55
+msgid "This dataset has no supporting files"
+msgstr "Ce jeu de données n'a pas de autres fichiers"
+
 #: ckanext/ontario_theme/templates/scheming/package/read.html:20
 #: ckanext/ontario_theme/templates/scheming/organization/about.html:28
 msgid "For more information"

--- a/ckanext/ontario_theme/templates/internal/package/snippets/resources_list.html
+++ b/ckanext/ontario_theme/templates/internal/package/snippets/resources_list.html
@@ -44,12 +44,16 @@
           {% endfor %}
         {% endblock %}
       <h3>{{ _("Supporting Files") }}</h3>
-      <ul class="resource-list">
-          {% set can_edit = h.check_access('package_update', {'id':pkg.id }) %}
-          {% for resource in resources|rejectattr("type","equalto","data") %}
-            {% snippet 'package/snippets/resource_item.html', pkg=pkg, res=resource, can_edit=can_edit, schema=schema %}
-          {% endfor %}
-      </ul>
+      {% if resources | rejectattr("type","equalto","data") | list | length > 0 %}
+        <ul class="resource-list">
+            {% set can_edit = h.check_access('package_update', {'id':pkg.id }) %}
+            {% for resource in resources|rejectattr("type","equalto","data") %}
+              {% snippet 'package/snippets/resource_item.html', pkg=pkg, res=resource, can_edit=can_edit, schema=schema %}
+            {% endfor %}
+        </ul>
+      {% else %}
+        <p class="empty">{{ _('This dataset has no supporting files') }}</p>
+      {% endif %}
     {% else %}
       {% if h.check_access('resource_create', {'package_id': pkg['id']}) %}
         {% trans url=h.url_for(controller='package', action='new_resource', id=pkg.name) %}


### PR DESCRIPTION
- added logic to display "This dataset has no supporting files" when number of non-data resources is 0