### PR TITLE
GA download tracker (CKAN 2.8)

### DIFF
--- a/ckanext/ontario_theme/fanstatic/internal/ontario_theme_download_tracker.js
+++ b/ckanext/ontario_theme/fanstatic/internal/ontario_theme_download_tracker.js
@@ -7,14 +7,7 @@ function trackDownload(resourceUrl, orgName, pkgTitle, groupName) {
 
   let fileName = resourceUrl.split('download/')[1];
 
-  if (groupName.length > 2) { 
-    // clean = groupName.replaceAll('&#39;','"').replaceAll('u"','"');
-    // groupName = JSON.parse("[" + clean + "]")[0][0]['name'];
-    groupName = "TBD";
-  } else {
-    groupName = "";
-  }
-  console.log('groupName after fix: ', groupName)
+  console.log('groupName: ', groupName)
 
   window.dataLayer = window.dataLayer || [];
   window.dataLayer.push({

--- a/ckanext/ontario_theme/fanstatic/internal/ontario_theme_download_tracker.js
+++ b/ckanext/ontario_theme/fanstatic/internal/ontario_theme_download_tracker.js
@@ -10,14 +10,16 @@ function trackDownload(resourceUrl, orgName, pkgTitle, groupName) {
   urlArray = resourceUrl.split('/');
   fileName = urlArray[urlArray.length - 1];
 
+  // Set variables from the Pageview event to undefined
+  // to prevent them from being collected in GTM
   window.dataLayer = window.dataLayer || [];
   window.dataLayer.push({
     'event': 'File Download',
     'ministryTag': orgName,
     'group': groupName,
     'datasetName': pkgTitle,
-    'dataResourceName': fileName
+    'dataResourceName': fileName,
+    'dataAvailability': undefined,
+    'resourceName': undefined
   });
-
-  console.log('dataLayer: ', dataLayer)
 }

--- a/ckanext/ontario_theme/fanstatic/internal/ontario_theme_download_tracker.js
+++ b/ckanext/ontario_theme/fanstatic/internal/ontario_theme_download_tracker.js
@@ -1,0 +1,27 @@
+// Enable JavaScript's strict mode. Strict mode catches some common
+// programming errors and throws exceptions, prevents some unsafe actions from
+// being taken, and disables some confusing and bad JavaScript features.
+"use strict";
+
+function trackDownload(resourceUrl, orgName, pkgTitle, groupName) {
+
+  let fileName = resourceUrl.split('download/')[1];
+
+  if (groupName.length > 2) { 
+    // clean = groupName.replaceAll('&#39;','"').replaceAll('u"','"');
+    // groupName = JSON.parse("[" + clean + "]")[0][0]['name'];
+    groupName = "TBD";
+  } else {
+    groupName = "";
+  }
+  console.log('groupName after fix: ', groupName)
+
+  window.dataLayer = window.dataLayer || [];
+  window.dataLayer.push({
+    'event': 'File Download',
+    'ministryTag': orgName,
+    'group': groupName,
+    'datasetName': pkgTitle,
+    'dataResourceName': fileName
+  });
+}

--- a/ckanext/ontario_theme/fanstatic/internal/ontario_theme_download_tracker.js
+++ b/ckanext/ontario_theme/fanstatic/internal/ontario_theme_download_tracker.js
@@ -7,8 +7,6 @@ function trackDownload(resourceUrl, orgName, pkgTitle, groupName) {
 
   let fileName = resourceUrl.split('download/')[1];
 
-  console.log('groupName: ', groupName)
-
   window.dataLayer = window.dataLayer || [];
   window.dataLayer.push({
     'event': 'File Download',

--- a/ckanext/ontario_theme/fanstatic/internal/ontario_theme_download_tracker.js
+++ b/ckanext/ontario_theme/fanstatic/internal/ontario_theme_download_tracker.js
@@ -5,10 +5,10 @@
 
 function trackDownload(resourceUrl, orgName, pkgTitle, groupName) {
 
-  let fileName = resourceUrl.split('download/')[1];
-
-	console.log('orgName: ', orgName);
-	console.log('groupName: ', groupName);
+  let fileName;
+  let urlArray;
+  urlArray = resourceUrl.split('/');
+  fileName = urlArray[urlArray.length - 1];
 
   window.dataLayer = window.dataLayer || [];
   window.dataLayer.push({
@@ -18,4 +18,6 @@ function trackDownload(resourceUrl, orgName, pkgTitle, groupName) {
     'datasetName': pkgTitle,
     'dataResourceName': fileName
   });
+
+  console.log('dataLayer: ', dataLayer)
 }

--- a/ckanext/ontario_theme/fanstatic/internal/ontario_theme_download_tracker.js
+++ b/ckanext/ontario_theme/fanstatic/internal/ontario_theme_download_tracker.js
@@ -7,6 +7,9 @@ function trackDownload(resourceUrl, orgName, pkgTitle, groupName) {
 
   let fileName = resourceUrl.split('download/')[1];
 
+	console.log('orgName: ', orgName);
+	console.log('groupName: ', groupName);
+
   window.dataLayer = window.dataLayer || [];
   window.dataLayer.push({
     'event': 'File Download',

--- a/ckanext/ontario_theme/templates/internal/base.html
+++ b/ckanext/ontario_theme/templates/internal/base.html
@@ -12,12 +12,17 @@
     {% if pkg.organization %}
       {% set this_pkg = pkg %}
       {% set this_org = h.get_translated(pkg.organization, 'title') or pkg.organization.name %}
+      {% if pkg.groups %}
+        {% set this_group = pkg.groups[0]['name'] %}
+      {% else %}
+        {% set this_group = '' %}
+      {% endif %}
       {% if res %}
         {% set this_res = res %}
       {% endif %}
     {% endif %}
   {% endif %}
-  {% snippet "gtm_pageview.html", this_pkg=this_pkg, this_org=this_org, this_res=this_res %}
+  {% snippet "gtm_pageview.html", this_pkg=this_pkg, this_org=this_org, this_group=this_group, this_res=this_res %}
   {% snippet "gtm.html" %}
 {% endblock %}
 

--- a/ckanext/ontario_theme/templates/internal/gtm_pageview.html
+++ b/ckanext/ontario_theme/templates/internal/gtm_pageview.html
@@ -5,7 +5,6 @@
     // page views. Otherwise, empty values are passed.
 
     window.dataLayer = window.dataLayer || [];
-    groupName = '';
 
     // Set `resourceName` for resource page views.
     // {{this_res}} is only non-empty for resource views
@@ -22,16 +21,10 @@
     // Set `datasetName` for dataset and resource page views.
     // {{this_pkg}} is non-empty for both page views and resource views
     if ('{{this_pkg}}'.length > 0) {
-	    // Check that {{this_pkg.groups}} is not '[]'; i.e. has length > 2
-	    if ('{{this_pkg.groups}}'.length > 2) { 
-		    result = '{{this_pkg.groups}}';
-		    clean = result.replaceAll('&#39;','"').replaceAll('u"','"');
-                    groupName = JSON.parse("[" + clean + "]")[0][0]['name'];
-	    }
         window.dataLayer.push({
             'event': 'Pageview',
             'ministryTag': '{{this_org}}',
-            'group': groupName,
+            'group': '{{this_group}}',
             'dataAvailability': '{{this_pkg.access_level}}',
             'datasetName': '{{this_pkg.title}}',
             'resourceName': resourceName

--- a/ckanext/ontario_theme/templates/internal/package/resource_read.html
+++ b/ckanext/ontario_theme/templates/internal/package/resource_read.html
@@ -1,8 +1,16 @@
 {% ckan_extends %}
 
 {% block resource_read_url %}
+  {% resource 'ontario_theme/ontario_theme_download_tracker.js' %}
+  {% if pkg.groups %}
+    {% set this_group = pkg.groups[0]['name'] %}
+  {% else %}
+    {% set this_group = '' %}
+  {% endif %}
   {% if res.url and h.is_url(res.url) %}
-    <p class="text-muted ellipsis">{{ _('URL:') }} <a class="resource-url-analytics dataset-download-link" href="{{ res.url }}" title="{{ res.url }}">{{ res.url }}</a></p>
+    {% set this_org = h.get_translated(pkg.organization, 'title') or pkg.organization.name %}
+    {# Download link URL on resource page #}
+    <p class="text-muted ellipsis">{{ _('URL:') }} <a class="resource-url-analytics dataset-download-link" href="{{ res.url }}" title="{{ res.url }}" onclick="trackDownload('{{ res.url }}', '{{ this_org }}', '{{ pkg.title }}', '{{ this_group }}');return true;">{{ res.url }}</a></p>
   {% elif res.url %}
     <p class="text-muted break-word">{{ _('URL:') }} {{ res.url }}</p>
   {% endif %}
@@ -10,44 +18,53 @@
 {% endblock %}
 
 {% block resource_actions_inner %}
-{% if h.check_access('package_update', {'id':pkg.id }) %}
-  <li>{% link_for _('Manage'), controller='package', action='resource_edit', id=pkg.name, resource_id=res.id, class_='btn btn-default', icon='wrench' %}</li>
-{% endif %}
-{% if res.url and h.is_url(res.url) %}
-  <li>
-    <div class="btn-group">
-    <a class="btn btn-primary dataset-download-link resource-url-analytics resource-type-{{ res.resource_type }}" href="{{ res.url }}">
-      {% if res.resource_type in ('listing', 'service') %}
-        <i class="fa fa-eye"></i> {{ _('View') }}
-      {% elif  res.resource_type == 'api' %}
-        <i class="fa fa-key"></i> {{ _('API Endpoint') }}
-      {% elif (not res.has_views or not res.can_be_previewed) and not res.url_type == 'upload' %}
-        <i class="fa fa-external-link"></i> {{ _('Open') }}
-      {% else %}
-        <i class="fa fa-arrow-circle-o-down"></i> {{ _('Download') }}
-      {% endif %}
-    </a>
-     {% block download_resource_button %}
-      {%if res.datastore_active %}
-    <button class="btn btn-primary dropdown-toggle" data-toggle="dropdown">
-        <span class="caret"></span>
-      </button>
-    <ul class="dropdown-menu">
-      <li>
-        <a class="dataset-download-link" href="{{ h.url_for(controller='ckanext.datastore.controller:DatastoreController', action='dump', resource_id=res.id, bom=True) }}"
-          target="_blank"><span>CSV</span></a>
-        <a class="dataset-download-link" href="{{ h.url_for(controller='ckanext.datastore.controller:DatastoreController', action='dump', resource_id=res.id, format='tsv', bom=True) }}"
-          target="_blank"><span>TSV</span></a>
-        <a class="dataset-download-link" href="{{ h.url_for(controller='ckanext.datastore.controller:DatastoreController', action='dump', resource_id=res.id, format='json') }}"
-          target="_blank"><span>JSON</span></a>
-        <a class="dataset-download-link" href="{{ h.url_for(controller='ckanext.datastore.controller:DatastoreController', action='dump', resource_id=res.id, format='xml') }}"
-          target="_blank"><span>XML</span></a>
-      </li>
-    </ul>
-    {%endif%} {% endblock %}
-    </div>
-  </li>
-{% endif %}
+  {% resource 'ontario_theme/ontario_theme_download_tracker.js' %}
+  {% set this_org = h.get_translated(pkg.organization, 'title') or pkg.organization.name %}
+  {% if h.check_access('package_update', {'id':pkg.id }) %}
+    <li>{% link_for _('Manage'), controller='package', action='resource_edit', id=pkg.name, resource_id=res.id, class_='btn btn-default', icon='wrench' %}</li>
+  {% endif %}
+  {% if res.url and h.is_url(res.url) %}
+    {% set this_org = h.get_translated(pkg.organization, 'title') or pkg.organization.name %}
+    {% if pkg.groups %}
+      {% set this_group = pkg.groups[0]['name'] %}
+    {% else %}
+      {% set this_group = '' %}
+    {% endif %}
+    <li>
+      <div class="btn-group">
+        <a class="btn btn-primary dataset-download-link resource-url-analytics resource-type-{{ res.resource_type }}" href="{{ res.url }}" onclick="trackDownload('{{ res.url }}', '{{ this_org }}', '{{ pkg.title }}', '{{ this_group }}');return true;">
+          {% if res.resource_type in ('listing', 'service') %}
+            <i class="fa fa-eye"></i> {{ _('View') }}
+          {% elif  res.resource_type == 'api' %}
+            <i class="fa fa-key"></i> {{ _('API Endpoint') }}
+          {% elif (not res.has_views or not res.can_be_previewed) and not res.url_type == 'upload' %}
+            <i class="fa fa-external-link"></i> {{ _('Open') }}
+          {% else %}
+            <i class="fa fa-arrow-circle-o-down"></i> {{ _('Download') }}
+          {% endif %}
+        </a>
+        {% block download_resource_button %}
+          {%if res.datastore_active %}
+            {% set this_org = h.get_translated(pkg.organization, 'title') or pkg.organization.name %}
+            {% if pkg.groups %}
+              {% set this_group = pkg.groups[0]['name'] %}
+            {% else %}
+              {% set this_group = '' %}
+            {% endif %}
+            <button class="btn btn-primary dropdown-toggle" data-toggle="dropdown"> <span class="caret"></span></button>
+            <ul class="dropdown-menu">
+              <li>
+                <a class="dataset-download-link" href="{{ h.url_for(controller='ckanext.datastore.controller:DatastoreController', action='dump', resource_id=res.id, bom=True) }}" target="_blank" onclick="trackDownload('{{ res.url }}', '{{ this_org }}', '{{ pkg.title }}', '{{ this_group }}');return true;"><span>CSV</span></a>
+                <a class="dataset-download-link" href="{{ h.url_for(controller='ckanext.datastore.controller:DatastoreController', action='dump', resource_id=res.id, format='tsv', bom=True) }}" target="_blank" onclick="trackDownload('{{ res.url }}', '{{ this_org }}', '{{ pkg.title }}', '{{ this_group }}');return true;"><span>TSV</span></a>
+                <a class="dataset-download-link" href="{{ h.url_for(controller='ckanext.datastore.controller:DatastoreController', action='dump', resource_id=res.id, format='json') }}" target="_blank" onclick="trackDownload('{{ res.url }}', '{{ this_org }}', '{{ pkg.title }}', '{{ this_group }}');return true;"><span>JSON</span></a>
+                <a class="dataset-download-link" href="{{ h.url_for(controller='ckanext.datastore.controller:DatastoreController', action='dump', resource_id=res.id, format='xml') }}" target="_blank" onclick="trackDownload('{{ res.url }}', '{{ this_org }}', '{{ pkg.title }}', '{{ this_group }}');return true;"><span>XML</span></a>
+              </li>
+          </ul>
+        {%endif%}
+      {% endblock %}
+      </div>
+    </li>
+  {% endif %}
 {% endblock %}
 
 {% block data_preview %}

--- a/ckanext/ontario_theme/templates/internal/package/snippets/resource_item.html
+++ b/ckanext/ontario_theme/templates/internal/package/snippets/resource_item.html
@@ -61,7 +61,14 @@
               {% endif %}
             </a>
           {% if res.url and h.is_url(res.url) %}
-            <a href="{{ res.url }}" class="resource-url-analytics btn btn-primary dataset-download-link" target="_blank">
+	    {% resource 'ontario_theme/ontario_theme_download_tracker.js' %}
+	    {% set this_org = h.get_translated(pkg.organization, 'title') or pkg.organization.name %}
+	    {% if pkg.groups %}
+	      {% set this_group = 'TODO' %}
+	    {% else %}
+	      {% set this_group = '' %}
+	    {% endif %}
+            <a href="{{ res.url }}" class="resource-url-analytics btn btn-primary dataset-download-link" target="_blank" onclick="trackDownload('{{ res.url }}', '{{ this_org }}', '{{ pkg.title }}', '{{ this_group }}');return true;">
               {% if res.has_views or res.url_type == 'upload' %}
                 <i class="fa fa-arrow-circle-o-down"></i>
                 {{ _('Download') }}

--- a/ckanext/ontario_theme/templates/internal/package/snippets/resource_item.html
+++ b/ckanext/ontario_theme/templates/internal/package/snippets/resource_item.html
@@ -64,7 +64,7 @@
 	    {% resource 'ontario_theme/ontario_theme_download_tracker.js' %}
 	    {% set this_org = h.get_translated(pkg.organization, 'title') or pkg.organization.name %}
 	    {% if pkg.groups %}
-	      {% set this_group = 'TODO' %}
+	      {% set this_group = pkg.groups[0]['name'] %}
 	    {% else %}
 	      {% set this_group = '' %}
 	    {% endif %}


### PR DESCRIPTION
## What this PR accomplishes
Implements a new JS function `trackDownload()` that is triggered every time a download button or download URL is clicked. The dataLayer object is sent to Google analytics for further processing.

## Issue addressed
- #243
- small fix in passing group  name for #237 in `ckanext/ontario_theme/templates/internal/base.html` and `ckanext/ontario_theme/templates/internal/gtm_pageview.html`)

## What needs review
The functionality of the code has already been reviewed from the Google analytics side. The reviewer here can generally review the code. The CKAN docs suggest creating a [JS module](https://docs.ckan.org/en/2.9/contributing/frontend/javascript-module-tutorial.html#building-a-javascript-module), but `ckan.module` was not recognized and as an alternative, an ordinary JS function was created instead.