### PR TITLE
heading levels for individual dataset page

### DIFF
--- a/ckanext/ontario_theme/fanstatic/common.css
+++ b/ckanext/ontario_theme/fanstatic/common.css
@@ -424,6 +424,12 @@ a:focus {
 .media-item:last-child{
   border-bottom: none;
 }
+.ontario-module-h3 {
+  font-size: 18px;
+  line-height: 1.3;
+  word-break: break-word;
+  hyphens: auto;
+}
 /* ========================================================================
    Custom overrides - individual pages
    ======================================================================== */

--- a/ckanext/ontario_theme/fanstatic/common.css
+++ b/ckanext/ontario_theme/fanstatic/common.css
@@ -433,6 +433,48 @@ a:focus {
 /* ========================================================================
    Custom overrides - individual pages
    ======================================================================== */
-.embedded-content h2 {
+/* .embedded-content h2 {
   font-size: 33px;
+} */
+/* embedded-content class used for
+dataset descriptions input by user
+via submission form. Copied from DS.*/
+.embedded-content h2 {
+  font-size: 1.6875rem;
+  letter-spacing: 0.03rem;
+  line-height: 1.37;
+  margin: 0 0 0.75rem 0;
+}
+@media screen and (min-width: 40em) {
+  .embedded-content h2 {
+    font-size: 2.0625rem;
+    letter-spacing: 0.02rem;
+    line-height: 1.33;
+  }
+}
+.embedded-content h3 {
+  font-size: 1.4375rem;
+  letter-spacing: 0.02rem;
+  line-height: 1.39;
+  margin: 0 0 0.75rem 0;
+}
+@media screen and (min-width: 40em) {
+  .embedded-content h3 {
+    font-size: 1.75rem;
+    letter-spacing: 0.02rem;
+    line-height: 1.43;
+  }
+}
+.embedded-content h4 {
+  font-size: 1.25rem;
+  letter-spacing: 0.03rem;
+  line-height: 1.5;
+  margin: 0 0 0.75rem 0;
+}
+@media screen and (min-width: 40em) {
+  .embedded-content h4 {
+    font-size: 1.5rem;
+    letter-spacing: 0.0313rem;
+    line-height: 1.5;
+  }
 }

--- a/ckanext/ontario_theme/fanstatic/common.css
+++ b/ckanext/ontario_theme/fanstatic/common.css
@@ -424,3 +424,9 @@ a:focus {
 .media-item:last-child{
   border-bottom: none;
 }
+/* ========================================================================
+   Custom overrides - individual pages
+   ======================================================================== */
+.embedded-content h2 {
+  font-size: 33px;
+}

--- a/ckanext/ontario_theme/templates/external/scheming/package/read.html
+++ b/ckanext/ontario_theme/templates/external/scheming/package/read.html
@@ -17,7 +17,7 @@
       {{ h.render_markdown(h.scheming_language_text(pkg['notes_translated'])) }}
     </div>
   {% endif %}
-  <h3>{% trans %}For more information{% endtrans %} </h3>
+  <h2 class="ontario-h2">{% trans %}For more information{% endtrans %} </h2>
   {% set contact_name = h.get_translated(pkg, 'maintainer') %}
   {% set contact_email = pkg.maintainer_email %}
   {% if (not contact_name) and (not contact_email) %}

--- a/ckanext/ontario_theme/templates/external/scheming/package/read.html
+++ b/ckanext/ontario_theme/templates/external/scheming/package/read.html
@@ -17,7 +17,7 @@
       {{ h.render_markdown(h.scheming_language_text(pkg['notes_translated'])) }}
     </div>
   {% endif %}
-  <h2 class="ontario-h2">{% trans %}For more information{% endtrans %} </h2>
+  <h2>{% trans %}For more information{% endtrans %} </h2>
   {% set contact_name = h.get_translated(pkg, 'maintainer') %}
   {% set contact_email = pkg.maintainer_email %}
   {% if (not contact_name) and (not contact_email) %}

--- a/ckanext/ontario_theme/templates/internal/package/snippets/additional_info.html
+++ b/ckanext/ontario_theme/templates/internal/package/snippets/additional_info.html
@@ -1,5 +1,5 @@
 <section class="additional-info">
-    <h2 class="ontario-h2">{{ _('Additional Info') }}</h2>
+    <h2>{{ _('Additional Info') }}</h2>
     <table class="table table-striped table-bordered table-condensed">
       <thead>
         <tr>

--- a/ckanext/ontario_theme/templates/internal/package/snippets/additional_info.html
+++ b/ckanext/ontario_theme/templates/internal/package/snippets/additional_info.html
@@ -1,0 +1,92 @@
+<section class="additional-info">
+    <h2 class="ontario-h2">{{ _('Additional Info') }}</h2>
+    <table class="table table-striped table-bordered table-condensed">
+      <thead>
+        <tr>
+          <th scope="col">{{ _('Field') }}</th>
+          <th scope="col">{{ _('Value') }}</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% block package_additional_info %}
+          {% if pkg_dict.url %}
+            <tr>
+              <th scope="row" class="dataset-label">{{ _('Source') }}</th>
+              {% if h.is_url(pkg_dict.url) %}
+                <td class="dataset-details" property="foaf:homepage">{{ h.link_to(pkg_dict.url, pkg_dict.url, rel='foaf:homepage', target='_blank') }}</td>
+              {% else %}
+                <td class="dataset-details" property="foaf:homepage">{{ pkg_dict.url }}</td>
+              {% endif %}
+            </tr>
+          {% endif %}
+  
+          {% if pkg_dict.author_email %}
+            <tr>
+              <th scope="row" class="dataset-label">{{ _("Author") }}</th>
+              <td class="dataset-details" property="dc:creator">{{ h.mail_to(email_address=pkg_dict.author_email, name=pkg_dict.author) }}</td>
+            </tr>
+          {% elif pkg_dict.author %}
+            <tr>
+              <th scope="row" class="dataset-label">{{ _("Author") }}</th>
+              <td class="dataset-details" property="dc:creator">{{ pkg_dict.author }}</td>
+            </tr>
+          {% endif %}
+  
+          {% if pkg_dict.maintainer_email %}
+            <tr>
+              <th scope="row" class="dataset-label">{{ _('Maintainer') }}</th>
+              <td class="dataset-details" property="dc:contributor">{{ h.mail_to(email_address=pkg_dict.maintainer_email, name=pkg_dict.maintainer) }}</td>
+            </tr>
+          {% elif pkg_dict.maintainer %}
+            <tr>
+              <th scope="row" class="dataset-label">{{ _('Maintainer') }}</th>
+              <td class="dataset-details" property="dc:contributor">{{ pkg_dict.maintainer }}</td>
+            </tr>
+          {% endif %}
+  
+          {% if pkg_dict.version %}
+            <tr>
+              <th scope="row" class="dataset-label">{{ _("Version") }}</th>
+              <td class="dataset-details">{{ pkg_dict.version }}</td>
+            </tr>
+          {% endif %}
+  
+          {% if h.check_access('package_update',{'id':pkg_dict.id}) %}
+            <tr>
+              <th scope="row" class="dataset-label">{{ _("State") }}</th>
+              <td class="dataset-details">{{ _(pkg_dict.state) }}</td>
+            </tr>
+          {% endif %}
+          {% if pkg_dict.metadata_modified %}
+            <tr>
+              <th scope="row" class="dataset-label">{{ _("Last Updated") }}</th>
+              <td class="dataset-details">
+                  {% snippet 'snippets/local_friendly_datetime.html', datetime_obj=pkg_dict.metadata_modified %}
+              </td>
+            </tr>
+          {% endif %}
+          {% if pkg_dict.metadata_created %}
+            <tr>
+              <th scope="row" class="dataset-label">{{ _("Created") }}</th>
+  
+              <td class="dataset-details">
+                  {% snippet 'snippets/local_friendly_datetime.html', datetime_obj=pkg_dict.metadata_created %}
+              </td>
+            </tr>
+          {% endif %}
+  
+        {% block extras scoped %}
+          {% for extra in h.sorted_extras(pkg_dict.extras) %}
+            {% set key, value = extra %}
+            <tr rel="dc:relation" resource="_:extra{{ i }}">
+              <th scope="row" class="dataset-label" property="rdfs:label">{{ _(key|e) }}</th>
+              <td class="dataset-details" property="rdf:value">{{ value }}</td>
+            </tr>
+          {% endfor %}
+        {% endblock %}
+  
+        {% endblock %}
+      </tbody>
+    </table>
+  </section>
+  

--- a/ckanext/ontario_theme/templates/internal/package/snippets/resources_list.html
+++ b/ckanext/ontario_theme/templates/internal/package/snippets/resources_list.html
@@ -3,7 +3,7 @@
 #}
 
 <section id="dataset-resources" class="resources">
-  <h2 class="ontario-h2">{{ _('Data') }}</h2>
+  <h2>{{ _('Data') }}</h2>
   {% block resource_list %}
     {% snippet "package/snippets/ontario_theme_access_level.html",
       pkg=pkg, dataset_type=dataset_type, schema=schema, resources=resources %}
@@ -17,9 +17,9 @@
           {% for group in resources|selectattr("type","equalto","data")|groupby("data_range")|sort(attribute="grouper", reverse=True) %}
 
             {% if group.list[0].data_range != "N/A - N/A" %}
-              <h3 class="ontario-h3">{{group.list[0].data_range}}</h3>
+              <h3>{{group.list[0].data_range}}</h3>
             {% else %}
-              <h3 class="ontario-h3">{{ _("No date range") }}</h3>
+              <h3>{{ _("No date range") }}</h3>
             {% endif %}
             <ul class="{% block resource_list_class %}resource-list{% endblock %}">
             {% for r in group.list|selectattr("format", "equalto", "CSV") %}
@@ -43,7 +43,7 @@
             </ul>
           {% endfor %}
         {% endblock %}
-      <h2 class="ontario-h2">{{ _("Supporting Files") }}</h2>
+      <h2>{{ _("Supporting Files") }}</h2>
       {% if resources | rejectattr("type","equalto","data") | list | length > 0 %}
         <ul class="resource-list">
             {% set can_edit = h.check_access('package_update', {'id':pkg.id }) %}

--- a/ckanext/ontario_theme/templates/internal/package/snippets/resources_list.html
+++ b/ckanext/ontario_theme/templates/internal/package/snippets/resources_list.html
@@ -3,7 +3,7 @@
 #}
 
 <section id="dataset-resources" class="resources">
-  <h3>{{ _('Data') }}</h3>
+  <h2 class="ontario-h2">{{ _('Data') }}</h2>
   {% block resource_list %}
     {% snippet "package/snippets/ontario_theme_access_level.html",
       pkg=pkg, dataset_type=dataset_type, schema=schema, resources=resources %}
@@ -17,9 +17,9 @@
           {% for group in resources|selectattr("type","equalto","data")|groupby("data_range")|sort(attribute="grouper", reverse=True) %}
 
             {% if group.list[0].data_range != "N/A - N/A" %}
-              <h4>{{group.list[0].data_range}}</h4>
+              <h3 class="ontario-h3">{{group.list[0].data_range}}</h3>
             {% else %}
-              <h4 class="empty">{{ _("No date range") }}</h4>
+              <h3 class="ontario-h3">{{ _("No date range") }}</h3>
             {% endif %}
             <ul class="{% block resource_list_class %}resource-list{% endblock %}">
             {% for r in group.list|selectattr("format", "equalto", "CSV") %}
@@ -43,7 +43,7 @@
             </ul>
           {% endfor %}
         {% endblock %}
-      <h3>{{ _("Supporting Files") }}</h3>
+      <h2 class="ontario-h2">{{ _("Supporting Files") }}</h2>
       {% if resources | rejectattr("type","equalto","data") | list | length > 0 %}
         <ul class="resource-list">
             {% set can_edit = h.check_access('package_update', {'id':pkg.id }) %}

--- a/ckanext/ontario_theme/templates/internal/snippets/organization.html
+++ b/ckanext/ontario_theme/templates/internal/snippets/organization.html
@@ -1,11 +1,11 @@
 {% ckan_extends %}
 
 {% block heading %}
-  <h1 class="heading">{{ h.get_translated(organization, "title") or organization.name }}
+  <h3 class="module-heading">{{ h.get_translated(organization, "title") or organization.name }}
     {% if organization.state == 'deleted' %}
       [{{ _('Deleted') }}]
     {% endif %}
-  </h1>
+  </h3>
 {% endblock %}
 
 {% block description %}

--- a/ckanext/ontario_theme/templates/internal/snippets/organization.html
+++ b/ckanext/ontario_theme/templates/internal/snippets/organization.html
@@ -1,7 +1,7 @@
 {% ckan_extends %}
 
 {% block heading %}
-  <h3 class="module-heading">{{ h.get_translated(organization, "title") or organization.name }}
+  <h3 class="ontario-module-h3">{{ h.get_translated(organization, "title") or organization.name }}
     {% if organization.state == 'deleted' %}
       [{{ _('Deleted') }}]
     {% endif %}


### PR DESCRIPTION
## What this PR accomplishes
Fixes heading levels in the individual dataset page as per figma mockup.

## Issues resolved
- h3.module-heading for organization title
- h2 and h3 hierarchy followed for headings in the order they appear in figma

## What needs review
- check that the headings have all been properly fixed
- an override category was added in `common.css` for `.embedded-content h2`. Do you think we should also have overrides for embedded h3, h4, etc in case someone uses them when creating the description of their dataset?