### PR TITLE
preload main.js in ontario_theme_lock_if_odc.js module. Closes #246

### DIFF
--- a/ckanext/ontario_theme/fanstatic/internal/webassets.yml
+++ b/ckanext/ontario_theme/fanstatic/internal/webassets.yml
@@ -23,6 +23,7 @@ ontario_theme_lock_if_odc_js:
   extra:
     preload:
       - vendor/jquery
+      - base/main
 
 ontario_theme_download_tracker_js:
   filters: rjsmin


### PR DESCRIPTION
## What this PR accomplishes
Error "Uncaught ReferenceError: ckan is not defined" is no longer displayed in the console when the Edit button of a package is clicked. See details: https://github.com/ongov/ckanext-ontario_theme/issues/246

## Issue addressed
#246 

## What needs review
Please verify that 
- the error no longer displays in the console when clicking on the Edit button of a package
- `main.js` is getting loaded prior to `ontario_theme_lock_if_odc.js` in the network tab