### PR TITLE
GA download tracker (CKAN 2.9)

### DIFF
--- a/ckanext/ontario_theme/fanstatic/internal/ontario_theme_download_tracker.js
+++ b/ckanext/ontario_theme/fanstatic/internal/ontario_theme_download_tracker.js
@@ -7,15 +7,6 @@ function trackDownload(resourceUrl, orgName, pkgTitle, groupName) {
 
   let fileName = resourceUrl.split('download/')[1];
 
-  if (groupName.length > 2) { 
-    // clean = groupName.replaceAll('&#39;','"').replaceAll('u"','"');
-    // groupName = JSON.parse("[" + clean + "]")[0][0]['name'];
-    groupName = "TBD";
-  } else {
-    groupName = "";
-  }
-  console.log('groupName after fix: ', groupName)
-
   window.dataLayer = window.dataLayer || [];
   window.dataLayer.push({
     'event': 'File Download',

--- a/ckanext/ontario_theme/fanstatic/internal/ontario_theme_download_tracker.js
+++ b/ckanext/ontario_theme/fanstatic/internal/ontario_theme_download_tracker.js
@@ -1,23 +1,11 @@
-// From: https://docs.ckan.org/en/2.9/theming/javascript.html
-// Calls the ckan.module() function to register a new JavaScript module with CKAN.
-// -------------------------------------------------------------------------------
-
 // Enable JavaScript's strict mode. Strict mode catches some common
 // programming errors and throws exceptions, prevents some unsafe actions from
 // being taken, and disables some confusing and bad JavaScript features.
-// "use strict";
+"use strict";
 
-console.log('in module')
+function trackDownload(resourceUrl, orgName, pkgTitle, groupName) {
 
-
-function myFunction(resourceUrl, orgName, pkgTitle, groupName) {
-
-  console.log('CLICKED !!!! file: ', resourceUrl)
   let fileName = resourceUrl.split('download/')[1];
-  console.log('this_file: ', fileName)
-  console.log('org_name: ', orgName)
-  console.log('pkg.title: ', pkgTitle)
-  console.log('groupName: ', groupName)
 
   if (groupName.length > 2) { 
     // clean = groupName.replaceAll('&#39;','"').replaceAll('u"','"');
@@ -25,7 +13,8 @@ function myFunction(resourceUrl, orgName, pkgTitle, groupName) {
     groupName = "TBD";
   } else {
     groupName = "";
-  }   
+  }
+  console.log('groupName after fix: ', groupName)
 
   window.dataLayer = window.dataLayer || [];
   window.dataLayer.push({
@@ -35,8 +24,4 @@ function myFunction(resourceUrl, orgName, pkgTitle, groupName) {
     'datasetName': pkgTitle,
     'dataResourceName': fileName
   });
-  
-
-  // Object.keys(myarray).forEach(key => console.log(myarray[key]));
-
 }

--- a/ckanext/ontario_theme/fanstatic/internal/ontario_theme_download_tracker.js
+++ b/ckanext/ontario_theme/fanstatic/internal/ontario_theme_download_tracker.js
@@ -5,7 +5,10 @@
 
 function trackDownload(resourceUrl, orgName, pkgTitle, groupName) {
 
-  let fileName = resourceUrl.split('download/')[1];
+  let fileName;
+  let urlArray;
+  urlArray = resourceUrl.split('/');
+  fileName = urlArray[urlArray.length - 1];
 
   window.dataLayer = window.dataLayer || [];
   window.dataLayer.push({

--- a/ckanext/ontario_theme/fanstatic/internal/ontario_theme_download_tracker.js
+++ b/ckanext/ontario_theme/fanstatic/internal/ontario_theme_download_tracker.js
@@ -10,12 +10,16 @@ function trackDownload(resourceUrl, orgName, pkgTitle, groupName) {
   urlArray = resourceUrl.split('/');
   fileName = urlArray[urlArray.length - 1];
 
+  // Set variables from the Pageview event to undefined
+  // to prevent them from being collected in GTM
   window.dataLayer = window.dataLayer || [];
   window.dataLayer.push({
     'event': 'File Download',
     'ministryTag': orgName,
     'group': groupName,
     'datasetName': pkgTitle,
-    'dataResourceName': fileName
+    'dataResourceName': fileName,
+    'dataAvailability': undefined,
+    'resourceName': undefined
   });
 }

--- a/ckanext/ontario_theme/fanstatic/internal/ontario_theme_download_tracker.js
+++ b/ckanext/ontario_theme/fanstatic/internal/ontario_theme_download_tracker.js
@@ -1,0 +1,42 @@
+// From: https://docs.ckan.org/en/2.9/theming/javascript.html
+// Calls the ckan.module() function to register a new JavaScript module with CKAN.
+// -------------------------------------------------------------------------------
+
+// Enable JavaScript's strict mode. Strict mode catches some common
+// programming errors and throws exceptions, prevents some unsafe actions from
+// being taken, and disables some confusing and bad JavaScript features.
+// "use strict";
+
+console.log('in module')
+
+
+function myFunction(resourceUrl, orgName, pkgTitle, groupName) {
+
+  console.log('CLICKED !!!! file: ', resourceUrl)
+  let fileName = resourceUrl.split('download/')[1];
+  console.log('this_file: ', fileName)
+  console.log('org_name: ', orgName)
+  console.log('pkg.title: ', pkgTitle)
+  console.log('groupName: ', groupName)
+
+  if (groupName.length > 2) { 
+    // clean = groupName.replaceAll('&#39;','"').replaceAll('u"','"');
+    // groupName = JSON.parse("[" + clean + "]")[0][0]['name'];
+    groupName = "TBD";
+  } else {
+    groupName = "";
+  }   
+
+  window.dataLayer = window.dataLayer || [];
+  window.dataLayer.push({
+    'event': 'File Download',
+    'ministryTag': orgName,
+    'group': groupName,
+    'datasetName': pkgTitle,
+    'dataResourceName': fileName
+  });
+  
+
+  // Object.keys(myarray).forEach(key => console.log(myarray[key]));
+
+}

--- a/ckanext/ontario_theme/fanstatic/internal/webassets.yml
+++ b/ckanext/ontario_theme/fanstatic/internal/webassets.yml
@@ -18,3 +18,11 @@ ontario_theme_lock_if_odc_js:
   extra:
     preload:
       - vendor/jquery
+
+ontario_theme_download_tracker_js:
+  filters: rjsmin
+  contents: ontario_theme_download_tracker.js
+  output: ontario_theme/%(version)s_ontario_theme_download_tracker.js
+  extra:
+    preload:
+      - vendor/jquery

--- a/ckanext/ontario_theme/templates/internal/base.html
+++ b/ckanext/ontario_theme/templates/internal/base.html
@@ -11,13 +11,18 @@
   {% if pkg %}
     {% if pkg.organization %}
       {% set this_org = h.get_translated(pkg.organization, 'title') or pkg.organization.name %}
+      {% if pkg.groups %}
+        {% set this_group = pkg.groups[0]['name'] %}
+      {% else %}
+        {% set this_group = '' %}
+      {% endif %}
       {% set this_pkg = pkg %}
       {% if res %}
         {% set this_res = res %}
       {% endif %}
     {% endif %}
   {% endif %}  
-  {% snippet "gtm_pageview.html", this_pkg=this_pkg, this_org=this_org, this_res=this_res %}
+  {% snippet "gtm_pageview.html", this_pkg=this_pkg, this_org=this_org, this_group=this_group, this_res=this_res %}
 
 
 {% endblock %}

--- a/ckanext/ontario_theme/templates/internal/gtm_pageview.html
+++ b/ckanext/ontario_theme/templates/internal/gtm_pageview.html
@@ -1,8 +1,6 @@
 <script>
     window.dataLayer = window.dataLayer || [];
 
-    groupName = '';
-
     // Only resource views have a resourceName
     if ('{{this_res}}'.length > 0) {
         // Even if a resource exists, it might not have a name.
@@ -16,16 +14,10 @@
 
     // Pushed when a dataset page or a resource page is viewed
     if ('{{this_pkg}}'.length > 0) {
-        // Check that {{this_pkg.groups}} is not '[]'; i.e. has length > 2
-        if ('{{this_pkg.groups}}'.length > 2) { 
-		    result = '{{this_pkg.groups}}';
-		    clean = result.replaceAll('&#39;','"').replaceAll('u"','"');
-            groupName = JSON.parse("[" + clean + "]")[0][0]['name'];
-	    }   
         window.dataLayer.push({
             'event': 'Pageview',
             'ministryTag': '{{this_org}}',
-            'group': groupName,
+            'group': '{{this_group}}',
             'dataAvailability': '{{this_pkg.access_level}}',
             'datasetName': '{{this_pkg.title}}',
             'resourceName': resourceName

--- a/ckanext/ontario_theme/templates/internal/package/resource_read.html
+++ b/ckanext/ontario_theme/templates/internal/package/resource_read.html
@@ -24,10 +24,10 @@
   {% endif %}
   {% if res.url and h.is_url(res.url) %}
     {% set this_org = h.get_translated(pkg.organization, 'title') or pkg.organization.name %}
-      {% if pkg.groups %}
-        {% set this_group = pkg.groups[0]['name'] %}
-      {% else %}
-        {% set this_group = '' %}
+    {% if pkg.groups %}
+      {% set this_group = pkg.groups[0]['name'] %}
+    {% else %}
+      {% set this_group = '' %}
     {% endif %}
     <li>
       <div class="btn-group">

--- a/ckanext/ontario_theme/templates/internal/package/resource_read.html
+++ b/ckanext/ontario_theme/templates/internal/package/resource_read.html
@@ -1,8 +1,11 @@
 {% ckan_extends %}
 
 {% block resource_read_url %}
+  {% asset 'ontario_theme/ontario_theme_download_tracker_js' %}
+  {% set this_org = h.get_translated(pkg.organization, 'title') or pkg.organization.name %}
   {% if res.url and h.is_url(res.url) %}
-    <p class="text-muted ellipsis">{{ _('URL:') }} <a class="resource-url-analytics dataset-download-link" href="{{ res.url }}" title="{{ res.url }}">{{ res.url }}</a></p>
+    {# Download link URL on resource page #}
+    <p class="text-muted ellipsis">{{ _('URL:') }} <a class="resource-url-analytics dataset-download-link" href="{{ res.url }}" title="{{ res.url }}" onclick="myFunction('{{ res.url }}', '{{ this_org }}', '{{ pkg.title }}', '{{ pkg.groups }}');return true;">{{ res.url }}</a></p>
   {% elif res.url %}
     <p class="text-muted break-word">{{ _('URL:') }} {{ res.url }}</p>
   {% endif %}
@@ -10,44 +13,46 @@
 {% endblock %}
 
 {% block resource_actions_inner %}
-{% if h.check_access('package_update', {'id':pkg.id }) %}
-  <li>{% link_for _('Edit'), named_route=pkg.type + '_resource.edit', id=pkg.name, resource_id=res.id, class_='btn btn-default', icon='wrench' %}</li>
-{% endif %}
-{% if res.url and h.is_url(res.url) %}
-  <li>
-    <div class="btn-group">
-    <a class="btn btn-primary dataset-download-link resource-url-analytics resource-type-{{ res.resource_type }}" href="{{ res.url }}">
-      {% if res.resource_type in ('listing', 'service') %}
-        <i class="fa fa-eye"></i> {{ _('View') }}
-      {% elif  res.resource_type == 'api' %}
-        <i class="fa fa-key"></i> {{ _('API Endpoint') }}
-      {% elif (not res.has_views or not res.can_be_previewed) and not res.url_type == 'upload' %}
-        <i class="fa fa-external-link"></i> {{ _('Open') }}
-      {% else %}
-        <i class="fa fa-arrow-circle-o-down"></i> {{ _('Download') }}
-      {% endif %}
-    </a>
-     {% block download_resource_button %}
-      {%if res.datastore_active %}
-    <button class="btn btn-primary dropdown-toggle" data-toggle="dropdown">
-        <span class="caret"></span>
-      </button>
-    <ul class="dropdown-menu">
-      <li>
-        <a class="dataset-download-link" href="{{ h.url_for('datastore.dump', resource_id=res.id, bom=True) }}"
-          target="_blank"><span>CSV</span></a>
-        <a class="dataset-download-link" href="{{ h.url_for('datastore.dump', resource_id=res.id, format='tsv', bom=True) }}"
-          target="_blank"><span>TSV</span></a>
-        <a class="dataset-download-link" href="{{ h.url_for('datastore.dump', resource_id=res.id, format='json') }}"
-          target="_blank"><span>JSON</span></a>
-        <a class="dataset-download-link" href="{{ h.url_for('datastore.dump', resource_id=res.id, format='xml') }}"
-          target="_blank"><span>XML</span></a>
-      </li>
-    </ul>
-    {%endif%} {% endblock %}
-    </div>
-  </li>
-{% endif %}
+  {% asset 'ontario_theme/ontario_theme_download_tracker_js' %}
+  {% if h.check_access('package_update', {'id':pkg.id }) %}
+    <li>{% link_for _('Edit'), named_route=pkg.type + '_resource.edit', id=pkg.name, resource_id=res.id, class_='btn btn-default', icon='wrench' %}</li>
+  {% endif %}
+  {% if res.url and h.is_url(res.url) %}
+    <li>
+      <div class="btn-group">
+        <a class="btn btn-primary dataset-download-link resource-url-analytics resource-type-{{ res.resource_type }}" href="{{ res.url }}">
+          {% if res.resource_type in ('listing', 'service') %}
+            <i class="fa fa-eye"></i> {{ _('View') }}
+          {% elif  res.resource_type == 'api' %}
+            <i class="fa fa-key"></i> {{ _('API Endpoint') }}
+          {% elif (not res.has_views or not res.can_be_previewed) and not res.url_type == 'upload' %}
+            <i class="fa fa-external-link"></i> {{ _('Open') }}
+          {% else %}
+            <i class="fa fa-arrow-circle-o-down"></i> {{ _('Download') }}
+          {% endif %}
+        </a>
+        {% block download_resource_button %}
+          {%if res.datastore_active %}
+            <button class="btn btn-primary dropdown-toggle" data-toggle="dropdown">
+              <span class="caret"></span>
+            </button>
+            <ul class="dropdown-menu">
+              <li>
+                <a class="dataset-download-link" href="{{ h.url_for('datastore.dump', resource_id=res.id, bom=True) }}"
+                  target="_blank"><span>CSV</span></a>
+                <a class="dataset-download-link" href="{{ h.url_for('datastore.dump', resource_id=res.id, format='tsv', bom=True) }}"
+                  target="_blank"><span>TSV</span></a>
+                <a class="dataset-download-link" href="{{ h.url_for('datastore.dump', resource_id=res.id, format='json') }}"
+                  target="_blank"><span>JSON</span></a>
+                <a class="dataset-download-link" href="{{ h.url_for('datastore.dump', resource_id=res.id, format='xml') }}"
+                  target="_blank"><span>XML</span></a>
+              </li>
+            </ul>
+          {%endif%}
+        {% endblock %}
+      </div>
+    </li>
+  {% endif %}
 {% endblock %}
 
 {% block data_preview %}

--- a/ckanext/ontario_theme/templates/internal/package/resource_read.html
+++ b/ckanext/ontario_theme/templates/internal/package/resource_read.html
@@ -3,9 +3,14 @@
 {% block resource_read_url %}
   {% asset 'ontario_theme/ontario_theme_download_tracker_js' %}
   {% set this_org = h.get_translated(pkg.organization, 'title') or pkg.organization.name %}
+  {% if pkg.groups %}
+    {% set this_group = pkg.groups[0]['name'] %}
+  {% else %}
+    {% set this_group = '' %}
+  {% endif %}
   {% if res.url and h.is_url(res.url) %}
     {# Download link URL on resource page #}
-    <p class="text-muted ellipsis">{{ _('URL:') }} <a class="resource-url-analytics dataset-download-link" href="{{ res.url }}" title="{{ res.url }}" onclick="trackDownload('{{ res.url }}', '{{ this_org }}', '{{ pkg.title }}', '{{ pkg.groups }}');return true;">{{ res.url }}</a></p>
+    <p class="text-muted ellipsis">{{ _('URL:') }} <a class="resource-url-analytics dataset-download-link" href="{{ res.url }}" title="{{ res.url }}" onclick="trackDownload('{{ res.url }}', '{{ this_org }}', '{{ pkg.title }}', '{{ this_group }}');return true;">{{ res.url }}</a></p>
   {% elif res.url %}
     <p class="text-muted break-word">{{ _('URL:') }} {{ res.url }}</p>
   {% endif %}
@@ -18,9 +23,15 @@
     <li>{% link_for _('Edit'), named_route=pkg.type + '_resource.edit', id=pkg.name, resource_id=res.id, class_='btn btn-default', icon='wrench' %}</li>
   {% endif %}
   {% if res.url and h.is_url(res.url) %}
+    {% set this_org = h.get_translated(pkg.organization, 'title') or pkg.organization.name %}
+      {% if pkg.groups %}
+        {% set this_group = pkg.groups[0]['name'] %}
+      {% else %}
+        {% set this_group = '' %}
+    {% endif %}
     <li>
       <div class="btn-group">
-        <a class="btn btn-primary dataset-download-link resource-url-analytics resource-type-{{ res.resource_type }}" href="{{ res.url }}" onclick="trackDownload('{{ res.url }}', '{{ this_org }}', '{{ pkg.title }}', '{{ pkg.groups }}');return true;">
+        <a class="btn btn-primary dataset-download-link resource-url-analytics resource-type-{{ res.resource_type }}" href="{{ res.url }}" onclick="trackDownload('{{ res.url }}', '{{ this_org }}', '{{ pkg.title }}', '{{ this_group }}');return true;">
           {% if res.resource_type in ('listing', 'service') %}
             <i class="fa fa-eye"></i> {{ _('View') }}
           {% elif  res.resource_type == 'api' %}
@@ -40,13 +51,13 @@
             <ul class="dropdown-menu">
               <li>
                 <a class="dataset-download-link" href="{{ h.url_for('datastore.dump', resource_id=res.id, bom=True) }}"
-                  target="_blank" onclick="trackDownload('{{ res.url }}', '{{ this_org }}', '{{ pkg.title }}', '{{ pkg.groups }}');return true;"> <span>CSV</span></a>
+                  target="_blank" onclick="trackDownload('{{ res.url }}', '{{ this_org }}', '{{ pkg.title }}', '{{ this_group }}');return true;"> <span>CSV</span></a>
                 <a class="dataset-download-link" href="{{ h.url_for('datastore.dump', resource_id=res.id, format='tsv', bom=True) }}"
-                  target="_blank" onclick="trackDownload('{{ res.url }}', '{{ this_org }}', '{{ pkg.title }}', '{{ pkg.groups }}');return true;"><span>TSV</span></a>
+                  target="_blank" onclick="trackDownload('{{ res.url }}', '{{ this_org }}', '{{ pkg.title }}', '{{ this_group }}');return true;"><span>TSV</span></a>
                 <a class="dataset-download-link" href="{{ h.url_for('datastore.dump', resource_id=res.id, format='json') }}"
-                  target="_blank" onclick="trackDownload('{{ res.url }}', '{{ this_org }}', '{{ pkg.title }}', '{{ pkg.groups }}');return true;"><span>JSON</span></a>
+                  target="_blank" onclick="trackDownload('{{ res.url }}', '{{ this_org }}', '{{ pkg.title }}', '{{ this_group }}');return true;"><span>JSON</span></a>
                 <a class="dataset-download-link" href="{{ h.url_for('datastore.dump', resource_id=res.id, format='xml') }}"
-                  target="_blank" onclick="trackDownload('{{ res.url }}', '{{ this_org }}', '{{ pkg.title }}', '{{ pkg.groups }}');return true;"><span>XML</span></a>
+                  target="_blank" onclick="trackDownload('{{ res.url }}', '{{ this_org }}', '{{ pkg.title }}', '{{ this_group }}');return true;"><span>XML</span></a>
               </li>
             </ul>
           {%endif%}

--- a/ckanext/ontario_theme/templates/internal/package/resource_read.html
+++ b/ckanext/ontario_theme/templates/internal/package/resource_read.html
@@ -5,7 +5,7 @@
   {% set this_org = h.get_translated(pkg.organization, 'title') or pkg.organization.name %}
   {% if res.url and h.is_url(res.url) %}
     {# Download link URL on resource page #}
-    <p class="text-muted ellipsis">{{ _('URL:') }} <a class="resource-url-analytics dataset-download-link" href="{{ res.url }}" title="{{ res.url }}" onclick="myFunction('{{ res.url }}', '{{ this_org }}', '{{ pkg.title }}', '{{ pkg.groups }}');return true;">{{ res.url }}</a></p>
+    <p class="text-muted ellipsis">{{ _('URL:') }} <a class="resource-url-analytics dataset-download-link" href="{{ res.url }}" title="{{ res.url }}" onclick="trackDownload('{{ res.url }}', '{{ this_org }}', '{{ pkg.title }}', '{{ pkg.groups }}');return true;">{{ res.url }}</a></p>
   {% elif res.url %}
     <p class="text-muted break-word">{{ _('URL:') }} {{ res.url }}</p>
   {% endif %}
@@ -20,7 +20,7 @@
   {% if res.url and h.is_url(res.url) %}
     <li>
       <div class="btn-group">
-        <a class="btn btn-primary dataset-download-link resource-url-analytics resource-type-{{ res.resource_type }}" href="{{ res.url }}" onclick="myFunction('{{ res.url }}', '{{ this_org }}', '{{ pkg.title }}', '{{ pkg.groups }}');return true;">
+        <a class="btn btn-primary dataset-download-link resource-url-analytics resource-type-{{ res.resource_type }}" href="{{ res.url }}" onclick="trackDownload('{{ res.url }}', '{{ this_org }}', '{{ pkg.title }}', '{{ pkg.groups }}');return true;">
           {% if res.resource_type in ('listing', 'service') %}
             <i class="fa fa-eye"></i> {{ _('View') }}
           {% elif  res.resource_type == 'api' %}
@@ -40,13 +40,13 @@
             <ul class="dropdown-menu">
               <li>
                 <a class="dataset-download-link" href="{{ h.url_for('datastore.dump', resource_id=res.id, bom=True) }}"
-                  target="_blank" onclick="myFunction('{{ res.url }}', '{{ this_org }}', '{{ pkg.title }}', '{{ pkg.groups }}');return true;"> <span>CSV</span></a>
+                  target="_blank" onclick="trackDownload('{{ res.url }}', '{{ this_org }}', '{{ pkg.title }}', '{{ pkg.groups }}');return true;"> <span>CSV</span></a>
                 <a class="dataset-download-link" href="{{ h.url_for('datastore.dump', resource_id=res.id, format='tsv', bom=True) }}"
-                  target="_blank" onclick="myFunction('{{ res.url }}', '{{ this_org }}', '{{ pkg.title }}', '{{ pkg.groups }}');return true;"><span>TSV</span></a>
+                  target="_blank" onclick="trackDownload('{{ res.url }}', '{{ this_org }}', '{{ pkg.title }}', '{{ pkg.groups }}');return true;"><span>TSV</span></a>
                 <a class="dataset-download-link" href="{{ h.url_for('datastore.dump', resource_id=res.id, format='json') }}"
-                  target="_blank" onclick="myFunction('{{ res.url }}', '{{ this_org }}', '{{ pkg.title }}', '{{ pkg.groups }}');return true;"><span>JSON</span></a>
+                  target="_blank" onclick="trackDownload('{{ res.url }}', '{{ this_org }}', '{{ pkg.title }}', '{{ pkg.groups }}');return true;"><span>JSON</span></a>
                 <a class="dataset-download-link" href="{{ h.url_for('datastore.dump', resource_id=res.id, format='xml') }}"
-                  target="_blank" onclick="myFunction('{{ res.url }}', '{{ this_org }}', '{{ pkg.title }}', '{{ pkg.groups }}');return true;"><span>XML</span></a>
+                  target="_blank" onclick="trackDownload('{{ res.url }}', '{{ this_org }}', '{{ pkg.title }}', '{{ pkg.groups }}');return true;"><span>XML</span></a>
               </li>
             </ul>
           {%endif%}

--- a/ckanext/ontario_theme/templates/internal/package/resource_read.html
+++ b/ckanext/ontario_theme/templates/internal/package/resource_read.html
@@ -20,7 +20,7 @@
   {% if res.url and h.is_url(res.url) %}
     <li>
       <div class="btn-group">
-        <a class="btn btn-primary dataset-download-link resource-url-analytics resource-type-{{ res.resource_type }}" href="{{ res.url }}">
+        <a class="btn btn-primary dataset-download-link resource-url-analytics resource-type-{{ res.resource_type }}" href="{{ res.url }}" onclick="myFunction('{{ res.url }}', '{{ this_org }}', '{{ pkg.title }}', '{{ pkg.groups }}');return true;">
           {% if res.resource_type in ('listing', 'service') %}
             <i class="fa fa-eye"></i> {{ _('View') }}
           {% elif  res.resource_type == 'api' %}
@@ -32,6 +32,7 @@
           {% endif %}
         </a>
         {% block download_resource_button %}
+          {% set this_org = h.get_translated(pkg.organization, 'title') or pkg.organization.name %}
           {%if res.datastore_active %}
             <button class="btn btn-primary dropdown-toggle" data-toggle="dropdown">
               <span class="caret"></span>
@@ -39,13 +40,13 @@
             <ul class="dropdown-menu">
               <li>
                 <a class="dataset-download-link" href="{{ h.url_for('datastore.dump', resource_id=res.id, bom=True) }}"
-                  target="_blank"><span>CSV</span></a>
+                  target="_blank" onclick="myFunction('{{ res.url }}', '{{ this_org }}', '{{ pkg.title }}', '{{ pkg.groups }}');return true;"> <span>CSV</span></a>
                 <a class="dataset-download-link" href="{{ h.url_for('datastore.dump', resource_id=res.id, format='tsv', bom=True) }}"
-                  target="_blank"><span>TSV</span></a>
+                  target="_blank" onclick="myFunction('{{ res.url }}', '{{ this_org }}', '{{ pkg.title }}', '{{ pkg.groups }}');return true;"><span>TSV</span></a>
                 <a class="dataset-download-link" href="{{ h.url_for('datastore.dump', resource_id=res.id, format='json') }}"
-                  target="_blank"><span>JSON</span></a>
+                  target="_blank" onclick="myFunction('{{ res.url }}', '{{ this_org }}', '{{ pkg.title }}', '{{ pkg.groups }}');return true;"><span>JSON</span></a>
                 <a class="dataset-download-link" href="{{ h.url_for('datastore.dump', resource_id=res.id, format='xml') }}"
-                  target="_blank"><span>XML</span></a>
+                  target="_blank" onclick="myFunction('{{ res.url }}', '{{ this_org }}', '{{ pkg.title }}', '{{ pkg.groups }}');return true;"><span>XML</span></a>
               </li>
             </ul>
           {%endif%}

--- a/ckanext/ontario_theme/templates/internal/package/snippets/resource_item.html
+++ b/ckanext/ontario_theme/templates/internal/package/snippets/resource_item.html
@@ -64,7 +64,7 @@
           {% if res.url and h.is_url(res.url) %}
             {% asset 'ontario_theme/ontario_theme_download_tracker_js' %}
             {% set this_org = h.get_translated(pkg.organization, 'title') or pkg.organization.name %}
-            <a href="{{ res.url }}" class="resource-url-analytics btn btn-primary dataset-download-link" target="_blank" onclick="myFunction('{{ res.url }}', '{{ this_org }}', '{{ pkg.title }}', '{{ pkg.groups }}');return true;">
+            <a href="{{ res.url }}" class="resource-url-analytics btn btn-primary dataset-download-link" target="_blank" onclick="trackDownload('{{ res.url }}', '{{ this_org }}', '{{ pkg.title }}', '{{ pkg.groups }}');return true;">
               {% if res.has_views or res.url_type == 'upload' %}
                 <i class="fa fa-arrow-circle-o-down"></i>
                 {{ _('Download') }}

--- a/ckanext/ontario_theme/templates/internal/package/snippets/resource_item.html
+++ b/ckanext/ontario_theme/templates/internal/package/snippets/resource_item.html
@@ -62,7 +62,9 @@
               {% endif %}
             </a>
           {% if res.url and h.is_url(res.url) %}
-            <a href="{{ res.url }}" class="resource-url-analytics btn btn-primary dataset-download-link" target="_blank">
+            {% asset 'ontario_theme/ontario_theme_download_tracker_js' %}
+            {% set this_org = h.get_translated(pkg.organization, 'title') or pkg.organization.name %}
+            <a href="{{ res.url }}" class="resource-url-analytics btn btn-primary dataset-download-link" target="_blank" onclick="myFunction('{{ res.url }}', '{{ this_org }}', '{{ pkg.title }}', '{{ pkg.groups }}');return true;">
               {% if res.has_views or res.url_type == 'upload' %}
                 <i class="fa fa-arrow-circle-o-down"></i>
                 {{ _('Download') }}

--- a/ckanext/ontario_theme/templates/internal/package/snippets/resource_item.html
+++ b/ckanext/ontario_theme/templates/internal/package/snippets/resource_item.html
@@ -64,7 +64,12 @@
           {% if res.url and h.is_url(res.url) %}
             {% asset 'ontario_theme/ontario_theme_download_tracker_js' %}
             {% set this_org = h.get_translated(pkg.organization, 'title') or pkg.organization.name %}
-            <a href="{{ res.url }}" class="resource-url-analytics btn btn-primary dataset-download-link" target="_blank" onclick="trackDownload('{{ res.url }}', '{{ this_org }}', '{{ pkg.title }}', '{{ pkg.groups }}');return true;">
+            {% if pkg.groups %}
+              {% set this_group = pkg.groups[0]['name'] %}
+            {% else %}
+              {% set this_group = '' %}
+            {% endif %}
+            <a href="{{ res.url }}" class="resource-url-analytics btn btn-primary dataset-download-link" target="_blank" onclick="trackDownload('{{ res.url }}', '{{ this_org }}', '{{ pkg.title }}', '{{ this_group }}');return true;">
               {% if res.has_views or res.url_type == 'upload' %}
                 <i class="fa fa-arrow-circle-o-down"></i>
                 {{ _('Download') }}


### PR DESCRIPTION
## What this PR accomplishes
Implements a new JS function `trackDownload()` that is triggered every time a download button or download URL is clicked. The dataLayer object is sent to Google analytics for further processing.

This PR is the CKAN 2.9 version of PR #244 (CKAN 2.8). The main difference is how assets are defined. In CKAN 2.9, assets are defined with `{% asset %}` tags in the view templates, and they need to be included in the `ckanext/ontario_theme/fanstatic/internal/webassets.yml` file.

## Issue addressed
- #243
- small fix in passing group  name for #237 in `ckanext/ontario_theme/templates/internal/base.html` and `ckanext/ontario_theme/templates/internal/gtm_pageview.html`)

## What needs review
As in PR #244, the reviewer here can generally review the code.  The CKAN docs suggest creating a [JS module](https://docs.ckan.org/en/2.9/contributing/frontend/javascript-module-tutorial.html#building-a-javascript-module), but `ckan.module` was not recognized and as an alternative, an ordinary JS function was created instead. 