### PR TITLE
Ontario Data Catalogue Harvester

### DIFF
--- a/ckanext/ontario_theme/fanstatic/internal/general_styles.less
+++ b/ckanext/ontario_theme/fanstatic/internal/general_styles.less
@@ -488,3 +488,20 @@ section.additional-info table.table {
       border-right: none;
   }
 }
+
+/* =====================================================
+   Create styles for readonly textarea
+   ===================================================== */
+
+textarea[readonly] {
+  background: #eee;
+  border-color: #ccc;
+  color: #999;
+  &:focus {
+    outline: none;
+  }
+  &::placeholder {
+      opacity: 1;
+      color: #999;
+  }
+}

--- a/ckanext/ontario_theme/fanstatic/internal/ontario_theme.css
+++ b/ckanext/ontario_theme/fanstatic/internal/ontario_theme.css
@@ -1107,6 +1107,21 @@ section.additional-info table.table tbody tr td.dataset-details {
   }
 }
 /* =====================================================
+   Create styles for readonly textarea
+   ===================================================== */
+textarea[readonly] {
+  background: #eee;
+  border-color: #ccc;
+  color: #999;
+}
+textarea[readonly]:focus {
+  outline: none;
+}
+textarea[readonly]::placeholder {
+  opacity: 1;
+  color: #999;
+}
+/* =====================================================
    The "account masthead" bar across the top of the site
    ===================================================== */
 .account-masthead {

--- a/ckanext/ontario_theme/fanstatic/internal/ontario_theme_lock_if_odc.js
+++ b/ckanext/ontario_theme/fanstatic/internal/ontario_theme_lock_if_odc.js
@@ -1,0 +1,19 @@
+// Enable JavaScript's strict mode. Strict mode catches some common
+// programming errors and throws exceptions, prevents some unsafe actions from
+// being taken, and disables some confusing and bad JavaScript features.
+"use strict";
+
+ckan.module('lock_if_odc', function ($) {  
+  return {
+    initialize: function () {
+      var harvest_id = $(this.el).val()
+      if (!!harvest_id) {
+        if (harvest_id == "ontario-data-catalogue") {
+          $(".lock_if_odc textarea, .lock_if_odc input").prop("readonly","readonly")
+          $(".lock_if_odc select").attr("readonly","readonly")
+        }
+      }
+      return null
+    }
+  };
+});

--- a/ckanext/ontario_theme/harvesters/__init__.py
+++ b/ckanext/ontario_theme/harvesters/__init__.py
@@ -1,0 +1,1 @@
+from ckanext.ontario_theme.harvesters.ontario_data_catalogue import OntarioDataCatalogueHarvester

--- a/ckanext/ontario_theme/harvesters/ontario_data_catalogue.py
+++ b/ckanext/ontario_theme/harvesters/ontario_data_catalogue.py
@@ -1,0 +1,237 @@
+# -*- coding: utf-8 -*-
+
+import six
+
+from ckan import model
+from ckan.model import Session
+from ckanext.harvest.harvesters.ckanharvester import CKANHarvester
+
+from ckan import plugins as p
+from ckan.logic.schema import default_create_package_schema
+from ckan.lib.navl.validators import ignore_missing, ignore
+from sqlalchemy import exists
+from sqlalchemy.sql import update, bindparam
+
+import logging
+log = logging.getLogger(__name__)
+
+class OntarioDataCatalogueHarvester(CKANHarvester):
+
+    def info(self):
+        return {
+            'name': 'ontario_data_catalogue',
+            'title': 'Ontario Data Catalogue',
+            'description': 'Harvester for Ontario Data Catalogue' +
+                           'to pull into the internal data catalogue.'
+        }
+
+    def _create_or_update_package(self, package_dict, harvest_object,
+                                  package_dict_form='rest'):
+        '''
+        Creates a new package or updates an existing one according to the
+        package dictionary provided.
+        The package dictionary can be in one of two forms:
+        1. 'rest' - as seen on the RESTful API:
+                http://datahub.io/api/rest/dataset/1996_population_census_data_canada
+           This is the legacy form. It is the default to provide backward
+           compatibility.
+           * 'extras' is a dict e.g. {'theme': 'health', 'sub-theme': 'cancer'}
+           * 'tags' is a list of strings e.g. ['large-river', 'flood']
+        2. 'package_show' form, as provided by the Action API (CKAN v2.0+):
+               http://datahub.io/api/action/package_show?id=1996_population_census_data_canada
+           * 'extras' is a list of dicts
+                e.g. [{'key': 'theme', 'value': 'health'},
+                        {'key': 'sub-theme', 'value': 'cancer'}]
+           * 'tags' is a list of dicts
+                e.g. [{'name': 'large-river'}, {'name': 'flood'}]
+        Note that the package_dict must contain an id, which will be used to
+        check if the package needs to be created or updated (use the remote
+        dataset id).
+        If the remote server provides the modification date of the remote
+        package, add it to package_dict['metadata_modified'].
+        :returns: The same as what import_stage should return. i.e. True if the
+                  create or update occurred ok, 'unchanged' if it didn't need
+                  updating or False if there were errors.
+        TODO: Not sure it is worth keeping this function. If useful it should
+        use the output of package_show logic function (maybe keeping support
+        for rest api based dicts
+        '''
+        assert package_dict_form in ('rest', 'package_show')
+        try:
+            # Change default schema
+            schema = default_create_package_schema()
+            schema['id'] = [ignore_missing, six.text_type]
+            schema['__junk'] = [ignore]
+
+            # Check API version
+            if self.config:
+                try:
+                    api_version = int(self.config.get('api_version', 2))
+                except ValueError:
+                    raise ValueError('api_version must be an integer')
+            else:
+                api_version = 2
+
+            user_name = self._get_user_name()
+            context = {
+                'model': model,
+                'session': Session,
+                'user': user_name,
+                'api_version': api_version,
+                'schema': schema,
+                'ignore_auth': True,
+            }
+
+            if self.config and self.config.get('clean_tags', False):
+                tags = package_dict.get('tags', [])
+                package_dict['tags'] = self._clean_tags(tags)
+
+            # Check if package exists
+            try:
+                # _find_existing_package can be overridden if necessary
+                existing_package_dict = self._find_existing_package(package_dict)
+
+                # In case name has been modified when first importing. See issue #101.
+                package_dict['name'] = existing_package_dict['name']
+
+                # Check modified date
+                if 'metadata_modified' not in package_dict or \
+                   package_dict['metadata_modified'] > existing_package_dict.get('metadata_modified') or package_dict['name'] == "status-of-covid-19-cases-in-ontario-by-public-health-unit-phu" or package_dict['id'] == 'ecb75ea0-8b72-4f46-a14a-9bd54841d6ab':
+                    log.info('Package with GUID %s exists and needs to be updated' % harvest_object.guid)
+                    # Update package
+                    context.update({'id': package_dict['id']})
+                    package_dict.setdefault('name',
+                                            existing_package_dict['name'])
+
+                    '''
+                    	what we want to do here is
+                    		- not overwrite maintainer name or maintainer email or maintainer branch with blank information
+                    		- not include resources because it will overwrite the existing resources
+                            - match owner_org
+                    '''
+
+                    package_dict['owner_org'] = package_dict['organization']['name']
+                    
+                    if package_dict.get("maintainer_email", "") == "":
+                    	del package_dict['maintainer_email']
+                    if "maintainer_translated" in package_dict:
+                    	if package_dict['maintainer_translated'].get("en","") == "" and package_dict['maintainer_translated'].get("fr","") == "":
+                    		del package_dict['maintainer_translated']
+                        elif package_dict['maintainer_translated'].get("en","") != "" and package_dict['maintainer_translated'].get("fr","") == "":
+                            package_dict['maintainer_translated']['fr'] = package_dict['maintainer_translated']['en'] 
+                        elif package_dict['maintainer_translated'].get("en","") == "" and package_dict['maintainer_translated'].get("fr","") != "":
+                            package_dict['maintainer_translated']['en'] = package_dict['maintainer_translated']['fr'] 
+                    if "maintainer_branch" in package_dict:
+                    	if package_dict['maintainer_branch'].get("en","") == "" and package_dict['maintainer_branch'].get("fr","") == "":
+                    		del package_dict['maintainer_branch']
+
+                    if 'resources' in package_dict:
+                        for resource in package_dict['resources']:
+                            resource.update({"harvested_resource" : True})
+                            resource_context = {
+                                'model': model,
+                                'session': Session,
+                                'user': user_name,
+                                'api_version': api_version,
+                                'id' : resource['id'],
+                                'ignore_auth': True,
+                            }
+                            p.toolkit.get_action("resource_patch" if resource['id'] in list(map(lambda x: x["id"], existing_package_dict["resources"])) else "resource_create")(resource_context, resource)
+                        list_of_remote_resources = list(map(lambda x: x["id"],package_dict["resources"]))
+                        for resource in list(filter(lambda x: x["harvested_resource"] == True, existing_package_dict["resources"])):
+                            # if there's a harvested resource locally that isn't in the latest harvested list of resources, delete it
+                            if resource['id'] not in list_of_remote_resources:
+                                resource_context = {
+                                    'model': model,
+                                    'session': Session,
+                                    'user': user_name,
+                                    'api_version': api_version,
+                                    'id' : resource['id'],
+                                    'ignore_auth': True,
+                                }
+                                p.toolkit.get_action("resource_delete")(resource_context, { 'id' : resource['id']})
+
+                        del package_dict['resources']
+                    new_package = p.toolkit.get_action("package_patch")(context, package_dict)
+
+                else:
+                    log.info('No changes to package with GUID %s, skipping...' % harvest_object.guid)
+                    # NB harvest_object.current/package_id are not set
+                    return 'unchanged'
+
+                # Flag the other objects linking to this package as not current anymore
+                from ckanext.harvest.model import harvest_object_table
+                conn = Session.connection()
+                u = update(harvest_object_table)\
+                    .where(harvest_object_table.c.package_id == bindparam('b_package_id')) \
+                    .values(current=False)
+                conn.execute(u, b_package_id=new_package['id'])
+
+                # Flag this as the current harvest object
+
+                harvest_object.package_id = new_package['id']
+                harvest_object.current = True
+                harvest_object.save()
+
+            except p.toolkit.ObjectNotFound:
+                # Package needs to be created
+
+                # Get rid of auth audit on the context otherwise we'll get an
+                # exception
+                context.pop('__auth_audit', None)
+
+                # Set name for new package to prevent name conflict, see issue #117
+                if package_dict.get('name', None):
+                    package_dict['name'] = self._gen_new_name(package_dict['name'])
+                else:
+                    package_dict['name'] = self._gen_new_name(package_dict['title'])
+
+                log.info('Package with GUID %s does not exist, let\'s create it' % harvest_object.guid)
+                harvest_object.current = True
+                harvest_object.package_id = package_dict['id']
+                # Defer constraints and flush so the dataset can be indexed with
+                # the harvest object id (on the after_show hook from the harvester
+                # plugin)
+                harvest_object.add()
+
+                model.Session.execute('SET CONSTRAINTS harvest_object_package_id_fkey DEFERRED')
+                model.Session.flush()
+
+                package_dict['owner_org'] = package_dict['organization']['name']
+                for resource in package_dict['resources']:
+                    resource.update({"harvested_resource" : True})
+
+                if package_dict.get("maintainer_email", "") == "":
+                    package_dict['maintainer_email'] = "opendata@ontario.ca"
+                if "maintainer_translated" in package_dict:
+                    if package_dict['maintainer_translated'].get("en","") == "" and package_dict['maintainer_translated'].get("fr","") == "":
+                        package_dict['maintainer_translated'] = {
+                            "en" : "Open Data",
+                            "fr" : "Données ouvertes"
+                        }
+                    elif package_dict['maintainer_translated'].get("en","") != "" and package_dict['maintainer_translated'].get("fr","") == "":
+                        package_dict['maintainer_translated']['fr'] = package_dict['maintainer_translated']['en'] 
+                    elif package_dict['maintainer_translated'].get("en","") == "" and package_dict['maintainer_translated'].get("fr","") != "":
+                        package_dict['maintainer_translated']['en'] = package_dict['maintainer_translated']['fr'] 
+                else: 
+                    package_dict['maintainer_translated'] = {
+                        "en" : "Open Data",
+                        "fr" : "Données ouvertes"
+                    }
+                new_package = p.toolkit.get_action(
+                    'package_create' if package_dict_form == 'package_show'
+                    else 'package_create_rest')(context, package_dict)
+
+            Session.commit()
+
+            return True
+
+        except p.toolkit.ValidationError as e:
+            log.exception(e)
+            self._save_object_error('Invalid package with GUID %s: %r' % (harvest_object.guid, e.error_dict),
+                                    harvest_object, 'Import')
+        except Exception as e:
+            log.exception(e)
+            self._save_object_error('%r' % e, harvest_object, 'Import')
+
+        return None

--- a/ckanext/ontario_theme/harvesters/ontario_data_catalogue.py
+++ b/ckanext/ontario_theme/harvesters/ontario_data_catalogue.py
@@ -111,7 +111,7 @@ class OntarioDataCatalogueHarvester(CKANHarvester):
                     '''
 
                     package_dict['owner_org'] = package_dict['organization']['name']
-                    
+                    package_dict['harvester'] = "ontario-data-catalogue"
                     if package_dict.get("maintainer_email", "") == "":
                     	del package_dict['maintainer_email']
                     if "maintainer_translated" in package_dict:
@@ -198,6 +198,7 @@ class OntarioDataCatalogueHarvester(CKANHarvester):
                 model.Session.flush()
 
                 package_dict['owner_org'] = package_dict['organization']['name']
+                package_dict['harvester'] = "ontario-data-catalogue"
                 for resource in package_dict['resources']:
                     resource.update({"harvested_resource" : True})
 

--- a/ckanext/ontario_theme/harvesters/ontario_data_catalogue.py
+++ b/ckanext/ontario_theme/harvesters/ontario_data_catalogue.py
@@ -136,8 +136,13 @@ class OntarioDataCatalogueHarvester(CKANHarvester):
                     		- not overwrite maintainer name or maintainer email or maintainer branch with blank information
                     		- not include resources because it will overwrite the existing resources
                             - match owner_org
+                            - not overwrite all keywords (just add)
                     '''
 
+                    package_dict['keywords'] = {
+                        "en" : list(set(existing_package_dict['keywords']['en'] + package_dict['keywords']['en'])),
+                        "fr" : list(set(existing_package_dict['keywords']['fr'] + package_dict['keywords']['fr']))
+                    }
                     package_dict['owner_org'] = package_dict['organization']['name']
                     package_dict['harvester'] = "ontario-data-catalogue"
                     if package_dict.get("maintainer_email", "") == "":

--- a/ckanext/ontario_theme/plugin.py
+++ b/ckanext/ontario_theme/plugin.py
@@ -300,6 +300,15 @@ def get_translated_lang(data_dict, field, specified_language):
         return helpers.get_translated(data_dict, field)
 
 
+def resource_update_auth(context, data_dict=None):
+    isHarvestedResource = False
+    if data_dict: 
+        isHarvestedResource = data_dict.get('harvested_resource', False)
+    if isHarvestedResource:
+        return {'success': False, 'msg': 'This user is not allowed to edit this resource'}
+    return {'success': True, 'msg': 'This package is editable.'}
+
+
 def get_package_keywords(language='en'):
     '''Helper to return a list of the top 3 keywords based on specified
     language.
@@ -387,6 +396,7 @@ ckanext.ontario_theme:schemas/ontario_theme_organization.json
 ckanext.ontario_theme:schemas/ontario_theme_group.json
 """
 
+
 class OntarioThemePlugin(plugins.SingletonPlugin, DefaultTranslation):
     plugins.implements(plugins.ITranslation)
     plugins.implements(plugins.IConfigurer)
@@ -396,6 +406,7 @@ class OntarioThemePlugin(plugins.SingletonPlugin, DefaultTranslation):
     plugins.implements(plugins.IFacets)
     plugins.implements(plugins.IPackageController)
     plugins.implements(plugins.IValidators)
+    plugins.implements(plugins.IAuthFunctions)
 
     # IConfigurer
 
@@ -422,6 +433,14 @@ true
         config_['ckan.extra_resource_fields'] = """
 type data_last_updated
 """
+
+    # IAuthFunctions
+
+    def get_auth_functions(self):
+        return {
+            'resource_update': resource_update_auth
+            } 
+
     # ITemplateHelpers
 
     def get_helpers(self):

--- a/ckanext/ontario_theme/plugin.py
+++ b/ckanext/ontario_theme/plugin.py
@@ -555,6 +555,7 @@ type data_last_updated
 
     def get_validators(self):
        return {
+            'lock_if_odc': validators.lock_if_odc,
             'ontario_theme_copy_fluent_keywords_to_tags': validators.ontario_theme_copy_fluent_keywords_to_tags,
             'ontario_tag_name_validator': validators.tag_name_validator
        }

--- a/ckanext/ontario_theme/schemas/internal/ontario_theme_dataset.json
+++ b/ckanext/ontario_theme/schemas/internal/ontario_theme_dataset.json
@@ -15,8 +15,9 @@
       "help_text": {
         "en": "Add a simple, descriptive, short (100 characters or less) title that everyone will understand (you can include the \"technical title\" for subject matter experts in your description). If there is no French title, please use an online translation tool to make one."
       },
-      "classes": ["form-group","col-md-12"],
+      "classes": ["form-group","col-md-12", "lock_if_odc"],
       "preset": "fluent_core_translated",
+      "validators": "fluent_text lock_if_odc",
       "form_placeholder": "e.g., A descriptive title",
       "required": "true",
       "fieldset": 1,
@@ -40,8 +41,9 @@
       "help_text": {
         "en": "Add a general, plain language description that everyone within the OPS can understand and provides context for these resources. Feel free to link to other pages (e.g., links to your program area, ministry, similar resources). If there is no French description, please include the English description in the French field."
       },
-      "classes": ["form-group","col-md-12"],
+      "classes": ["form-group","col-md-12", "lock_if_odc"],
       "preset": "fluent_core_translated",
+      "validators": "fluent_text lock_if_odc",
       "form_snippet": "fluent_markdown.html",
       "form_placeholder": "e.g., Some useful notes about the data"
     },
@@ -71,9 +73,9 @@
       "help_text": {
         "en": "What type of asset are you disclosing?"
       }, 
-      "classes": ["form-group","col-md-12"],
+      "classes": ["form-group","col-md-12", "lock_if_odc"],
       "preset": "select",
-      "validators": "default(dataset) scheming_choices scheming_required",
+      "validators": "default(dataset) scheming_choices scheming_required lock_if_odc",
       "choices": [
         {
           "value": "dataset",
@@ -106,10 +108,10 @@
       },
       "tag_validators": "tag_length_validator ontario_tag_name_validator",
       "preset": "fluent_tags",
-      "validators": "fluent_tags ontario_theme_copy_fluent_keywords_to_tags",
+      "validators": "fluent_tags ontario_theme_copy_fluent_keywords_to_tags lock_if_odc",
       "output_validators": "fluent_tags_output",
       "form_placeholder": "e.g., housing, GDP per capita, greenhouse gas mitigation",
-      "classes": ["form-group","col-md-6"],
+      "classes": ["form-group","col-md-6", "lock_if_odc"],
       "form_attrs": {
         "data-module": "autocomplete",
         "data-module-tags": "e.g., housing, GDP per capita",
@@ -126,8 +128,9 @@
       "help_text": {
         "en": "What geographic area does this resource describe/cover?"
       },
-      "classes": ["col-md-12","form-group"],      
+      "classes": ["col-md-12","form-group", "lock_if_odc"],      
       "preset": "fluent_text",
+      "validators" : "fluent_text lock_if_odc",
       "form_placeholder": "e.g., Ontario"
     },
     {
@@ -141,8 +144,8 @@
         "en": "Does this resource have data that breaks down by smaller geographies (e.g., municipalities, census sub-division, cities, watersheds)?"
       }, 
       "preset": "select",
-      "validators": "ignore_missing scheming_choices",
-      "classes": ["form-group","col-md-12"],
+      "validators": "ignore_missing scheming_choices lock_if_odc",
+      "classes": ["form-group","col-md-12", "lock_if_odc"],
       "choices": [
         {
           "value": "",
@@ -236,7 +239,7 @@
       "form_placeholder": "e.g., http://example.com/description-of-this-dataset",
       "display_property": "foaf:homepage",
       "display_snippet": "link.html",
-      "classes": ["form-group","col-md-12"]
+      "classes": ["form-group","col-md-12", "lock_if_odc"]
     },
     {
       "field_name": "owner_org",
@@ -250,7 +253,8 @@
         "en": "The ministry managing this resource within the OPS"
       },
       "preset": "dataset_organization",
-      "classes": ["col-md-12","form-group"]
+      "validators": "owner_org_validator unicode lock_if_odc",
+      "classes": ["col-md-12","form-group", "lock_if_odc"]
     },
     {
       "field_name": "maintainer_translated",
@@ -360,8 +364,8 @@
         "en": "Let others know when they can expect new data."
       }, 
       "preset": "select",
-      "validators": "ignore_missing scheming_choices",
-      "classes": ["form-group","col-md-12"],
+      "validators": "ignore_missing scheming_choices lock_if_odc",
+      "classes": ["form-group","col-md-12", "lock_if_odc"],
       "choices": [
         {
           "value": "as_required",
@@ -476,7 +480,8 @@
       "help_text": {
         "en": "Explain any additional steps needed to access the resource"
       },
-      "classes": ["form-group","col-md-12"],
+      "classes": ["form-group","col-md-12", "lock_if_odc"],
+      "validators": "fluent_text lock_if_odc",
       "preset": "fluent_markdown",
       "form_placeholder": "e.g., Users will need to register with the website to recieve a login and provide an email address. Visit http://www.example.com/register."
     },
@@ -492,7 +497,8 @@
         "en": "Are you releasing this under a licence?",
         "fr": "Licence s’appliquant au jeu de données"
       },
-      "classes": ["col-md-12","form-group"]
+      "classes": ["col-md-12","form-group", "lock_if_odc"],
+      "validators": "lock_if_odc"
     },
     {
       "field_name": "licence_range_start",
@@ -537,9 +543,9 @@
       "help_text": {
         "en": "Who can access these resources?"
       }, 
-      "classes": ["form-group","col-md-12"],
+      "classes": ["form-group","col-md-12", "lock_if_odc"],
       "preset": "select",
-      "validators": "ignore_missing scheming_choices",
+      "validators": "ignore_missing scheming_choices lock_if_odc",
       "choices": [
         {
           "value": "open",
@@ -574,9 +580,9 @@
       "help_text": {
         "en": "When the first resource initially (the actual files) was added to the public-facing Open Data Catalogue."
       },
-      "classes": ["form-group","col-md-12"], 
+      "classes": ["form-group","col-md-12", "lock_if_odc"], 
       "preset": "date",
-      "validators": "ignore_missing isodate convert_to_json_if_date",
+      "validators": "ignore_missing isodate convert_to_json_if_date lock_if_odc",
       "form_placeholder": "yyyy-mm-dd"
     },
     {
@@ -589,9 +595,9 @@
       "help_text": {
         "en": "What is the specific exemption for this collection of resources to not be shared with the public? Refer to the <a href='https://www.ontario.ca/document/open-data-guidebook-guide-open-data-directive-2015/data-inventory#section-1' target='_blank'>Open Data Guidebook</a> for more on exemptions."
       },
-      "classes": ["form-group","col-md-12"],
+      "classes": ["form-group","col-md-12", "lock_if_odc"],
       "preset": "select",
-      "validators": "ignore_missing default(none) scheming_choices",
+      "validators": "ignore_missing default(none) scheming_choices lock_if_odc",
       "choices": [
         {
           "value": "commercial_sensitivity",
@@ -647,9 +653,10 @@
       "help_text": {
         "en": "Explain why the resource cannot be disclosed to the public"
       }, 
-      "classes": ["form-group","col-md-12"],
+      "classes": ["form-group","col-md-12", "lock_if_odc"],
       "form_placeholder": "e.g., This dataset cannot be sufficiently de-identified to assure users cannot use it to identify members of the public.",      
-      "preset": "fluent_markdown"
+      "preset": "fluent_markdown",
+      "validators": "fluent_text lock_if_odc"
     },
     {
       "field_name": "cluster_application_id",
@@ -681,15 +688,17 @@
       "form_placeholder": "P00000"
     },
     {
-      "field_name": "node_id",
+      "field_name": "harvester",
       "label": {
-        "en": "Ontario node ID",
-        "fr": "Ontario node ID"
+        "en": "Harvester ID",
+        "fr": "Harvester ID"
       },
-      "form_snippet": null,
+      "form_attrs": {
+        "data-module": "lock_if_odc"
+      },
+      "form_snippet": "hidden.html",
       "display_snippet": null,
-      "form_placeholder": "4321",
-      "validators": "ignore_missing int_validator"
+      "validators": "ignore_missing"
     }
   ],
   "resource_fields": [
@@ -913,7 +922,7 @@
       "help_text": {
         "en": "The last time this data was updated to add or be replaced with more recent data."
       }, 
-      "classes": ["form-group","col-md-12","lock_if_public"],
+      "classes": ["form-group","col-md-12"],
       "preset": "date",
       "validators": "ignore_missing isodate convert_to_json_if_date",
       "form_placeholder": "yyyy-mm-dd"

--- a/ckanext/ontario_theme/schemas/internal/ontario_theme_dataset.json
+++ b/ckanext/ontario_theme/schemas/internal/ontario_theme_dataset.json
@@ -46,6 +46,21 @@
       "form_placeholder": "e.g., Some useful notes about the data"
     },
     {
+      "field_name": "colby_notes",
+      "label": {
+        "en": "Internal Notes",
+        "fr": "Notes internes"
+      },
+      "help_inline" : true,
+      "help_text": {
+        "en": "Add any additional notes on the the asset specific to its internal use."
+      },
+      "classes": ["form-group","col-md-12"],
+      "validators" : "ignore_missing unicode",
+      "form_snippet": "markdown.html",
+      "form_placeholder": "e.g., Some useful notes about the data"
+    },
+    {
       "field_name": "asset_type",
       "label": {
         "en": "Asset Type",
@@ -798,6 +813,13 @@
           }
         },
         {
+          "value": "english_and_french",
+          "label": {
+            "en": "English and French",
+            "fr": "Anglais et Français"
+          }
+        },
+        {
           "value": "french",
           "label": {
             "en": "French",
@@ -882,6 +904,21 @@
       "form_placeholder": "yyyy-mm-dd"
     },
     {
+      "field_name": "data_last_updated",
+      "label": {
+        "en": "Data Last Updated",
+        "fr": "Dernière mise à jour des données"
+      },
+      "help_inline" : true,
+      "help_text": {
+        "en": "The last time this data was updated to add or be replaced with more recent data."
+      }, 
+      "classes": ["form-group","col-md-12","lock_if_public"],
+      "preset": "date",
+      "validators": "ignore_missing isodate convert_to_json_if_date",
+      "form_placeholder": "yyyy-mm-dd"
+    },
+    {
       "field_name": "data_birth_date",
       "label": {
         "en": "Data birth date",
@@ -897,11 +934,11 @@
       "form_placeholder": "yyyy-mm-dd"
     },
     {
-      "field_name": "version",
-      "label": "Version",
-      "form_placeholder": "1.0",
-      "validators": "ignore_missing unicode package_version_validator",
-      "classes": ["form-group","col-md-12"]
+      "field_name": "harvested_resource",
+      "label": "Harvested Resource?",
+      "form_snippet": "hidden.html",
+      "display_snippet": null,
+      "validators": "ignore_missing"
     }
   ]
 }

--- a/ckanext/ontario_theme/templates/internal/package/snippets/resource_item.html
+++ b/ckanext/ontario_theme/templates/internal/package/snippets/resource_item.html
@@ -66,6 +66,7 @@
               {% endif %}
             </a>
           {% endif %}
+          {% set can_edit = h.check_access('package_update', {'id':pkg.id }) and h.check_access('resource_update', res) %}
           {% if can_edit %}
             <a href="{{ h.url_for(controller='package', action='resource_edit', id=pkg.name, resource_id=res.id) }}" class="btn btn-primary">
               <i class="fa fa-pencil-square-o"></i>

--- a/ckanext/ontario_theme/templates/internal/scheming/form_snippets/extrafields_fluent_title.html
+++ b/ckanext/ontario_theme/templates/internal/scheming/form_snippets/extrafields_fluent_title.html
@@ -26,7 +26,7 @@ Future solutions may include:
     value=data[field.field_name + '-' + lang]
         or data.get(field.field_name, {})[lang],
     error=errors[field.field_name + '-' + lang],
-    classes=['col-md-6'],
+    classes=['col-md-6']+field.classes,
     attrs={'data-module': 'slug-preview-target', 'class': 'form-control'} if lang == h.extrafields_default_locale() else {'class': 'form-control'},
     is_required=h.scheming_field_required(field)
     ) %}

--- a/ckanext/ontario_theme/templates/internal/scheming/form_snippets/fluent_markdown.html
+++ b/ckanext/ontario_theme/templates/internal/scheming/form_snippets/fluent_markdown.html
@@ -9,7 +9,7 @@
     value=data[field.field_name + '-' + lang]
         or data.get(field.field_name, {})[lang],
     error=errors[field.field_name + '-' + lang],
-    classes=['col-md-6'],
+    classes=['col-md-6']+field.classes if 'classes' in field else [],
     attrs=field.form_attrs or {'class': 'col-md-6'},
     is_required=h.scheming_field_required(field)
     ) %}

--- a/ckanext/ontario_theme/templates/internal/scheming/form_snippets/fluent_text.html
+++ b/ckanext/ontario_theme/templates/internal/scheming/form_snippets/fluent_text.html
@@ -9,7 +9,7 @@
     value=data[field.field_name + '-' + lang]
         or data.get(field.field_name, {})[lang],
     error=errors[field.field_name + '-' + lang],
-    classes=['col-md-6'],
+    classes=['col-md-6']+field.classes if 'classes' in field else [],
     attrs=field.form_attrs if 'form_attrs' in field else {'class': 'form-control'},
     is_required=h.scheming_field_required(field)
     ) %}

--- a/ckanext/ontario_theme/templates/internal/scheming/form_snippets/hidden.html
+++ b/ckanext/ontario_theme/templates/internal/scheming/form_snippets/hidden.html
@@ -1,0 +1,11 @@
+{% import 'macros/form.html' as form %}
+
+{% set id = 'field-' + field.field_name %}
+{% set name = field.field_name %}
+
+{% set attrs = field.form_attrs if 'form_attrs' in field else {"class": "form-control"} %}
+{% set value = data.get(field.field_name, '') %}
+{% set classes = field.classes if 'classes' in field else ['control-medium'] %}
+<div classes="{{ classes|join(' ') }}">
+	<input id="{{ id or name }}" type="hidden" name="{{ name }}" value="{{ value | empty_and_escape }}" {{ form.attributes(attrs) }} />
+</div>

--- a/ckanext/ontario_theme/templates/internal/scheming/form_snippets/markdown.html
+++ b/ckanext/ontario_theme/templates/internal/scheming/form_snippets/markdown.html
@@ -1,0 +1,15 @@
+{% import 'macros/form.html' as form %}
+
+{% call form.markdown(
+    field.field_name,
+    id='field-' + field.field_name,
+    label=h.scheming_language_text(field.label),
+    placeholder=h.scheming_language_text(field.form_placeholder),
+    value=data[field.field_name],
+    error=errors[field.field_name],
+    attrs=dict({"class": "form-control"}, **(field.get('form_attrs', {}))),
+    is_required=h.scheming_field_required(field)
+    )
+%}
+    {%- snippet 'scheming/form_snippets/help_text.html', field=field -%}
+{% endcall %}

--- a/ckanext/ontario_theme/templates/internal/scheming/form_snippets/markdown.html
+++ b/ckanext/ontario_theme/templates/internal/scheming/form_snippets/markdown.html
@@ -7,6 +7,7 @@
     placeholder=h.scheming_language_text(field.form_placeholder),
     value=data[field.field_name],
     error=errors[field.field_name],
+    classes = field.get('classes',[]),
     attrs=dict({"class": "form-control"}, **(field.get('form_attrs', {}))),
     is_required=h.scheming_field_required(field)
     )

--- a/ckanext/ontario_theme/templates/internal/scheming/package/read.html
+++ b/ckanext/ontario_theme/templates/internal/scheming/package/read.html
@@ -15,6 +15,16 @@
       {{ h.render_markdown(h.scheming_language_text(pkg['notes_translated'])) }}
     </div>
   {% endif %}
+
+  {% if h.scheming_field_by_name(schema.dataset_fields, 'colby_notes') %}
+    <h3>
+      {{ h.scheming_language_text(h.scheming_field_by_name(schema.dataset_fields, 'colby_notes').label) }}
+    </h3>
+    <div class="colby_notes embedded-content">
+      {{ h.render_markdown(h.scheming_language_text(pkg['colby_notes'])) }}
+    </div>
+  {% endif %}
+  
 {% endblock %}
 
 {% block package_tags %}

--- a/ckanext/ontario_theme/templates/internal/scheming/package/snippets/additional_info.html
+++ b/ckanext/ontario_theme/templates/internal/scheming/package/snippets/additional_info.html
@@ -14,6 +14,7 @@
     'opened_date',
     'exemption',
     'exemption_rationale',
+    'colby_notes',
     'title_translated'
     ] -%}
 

--- a/ckanext/ontario_theme/templates/internal/scheming/package/snippets/package_form.html
+++ b/ckanext/ontario_theme/templates/internal/scheming/package/snippets/package_form.html
@@ -17,6 +17,7 @@ control-rows to align french and english fields side by side.
 {% endblock %}
 
 {% block basic_fields %}
+  {% resource 'ontario_theme/ontario_theme_lock_if_odc.js' %}
   {%- if not dataset_type -%}
     <p>
     dataset_type not passed to template. your version of CKAN

--- a/ckanext/ontario_theme/templates/internal/snippets/search_result_text.html
+++ b/ckanext/ontario_theme/templates/internal/snippets/search_result_text.html
@@ -1,3 +1,4 @@
+{% ckan_extends %}
 {#
 
 Displays a test for results of a search.

--- a/ckanext/ontario_theme/validators.py
+++ b/ckanext/ontario_theme/validators.py
@@ -5,6 +5,11 @@ from ckan.common import _
 from ckantoolkit import Invalid
 from ckanext.scheming.validation import scheming_validator
 from ckanext.fluent.validators import fluent_text_output
+from pylons.i18n import _
+from ckantoolkit import Invalid
+from ckan.authz import is_sysadmin
+import json
+
 
 def tag_name_validator(value, context):
     '''
@@ -63,3 +68,101 @@ def ontario_theme_copy_fluent_keywords_to_tags(field, schema):
                 )
 
     return validator
