### PR TITLE
Aligns homepage to Figma.

### DIFF
--- a/ckanext/ontario_theme/fanstatic/common.css
+++ b/ckanext/ontario_theme/fanstatic/common.css
@@ -90,7 +90,7 @@
   font-size: 20px;
   font-weight: 600;
   margin-top: 10px;
-  margin-bottom: 10px;
+  margin-bottom: 19px;
   line-height: 25.6px;
 }
 /* fa and feedback classes can be removed once icon is replaced with a svg */
@@ -103,7 +103,13 @@
   width:100px;
   margin-left: 3rem;
 }
-@media screen and (max-width: 40em){
+.feedback.ontario-alert__body {
+  max-width: unset;
+  margin-left: 1rem;
+  padding-top: 22px;
+}
+
+@media screen and (max-width: 992px){
   .fa.fa-comments{
       font-size: 80px;
   }
@@ -115,15 +121,11 @@
   .feedback.ontario-alert__body h2{
     margin-top: unset;
   }
+  .feedback.ontario-alert__body {
+    padding-top: unset;
+  }
 }
 .feedback.ontario-alert {
   display: flex;
   min-height: 198px;
-}
-.feedback.ontario-alert__body {
-  max-width: unset;
-  margin-left: 1rem;
-}
-.feedback.ontario-alert__body p{
-  padding-top: 1rem;
 }

--- a/ckanext/ontario_theme/fanstatic/external/ontario_theme.css
+++ b/ckanext/ontario_theme/fanstatic/external/ontario_theme.css
@@ -635,7 +635,7 @@ div#topics {
 div#topics a {
   color: #1A1A1A;
 }
-div#topics div {
+.hp_category {
   text-align: center;
 }
 div#topics div p {
@@ -1027,7 +1027,7 @@ section.additional-info table.table tbody tr td.dataset-details {
   border: none;
 }
 .banner-datasets {
-  padding-left: 20px;
+  padding-left: 25px;
 }
 .banner-section {
   background: #F2F2F2;
@@ -1241,4 +1241,10 @@ footer.site-footer div.footer-swoosh--right {
 }
 footer.site-footer .ckan-footer-logo {
   background: url(/base/images/ckan-logo-footer_dark.png) no-repeat top left;
+}
+#resources_and_information {
+  margin-top: 51px;
+}
+#resources_and_information h2{
+  margin-bottom: 34px;
 }

--- a/ckanext/ontario_theme/templates/external/home/snippets/ontario_theme_resources_and_information.html
+++ b/ckanext/ontario_theme/templates/external/home/snippets/ontario_theme_resources_and_information.html
@@ -7,41 +7,41 @@
 </div>
 <div class="row">
   <div class="col-md-3">
-    <h4 class="data-h4">
+    <h3 class="data-h4">
       <a href="{% trans %}https://www.ontario.ca/page/sharing-government-data{% endtrans %}">
         {% trans %}What's Open Data?{% endtrans %}
       </a>
-    </h4>
+    </h3>
     <p>
       {% trans %}Learn about Open Data and the Ontario Data Catalogue.{% endtrans %}
     </p>
   </div>
   <div class="col-md-3">
-    <h4 class="data-h4">
+    <h3 class="data-h4">
       <a href="/{{ request.environ.CKAN_LANG }}/about#licensing">
         {% trans %}Licences and Using Data{% endtrans %}
       </a>
-    </h4>
+    </h3>
     <p>
       {% trans %}Learn about the conditions and terms of use for using data.{% endtrans %}
     </p>
   </div>
   <div class="col-md-3">
-    <h4 class="data-h4">
+    <h3 class="data-h4">
       <a href="/{{ request.environ.CKAN_LANG }}/about#developers">
         {% trans %}Developers{% endtrans %}
       </a>
-    </h4>
+    </h3>
     <p>
       {% trans %}If you are using the catalogue in a software application.{% endtrans %}
     </p>
   </div>
   <div class="col-md-3">
-    <h4 class="data-h4">
+    <h3 class="data-h4">
       <a href="/{{ request.environ.CKAN_LANG }}/about#training-materials">
         {% trans %}Training Materials{% endtrans %}
       </a>
-    </h4>
+    </h3>
     <p>
       {% trans %}Learn to work with government data.{% endtrans %}
     </p>

--- a/ckanext/ontario_theme/templates/internal/home/layout3.html
+++ b/ckanext/ontario_theme/templates/internal/home/layout3.html
@@ -41,11 +41,11 @@
   <div id="news" class="container">
     <div class="row homepage-section">
       <div class="col-md-6 dataset-list">
-        <h3>{{ _("Most popular datasets") }}</h3>
+        <h2>{{ _("Most popular datasets") }}</h2>
         {% snippet 'home/snippets/ontario_theme_popular_datasets.html' %}
       </div>
       <div class="col-md-6 dataset-list">
-        <h3>{{ _("COVID datasets") }}</h3>
+        <h2>{{ _("COVID datasets") }}</h2>
         {% snippet 'home/snippets/ontario_theme_covid_datasets.html' %}
       </div>
     </div>


### PR DESCRIPTION
## What this PR accomplishes

- Aligns homepage to Figma

## Issue(s) addressed

- Left-aligns 'Topics'
- Removes padding from page alert
- Adds margins to "Resources and information"
- Change dataset headings to `h2`
- Change "Resources and information" subheadings to `h3`

## What needs review

- Homepage is responsive
- Homepage follows the Figma design