### PR TITLE
Bash script to install Solr 8

### DIFF
--- a/config/README.rst
+++ b/config/README.rst
@@ -1,0 +1,32 @@
+====================
+Configuration Files
+====================
+
+Configuration files for:  
+
+* Solr 
+
+.. list-table:: Details: 
+ :header-rows: 1
+
+ * - Application
+   - Version 
+   - Config file
+ * - Solr
+   - 8.11.1
+   - ``managed-schema`` 
+
+------------
+Solr
+------------
+
+The ``managed-schema`` config file was originally obtained from the `ckan-solr <https://github.com/ckan/ckan-solr>`_ Docker image (tag ``ckan/ckan-solr:2.9-solr8``). This file was then modified for Ontario ckan by including the following multi-valued fields:
+
+    <!-- Extra Ontario fields -->
+
+    <field name="keywords_en" type="string" indexed="true" stored="true" multiValued="true"/>
+
+    <field name="keywords_fr" type="string" indexed="true" stored="true" multiValued="true"/>
+
+The ``managed-schema`` config file is fetched in the `setup_solr.sh <https://github.com/ongov/ckanext-ontario_theme/blob/solr8/scripts/setup_solr.sh>`_ bash script for setting up Solr.   
+

--- a/config/solr/managed-schema
+++ b/config/solr/managed-schema
@@ -6,7 +6,9 @@
  The ASF licenses this file to You under the Apache License, Version 2.0
  (the "License"); you may not use this file except in compliance with
  the License.  You may obtain a copy of the License at
+
      http://www.apache.org/licenses/LICENSE-2.0
+
  Unless required by applicable law or agreed to in writing, software
  distributed under the License is distributed on an "AS IS" BASIS,
  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,44 +22,46 @@
 -->
 
 <!-- We update the version when there is a backward-incompatible change to this
-schema. In this case the version should be set to the next CKAN version number.
-(x.y but not x.y.z since it needs to be a float) -->
-<schema name="ckan" version="2.8">
+schema. We used to use the `version` attribute for this but this is an internal
+attribute that should not be used so starting from CKAN 2.10 we use the `name`
+attribute with the form `ckan-X.Y` -->
+<schema name="ckan-2.10" version="1.6">
 
 <types>
     <fieldType name="string" class="solr.StrField" sortMissingLast="true" omitNorms="true"/>
     <fieldType name="boolean" class="solr.BoolField" sortMissingLast="true" omitNorms="true"/>
     <fieldtype name="binary" class="solr.BinaryField"/>
-    <fieldType name="int" class="solr.TrieIntField" precisionStep="0" omitNorms="true" positionIncrementGap="0"/>
-    <fieldType name="float" class="solr.TrieFloatField" precisionStep="0" omitNorms="true" positionIncrementGap="0"/>
-    <fieldType name="long" class="solr.TrieLongField" precisionStep="0" omitNorms="true" positionIncrementGap="0"/>
-    <fieldType name="double" class="solr.TrieDoubleField" precisionStep="0" omitNorms="true" positionIncrementGap="0"/>
-    <fieldType name="tint" class="solr.TrieIntField" precisionStep="8" omitNorms="true" positionIncrementGap="0"/>
-    <fieldType name="tfloat" class="solr.TrieFloatField" precisionStep="8" omitNorms="true" positionIncrementGap="0"/>
-    <fieldType name="tlong" class="solr.TrieLongField" precisionStep="8" omitNorms="true" positionIncrementGap="0"/>
-    <fieldType name="tdouble" class="solr.TrieDoubleField" precisionStep="8" omitNorms="true" positionIncrementGap="0"/>
-    <fieldType name="date" class="solr.TrieDateField" omitNorms="true" precisionStep="0" positionIncrementGap="0"/>
-    <fieldType name="tdate" class="solr.TrieDateField" omitNorms="true" precisionStep="6" positionIncrementGap="0"/>
+    <fieldType name="int" class="solr.IntPointField" omitNorms="true" positionIncrementGap="0"/>
+    <fieldType name="float" class="solr.FloatPointField" omitNorms="true" positionIncrementGap="0"/>
+    <fieldType name="long" class="solr.LongPointField" omitNorms="true" positionIncrementGap="0"/>
+    <fieldType name="double" class="solr.DoublePointField" omitNorms="true" positionIncrementGap="0"/>
+    <fieldType name="pint" class="solr.IntPointField" omitNorms="true" positionIncrementGap="0"/>
+    <fieldType name="pfloat" class="solr.FloatPointField" omitNorms="true" positionIncrementGap="0"/>
+    <fieldType name="plong" class="solr.LongPointField" omitNorms="true" positionIncrementGap="0"/>
+    <fieldType name="pdouble" class="solr.DoublePointField" omitNorms="true" positionIncrementGap="0"/>
+    <fieldType name="date" class="solr.DatePointField" omitNorms="true" positionIncrementGap="0"/>
+    <fieldType name="pdate" class="solr.DatePointField" omitNorms="true" positionIncrementGap="0"/>
 