+
+
+def __lock_value(value, original_value):
+    '''
+        compares two values
+    '''
+
+    # avoid mismatches due to extra spaces, etc
+    if type(value) == str:
+        value = value.strip().replace("\r\n", "\n")
+    if type(original_value) == str:
+        original_value = original_value.strip().replace("\r\n", "\n")
+    if value != original_value:
+        return False
+    return True
+
+def __add_error_message(errors, key, message):
+    '''
+        adds error messages to error dict
+    '''
+
+    if key not in errors:
+        errors[key] = []
+    errors[key].append(message)
+    return errors
+
+def __check_all_values(key, value, original_value, errors, message, sub_validator):
+    '''
+        Adds error for fluent and non-fluent fields
+    '''
+
+    try:
+        check_value = json.loads(value)
+        original_value = json.loads(original_value)
+        if isinstance(check_value, dict):
+            for fkey, fvalue in check_value.items():
+                if fkey not in original_value:
+                    original_value[fkey] = ""
+                if not sub_validator(fvalue, original_value[fkey]):
+                    errors = __add_error_message(errors, (key[:-1] + (key[-1] + '-' + fkey,)), message)
+        else:
+            if not sub_validator(value, original_value):
+                errors = __add_error_message(errors, key, message)
+    except:
+        if not sub_validator(value, original_value):
+            errors = __add_error_message(errors, key, message)
+
+    return errors
+
+def __is_public_record(context):
+    '''
+        Determines whether a package corresponds to a package on the Ontario Data Catalogue
+    '''
+
+    package = context.get('package')
+    if package:
+        harvester_id = package.extras.get('harvester', '')
+        if harvester_id == "ontario-data-catalogue":
+            return True
+    return False
+
+
+def __get_value(key, original_values):
+    '''
+        gets the value from the package or resource whether or not it's an extra or not
+    '''
+
+    #check if the key is present in the package/resource
+    if hasattr(original_values, key[0]):
+        return getattr(original_values, key[0])
+    #if not, check in extras
+    else:
+        return original_values.extras.get(key[0], '')
+
+
+def __if_change_submitted(key, data, context, errors, message):
+    '''
+        determines whether a change for a package field has been submitted 
+    '''
+
+    package = context.get('package')
+    if package:
+        current = data.get(key, '')
+        original = __get_value(key, package)
+        # now we have to run each value (fluent or not, through the validator and add errors)
+        errors = __check_all_values(key, current, original, errors, message, __lock_value)
+
+    return errors
+
+
+def lock_if_odc(key, data, errors, context):
+    ''' 
+        Don't let the user change any of these values in the package if it has a public_catalogue_id 
+    '''
+
+    if __is_public_record(context) and not is_sysadmin(context['user']):
+        errors = __if_change_submitted(key, data, context, errors, _(u'This is a public catalogue field and can\'t be changed.')) or errors
+    return

--- a/setup.py
+++ b/setup.py
@@ -83,6 +83,7 @@ setup(
     # pip to create the appropriate form of executable for the target platform.
     entry_points='''
         [ckan.plugins]
+        ontario_data_catalogue_harvester=ckanext.ontario_theme.harvesters:OntarioDataCatalogueHarvester
         ontario_theme_external=ckanext.ontario_theme.plugin:OntarioThemeExternalPlugin
         ontario_theme=ckanext.ontario_theme.plugin:OntarioThemePlugin
 


### PR DESCRIPTION
This PR consists of:
 - a harvester for the Ontario data catalogue
 - a validator that prevents the changing of certain fields harvested through the validator
 - an authorization mod that prevents the changing of resources harvested through the validator
 - the removal of the node_id field
 - the addition of a colby notes field specifically for internal notes