### PR TITLE
FIX: zip files containing directories can be uploaded

### DIFF
--- a/ckanext/ontario_theme/resource_upload.py
+++ b/ckanext/ontario_theme/resource_upload.py
@@ -105,15 +105,17 @@ class ResourceUpload(DefaultResourceUpload):
 
             with ZipFile(fileobj) as this_zip:
                 zip_list = this_zip.namelist()
+                # Skip directory names
                 for zip_item in zip_list:
-                    with this_zip.open(zip_item) as each_file:
-                        try: 
-                            each_mimetype = magic.from_buffer(each_file.read(),
-                                            mime=True)
-                            if not allowed_mimetype(each_mimetype):
+                    if not zip_item.endswith("/"):
+                        with this_zip.open(zip_item) as each_file:
+                            try:
+                                each_mimetype = magic.from_buffer(each_file.read(),
+                                                mime=True)
+                                if not allowed_mimetype(each_mimetype):
+                                    alert_invalidfile(resource, self.filename)
+                            except:
                                 alert_invalidfile(resource, self.filename)
-                        except:
-                            alert_invalidfile(resource, self.filename)
                         
         path = get_storage_path()
         config_mimetype_guess = config.get('ckan.mimetype_guess', 'file_ext')


### PR DESCRIPTION
## What this PR accomplishes
Mimetypes of every item inside a zip file to be uploaded were being checked, but the case where the zip file contains a directory was not accounted for. To get around this, a condition was added to ignore strings that represent directories, and only the mimetypes of filename strings are now checked.

## Issue resolved
Fixes error in trying to upload zip files containing directories.

## What needs review
- Please confirm that zip files containing directories can be uploaded successfully.
- If there is a better way of determining whether an item is a directory name, please suggest it. I am simply checking whether there is a `/` at the end of the string.