-    <fieldType name="tdates" class="solr.TrieDateField" precisionStep="7" positionIncrementGap="0" multiValued="true"/>
+    <fieldType name="pdates" class="solr.DatePointField" positionIncrementGap="0" multiValued="true"/>
     <fieldType name="booleans" class="solr.BoolField" sortMissingLast="true" multiValued="true"/>
-    <fieldType name="tints" class="solr.TrieIntField" precisionStep="8" positionIncrementGap="0" multiValued="true"/>
-    <fieldType name="tfloats" class="solr.TrieFloatField" precisionStep="8" positionIncrementGap="0" multiValued="true"/>
-    <fieldType name="tlongs" class="solr.TrieLongField" precisionStep="8" positionIncrementGap="0" multiValued="true"/>
-    <fieldType name="tdoubles" class="solr.TrieDoubleField" precisionStep="8" positionIncrementGap="0" multiValued="true"/>
+    <fieldType name="pints" class="solr.IntPointField" positionIncrementGap="0" multiValued="true"/>
+    <fieldType name="pfloats" class="solr.FloatPointField" positionIncrementGap="0" multiValued="true"/>
+    <fieldType name="plongs" class="solr.LongPointField" positionIncrementGap="0" multiValued="true"/>
+    <fieldType name="pdoubles" class="solr.DoublePointField" positionIncrementGap="0" multiValued="true"/>
 
     <fieldType name="text" class="solr.TextField" positionIncrementGap="100">
         <analyzer type="index">
             <tokenizer class="solr.WhitespaceTokenizerFactory"/>
-            <filter class="solr.WordDelimiterFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="1" catenateNumbers="1" catenateAll="0" splitOnCaseChange="1"/>
+            <filter class="solr.WordDelimiterGraphFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="1" catenateNumbers="1" catenateAll="0" splitOnCaseChange="1"/>
+            <filter class="solr.FlattenGraphFilterFactory"/> <!-- required on index analyzers after graph filters -->
             <filter class="solr.LowerCaseFilterFactory"/>
             <filter class="solr.SnowballPorterFilterFactory" language="English" protected="protwords.txt"/>
             <filter class="solr.ASCIIFoldingFilterFactory"/>
         </analyzer>
         <analyzer type="query">
             <tokenizer class="solr.WhitespaceTokenizerFactory"/>
-            <filter class="solr.SynonymFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="true"/>
-            <filter class="solr.WordDelimiterFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="0" catenateNumbers="0" catenateAll="0" splitOnCaseChange="1"/>
+            <filter class="solr.SynonymGraphFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="true"/>
+            <filter class="solr.WordDelimiterGraphFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="0" catenateNumbers="0" catenateAll="0" splitOnCaseChange="1"/>
             <filter class="solr.LowerCaseFilterFactory"/>
             <filter class="solr.SnowballPorterFilterFactory" language="English" protected="protwords.txt"/>
             <filter class="solr.ASCIIFoldingFilterFactory"/>
@@ -66,19 +70,32 @@ schema. In this case the version should be set to the next CKAN version number.
 
 
     <!-- A general unstemmed text field - good if one does not know the language of the field -->
-    <fieldType name="textgen" class="solr.TextField" positionIncrementGap="100">
+    <fieldType name="text_general" class="solr.TextField" positionIncrementGap="100">
         <analyzer type="index">
             <tokenizer class="solr.WhitespaceTokenizerFactory"/>
-            <filter class="solr.WordDelimiterFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="1" catenateNumbers="1" catenateAll="0" splitOnCaseChange="0"/>
+            <filter class="solr.WordDelimiterGraphFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="1" catenateNumbers="1" catenateAll="0" splitOnCaseChange="0"/>
+            <filter class="solr.FlattenGraphFilterFactory"/> <!-- required on index analyzers after graph filters -->
             <filter class="solr.LowerCaseFilterFactory"/>
         </analyzer>
         <analyzer type="query">
             <tokenizer class="solr.WhitespaceTokenizerFactory"/>
