### PR TITLE
Adds Ontario Forest Region geo breakdown for ckan2.8

### DIFF
--- a/ckanext/ontario_theme/schemas/external/ontario_theme_dataset.json
+++ b/ckanext/ontario_theme/schemas/external/ontario_theme_dataset.json
@@ -205,6 +205,13 @@
             "en": "Forward Sortation Area",
             "fr": "régions de tri d’acheminement"
           }
+        },
+	 {
+          "value": "ofa",
+          "label": {
+            "en": "Ontario Forest Region",
+            "fr": "régions forestières de l'Ontario"
+          }
         }
       ]
     }, 

--- a/ckanext/ontario_theme/schemas/internal/ontario_theme_dataset.json
+++ b/ckanext/ontario_theme/schemas/internal/ontario_theme_dataset.json
@@ -223,6 +223,13 @@
             "en": "Forward Sortation Area",
             "fr": "régions de tri d’acheminement"
           }
+        },
+	 {
+          "value": "ofa",
+          "label": {
+            "en": "Ontario Forest Region",
+            "fr": "régions forestières de l'Ontario"
+          }
         }
       ]
     }, 


### PR DESCRIPTION
Same as PR #250 but for CKAN 2.8.
Code change is identical, but includes for internal schema as well.