### PR TITLE
Task: Change default text for resources to 'Data' when it's left blank

### DIFF
--- a/ckanext/ontario_theme/plugin.py
+++ b/ckanext/ontario_theme/plugin.py
@@ -14,6 +14,7 @@ from flask import render_template, render_template_string
 import ckanapi_exporter.exporter as exporter
 import json
 import ckan.lib.helpers as helpers
+from ckan.lib.helpers import core_helper
 
 from ckan.model import Package
 
@@ -64,6 +65,24 @@ def default_tags_schema(
     }
 
 ckan.logic.schema.default_tags_schema = default_tags_schema
+
+@core_helper
+def resource_display_name(resource_dict):
+    # TODO: (?) support resource objects as well
+    name = helpers.get_translated(resource_dict, 'name')
+    description = helpers.get_translated(resource_dict, 'description')
+    if name:
+        return name
+    elif description:
+        description = description.split('.')[0]
+        max_len = 60
+        if len(description) > max_len:
+            description = description[:max_len] + '...'
+        return description
+    else:
+        return helpers._("Data")
+
+ckan.lib.helpers.resource_display_name = resource_display_name
 
 def help():
     '''New help page for site.

--- a/ckanext/ontario_theme/schemas/external/ontario_theme_dataset.json
+++ b/ckanext/ontario_theme/schemas/external/ontario_theme_dataset.json
@@ -652,7 +652,7 @@
       "form_placeholder": "e.g., January 2011 Gold Prices",
       "help_inline" : true,
       "help_text": {
-        "en": "Create a human-readable title that will help users understand what the file contains."
+        "en": "Create a human-readable title that will help users understand what the file contains. Leaving the field blank will default the resource name to 'Data'. Add a name if the data describes something different than other files in the same dataset (e.g., 'Stone fruit crops' vs 'Non-stone fruit crops'). Leave blank if information about the data is captured by other fields in this form."
       },
       "fieldset": 2,
       "fieldset_name": "Describe the file",

--- a/ckanext/ontario_theme/schemas/internal/ontario_theme_dataset.json
+++ b/ckanext/ontario_theme/schemas/internal/ontario_theme_dataset.json
@@ -710,7 +710,7 @@
       "form_placeholder": "e.g., January 2011 Gold Prices",
       "help_inline" : true,
       "help_text": {
-        "en": "Create a human-readable title that will help users understand what the file contains."
+        "en": "Create a human-readable title that will help users understand what the file contains. Leaving the field blank will default the resource name to 'Data'. Add a name if the data describes something different than other files in the same dataset (e.g., 'Stone fruit crops' vs 'Non-stone fruit crops'). Leave blank if information about the data is captured by other fields in this form."
       },
       "fieldset": 2,
       "fieldset_name": "Describe the file",


### PR DESCRIPTION
- changed all instances of 'unnamed resource' to show 'data'
- modified help text to provide better guidance on naming convention for resource editors