-            <filter class="solr.SynonymFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="true"/>
-            <filter class="solr.WordDelimiterFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="0" catenateNumbers="0" catenateAll="0" splitOnCaseChange="0"/>
+            <filter class="solr.SynonymGraphFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="true"/>
+            <filter class="solr.WordDelimiterGraphFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="0" catenateNumbers="0" catenateAll="0" splitOnCaseChange="0"/>
             <filter class="solr.LowerCaseFilterFactory"/>
         </analyzer>
     </fieldType>
+
+    <fieldType name="text_ngram" class="solr.TextField" positionIncrementGap="100">
+      <analyzer type="index">
+        <tokenizer class="solr.NGramTokenizerFactory" minGramSize="2" maxGramSize="10"/>
+        <filter class="solr.LowerCaseFilterFactory"/>
+      </analyzer>
+      <analyzer type="query">
+        <tokenizer class="solr.WhitespaceTokenizerFactory"/>
+        <filter class="solr.LowerCaseFilterFactory"/>
+      </analyzer>
+    </fieldType>
+
 </types>
 
 
@@ -87,24 +104,24 @@ schema. In this case the version should be set to the next CKAN version number.
     <field name="id" type="string" indexed="true" stored="true" required="true" />
     <field name="site_id" type="string" indexed="true" stored="true" required="true" />
     <field name="title" type="text" indexed="true" stored="true" />
+    <field name="title_ngram" type="text_ngram" indexed="true" stored="true" />
     <field name="entity_type" type="string" indexed="true" stored="true" omitNorms="true" />
     <field name="dataset_type" type="string" indexed="true" stored="true" />
     <field name="state" type="string" indexed="true" stored="true" omitNorms="true" />
     <field name="name" type="string" indexed="true" stored="true" omitNorms="true" />
+    <field name="name_ngram" type="text_ngram" indexed="true" stored="true" />
     <field name="revision_id" type="string" indexed="true" stored="true" omitNorms="true" />
     <field name="version" type="string" indexed="true" stored="true" />
     <field name="url" type="string" indexed="true" stored="true" omitNorms="true" />
     <field name="ckan_url" type="string" indexed="true" stored="true" omitNorms="true" />
     <field name="download_url" type="string" indexed="true" stored="true" omitNorms="true" />
     <field name="notes" type="text" indexed="true" stored="true"/>
-    <field name="author" type="textgen" indexed="true" stored="true" />
-    <field name="author_email" type="textgen" indexed="true" stored="true" />
-    <field name="maintainer" type="textgen" indexed="true" stored="true" />
-    <field name="maintainer_email" type="textgen" indexed="true" stored="true" />
+    <field name="author" type="text_general" indexed="true" stored="true" />
+    <field name="author_email" type="text_general" indexed="true" stored="true" />
+    <field name="maintainer" type="text_general" indexed="true" stored="true" />
+    <field name="maintainer_email" type="text_general" indexed="true" stored="true" />
     <field name="license" type="string" indexed="true" stored="true" />
     <field name="license_id" type="string" indexed="true" stored="true" />
-    <field name="ratings_count" type="int" indexed="true" stored="false" />
-    <field name="ratings_average" type="float" indexed="true" stored="false" />
     <field name="tags" type="string" indexed="true" stored="true" multiValued="true"/>
     <field name="groups" type="string" indexed="true" stored="true" multiValued="true"/>
     <field name="organization" type="string" indexed="true" stored="true" multiValued="false"/>
@@ -112,8 +129,8 @@ schema. In this case the version should be set to the next CKAN version number.
     <field name="capacity" type="string" indexed="true" stored="true" multiValued="false"/>
     <field name="permission_labels" type="string" indexed="true" stored="false" multiValued="true"/>
 
-    <field name="res_name" type="textgen" indexed="true" stored="true" multiValued="true" />
-    <field name="res_description" type="textgen" indexed="true" stored="true" multiValued="true"/>
+    <field name="res_name" type="text_general" indexed="true" stored="true" multiValued="true" />
+    <field name="res_description" type="text_general" indexed="true" stored="true" multiValued="true"/>
     <field name="res_format" type="string" indexed="true" stored="true" multiValued="true"/>
     <field name="res_url" type="string" indexed="true" stored="true" multiValued="true"/>
     <field name="res_type" type="string" indexed="true" stored="true" multiValued="true"/>
