### PR TITLE
Ckan 2.9 name sort

### DIFF
--- a/ckanext/ontario_theme/templates/internal/group/index.html
+++ b/ckanext/ontario_theme/templates/internal/group/index.html
@@ -26,7 +26,7 @@
     {% set type = 'group' %}
     {% set searchbar_title = _('Search groups') + _(':') %}
     {% set hidden_searchbar_title = _('Search groups') %}
-    {% snippet 'snippets/search_form.html', searchbar_title=searchbar_title, hidden_searchbar_title=hidden_searchbar_title, form_id=form_id, type=type, query=query, sorting_selected=c.sort_by_selected, count=c.page.item_count, placeholder=placeholder, sr_input_text=sr_input_text, sr_submit_text=sr_submit_text, show_empty=request.params, no_bottom_border=true if c.page.items, sorting = [(_('Name Ascending'), 'title asc'), (_('Name Descending'), 'title desc')] %}
+    {% snippet 'snippets/search_form.html', searchbar_title=searchbar_title, hidden_searchbar_title=hidden_searchbar_title, form_id=form_id, type=type, query=query, sorting_selected=c.sort_by_selected, count=c.page.item_count, placeholder=placeholder, sr_input_text=sr_input_text, sr_submit_text=sr_submit_text, show_empty=request.params, no_bottom_border=true if c.page.items, sorting = [(_('Name Ascending'), 'name asc'), (_('Name Descending'), 'name desc')] %}
   {% endblock %}
 {% endblock %}
 

--- a/ckanext/ontario_theme/templates/internal/group/read.html
+++ b/ckanext/ontario_theme/templates/internal/group/read.html
@@ -8,6 +8,23 @@ block. super() will end up calling the facets twice.
 #}
 
 {% ckan_extends %}
+{% block groups_search_form %}
+  {% set facets = {
+    'fields': fields_grouped,
+    'search': search_facets,
+    'titles': facet_titles,
+    'translated_fields': translated_fields,
+    'remove_field': remove_field }
+  %}
+  {% set sorting = [
+    (_('Relevance'), 'score desc, metadata_modified desc'),
+    (_('Name Ascending'), 'name asc'),
+    (_('Name Descending'), 'name desc'),
+    (_('Last Modified'), 'metadata_modified desc'),
+    (_('Popular'), 'views_recent desc') if g.tracking_enabled else (false, false) ]
+  %}
+  {% snippet 'snippets/search_form.html', form_id='group-datasets-search-form', type='dataset', query=q, sorting=sorting, sorting_selected=sort_by_selected, count=page.item_count, facets=facets, placeholder=_('Search datasets'), show_empty=request.params, fields=fields %}
+{% endblock %}
 
 {% block secondary_content %}
   {% snippet "group/snippets/info.html", group=c.group_dict, show_nums=true %}

--- a/ckanext/ontario_theme/templates/internal/organization/read.html
+++ b/ckanext/ontario_theme/templates/internal/organization/read.html
@@ -6,6 +6,24 @@ Override CKAN's read.html to add some new facets.
 
 {% ckan_extends %}
 
+{% block groups_search_form %}
+  {% set facets = {
+    'fields': fields_grouped,
+    'search': search_facets,
+    'titles': facet_titles,
+    'translated_fields': translated_fields,
+    'remove_field': remove_field }
+  %}
+  {% set sorting = [
+    (_('Relevance'), 'score desc, metadata_modified desc'),
+    (_('Name Ascending'), 'name asc'),
+    (_('Name Descending'), 'tname desc'),
+    (_('Last Modified'), 'metadata_modified desc'),
+    (_('Popular'), 'views_recent desc') if g.tracking_enabled else (false, false) ]
+  %}
+  {% snippet 'snippets/search_form.html', form_id='organization-datasets-search-form', type='dataset', query=q, sorting=sorting, sorting_selected=sort_by_selected, count=page.item_count, facets=facets, placeholder=_('Search datasets...'), show_empty=request.params, fields=fields %}
+{% endblock %}
+
 {% block organization_facets %}
   <div class="filters">
     <div>

--- a/ckanext/ontario_theme/templates/internal/package/search.html
+++ b/ckanext/ontario_theme/templates/internal/package/search.html
@@ -29,8 +29,8 @@ in the core template for search.html.
       %}
       {% set sorting = [
         (_('Relevance'), 'score desc, metadata_modified desc'),
-        (_('Name Ascending'), 'title_string asc'),
-        (_('Name Descending'), 'title_string desc'),
+        (_('Name Ascending'), 'name asc'),
+        (_('Name Descending'), 'name desc'),
         (_('Last Modified'), 'metadata_modified desc'),
         (_('Recently Created'), 'dataset_published_date desc'),
         (_('Datasets With Data'), 'num_resources desc, metadata_modified desc'),


### PR DESCRIPTION
## What this PR accomplishes

- Replaces `title_string` in filter query to `name` in the datasets search page and individual group and organization pages

## Issue(s) addressed

- Broken sorting methods on Organizations and Datasets pages
- Both “Name ascending” and “Name descending” methods only show some ministries and datasets in alphabetical order, some not sorted properly.

## What needs review

- Name ascending and name descending sort works correctly on organizations and datasets search pages. 
- Name ascending and name descending sort works correctly on organizations and group individual pages.