### PR TITLE
Resource attribute adjustments

### DIFF
--- a/ckanext/ontario_theme/schemas/external/ontario_theme_dataset.json
+++ b/ckanext/ontario_theme/schemas/external/ontario_theme_dataset.json
@@ -804,7 +804,7 @@
     {
       "field_name": "data_last_updated",
       "label": {
-        "en": "Data Last Updated",
+        "en": "Data last updated",
         "fr": "Dernière mise à jour des données"
       },
       "help_inline" : true,

--- a/ckanext/ontario_theme/templates/internal/scheming/package/resource_read.html
+++ b/ckanext/ontario_theme/templates/internal/scheming/package/resource_read.html
@@ -5,6 +5,7 @@
 {% extends "package/resource_read.html" %}
 
 {%- set exclude_fields = [
+    'data_last_updated',
     'name',
     'description_translated',
     'url',
@@ -45,7 +46,7 @@
         {%- block resource_last_updated -%}
           <tr>
             <th scope="row">{{ _('Last updated') }}</th>
-            <td>{{ h.render_datetime(res.last_modified) or h.render_datetime(res.revision_timestamp) or h.render_datetime(res.created) or _('unknown') }}</td>
+            <td>{{ h.render_datetime(res.data_last_updated) or h.render_datetime(res.last_modified) or h.render_datetime(res.revision_timestamp) or h.render_datetime(res.created) or _('unknown') }}</td>
           </tr>
         {%- endblock -%}
         {%- block resource_created -%}


### PR DESCRIPTION
This PR includes:
- changing the label for data_last_updated to match the case of other resource field labels
- remove data_last_updated from the list of fields to be displayed in the "additional info" section of the resource page
- change "Last updated" display to show data_last_updated if it's available (if not, show last_modified or created)