### PR TITLE
Move ontario theme out of ckan source directory

### DIFF
--- a/test.ini
+++ b/test.ini
@@ -9,7 +9,7 @@ host = 0.0.0.0
 port = 5000
 
 [app:main]
-use = config:../../test-core.ini
+use = config:../ckan/test-core.ini
  
 # Insert any custom config settings to be used when running your extension's
 # tests here.
@@ -17,7 +17,7 @@ use = config:../../test-core.ini
 ckan.plugins = ontario_theme scheming_organizations scheming_datasets fluent
 
 # Needs to be here for tests even though in plugin.py
-licenses_group_url = file:///usr/lib/ckan/default/src/ckan/ckanext/ckanext-ontario_theme/ckanext/ontario_theme/schemas/licences.json
+licenses_group_url = file:///usr/lib/ckan/default/src/ckanext-ontario_theme/ckanext/ontario_theme/schemas/licences.json
 
 scheming.dataset_schemas = ckanext.ontario_theme:schemas/internal/ontario_theme_dataset.json
 


### PR DESCRIPTION
## What this PR accomplishes
Modifies the paths in `ckan.ini` to be relative to the new path of ontario theme in `/usr/lib/ckan/default/src`.

## Issue addressed
#208 

## What needs review
Check that moving the theme to `/usr/lib/ckan/default/src` with these path changes in `ckan.ini` works fine.