@@ -163,10 +180,10 @@ schema. In this case the version should be set to the next CKAN version number.
 </fields>
 
 <uniqueKey>index_id</uniqueKey>
-<defaultSearchField>text</defaultSearchField>
-<solrQueryParser defaultOperator="AND"/>
 
 <copyField source="url" dest="urls"/>
+<copyField source="title" dest="title_ngram"/>
+<copyField source="name" dest="name_ngram"/>
 <copyField source="ckan_url" dest="urls"/>
 <copyField source="download_url" dest="urls"/>
 <copyField source="res_url" dest="urls"/>

--- a/scripts/README.rst
+++ b/scripts/README.rst
@@ -1,0 +1,17 @@
+====================
+Installation Scripts
+====================
+
+Bash scripts to install Ontario ckan 2.9 and Solr 8.11.1 on separate Ubuntu 20.04 virtual machines.
+
+------------
+Solr
+------------
+
+Script: ``setup_solr.sh``    
+Version: Solr 8.11.1
+
+The bash script requires the ``managed-schema`` config file customized for Ontario ckan, stored in ``config/solr``. This config file is obtained in the script by cloning this repository and copying the file into the Solr config folder ``/opt/solr/server/solr/configsets/_default/``.
+
+Note that the bash script installs Solr but does not rebuild the index: this must be done on the ckan machine.
+

--- a/scripts/setup_solr.sh
+++ b/scripts/setup_solr.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+# Assume that the sudo password has been exported as an environment variable
+# export SUDOPASS="mysudopass"
+
+echo "Installing packages..."
+echo $SUDOPASS | sudo -S apt-get update
+echo $SUDOPASS | sudo -S  apt-get install -y net-tools openssh-server openjdk-11-jre python3-pip python3-virtualenv python3-dev python3.8-venv git
+
+SOLRVER=8.11.1
+echo ""
+echo "Installing Solr binary installer for version ${SOLRVER}..."
+wget https://dlcdn.apache.org/lucene/solr/$SOLRVER/solr-$SOLRVER.tgz
+tar xzf solr-$SOLRVER.tgz
+echo $SUDOPASS | sudo -S ./solr-$SOLRVER/bin/install_solr_service.sh solr-$SOLRVER.tgz > status_out.txt
+sleep 5
+echo "Solr is running."
+echo $SUDOPASS | sudo -S chown -R `whoami` /opt/solr/server/
+ls -lt
+
+echo "Fetching managed-schema for ontario_theme..."
+git clone https://github.com/ongov/ckanext-ontario_theme.git
+cd ckanext-ontario_theme
+git fetch origin solr8:solr8
+git checkout solr8
+cd /opt/solr/server/solr/configsets/_default/
+echo $SUDOPASS | sudo -S chown -R `whoami` .
+echo $SUDOPASS | sudo -S chmod -R u+rwx .
+# Make a backup copy of managed-schema
+cd conf/
+pwd
+mv managed-schema managed-schema.bk
+ls -lt
+# Copy ontario_theme schema from repository
+cp ~/ckanext-ontario_theme/config/solr/managed-schema .
+sudo chmod 775 managed-schema
+ls -lt
+echo "Schema fetched."
+
+
+echo ""
+echo "Creating a CKAN core..."
+sudo su solr <<EOF
+cd /opt/solr/bin
+pwd
+./solr create -c ckan
+exit
+EOF
+echo "CKAN core created."


### PR DESCRIPTION
## What this PR accomplishes
Provides:
- a [bash script](https://github.com/ongov/ckanext-ontario_theme/blob/solr8/scripts/setup_solr.sh) to install Solr 8.11.1 in its own VM
- a [config file](https://github.com/ongov/ckanext-ontario_theme/tree/solr8/config/solr) customized for Ontario ckan
- documentation for both

## What needs review
- check that you approve of the script code and passing of the sudo credentials as an environment variable
- the script is specific to the `solr8` branch; once the branch is finally merged, [this line to switch branches](https://github.com/ongov/ckanext-ontario_theme/blob/solr8/scripts/setup_solr.sh#L25) is no longer necessary. Shall I remove it now already?
- read over the documentation for anything that is not clear