### PR TITLE
Remove icons from inner tab navigation

### DIFF
--- a/ckanext/ontario_theme/templates/internal/group/edit_base.html
+++ b/ckanext/ontario_theme/templates/internal/group/edit_base.html
@@ -6,3 +6,9 @@
   <li>{% link_for group.display_name|truncate(35), named_route='group.read', id=group.name, named_route=group_type + '.read' %}</li>
   <li class="active">{% link_for _('Edit'), named_route='group.edit', id=group.name, named_route=group_type + '.edit' %}</li>
 {% endblock %}
+
+{# Override CKAN: Do not pass any icons to nav bar menu items #}
+{% block content_primary_nav %}
+  {{ h.build_nav_icon(group_type + '.edit', _('Edit'), id=group_dict.name) }}
+  {{ h.build_nav_icon(group_type + '.members', _('Members'), id=group_dict.name) }}
+{% endblock %}

--- a/ckanext/ontario_theme/templates/internal/group/read_base.html
+++ b/ckanext/ontario_theme/templates/internal/group/read_base.html
@@ -5,3 +5,10 @@
     {% link_for _('Edit'), named_route='group.edit', id=c.group_dict.name, class_='btn btn-default btn-secondary', icon='wrench', named_route=group_type + '.edit' %}
   {% endif %}
 {% endblock %}
+
+{# Override CKAN: Do not pass any icons to nav bar menu items #}
+{% block content_primary_nav %}
+  {{ h.build_nav_icon(group_type + '.read', _('Datasets'), id=group_dict.name) }}
+  {{ h.build_nav_icon(group_type + '.activity', _('Activity Stream'), id=group_dict.name, offset=0) }}
+  {{ h.build_nav_icon(group_type + '.about', _('About'), id=group_dict.name) }}
+{% endblock %}

--- a/ckanext/ontario_theme/templates/internal/organization/edit_base.html
+++ b/ckanext/ontario_theme/templates/internal/organization/edit_base.html
@@ -9,3 +9,10 @@
     <li class="active">{% link_for _('Edit'), named_route=group_type+'.edit', id=organization.name %}</li>
   {% endblock %}
 {% endblock %}
+
+{# Override CKAN: Do not pass any icons to nav bar menu items #}
+{% block content_primary_nav %}
+  {{ h.build_nav_icon(group_type + '.edit', _('Edit'), id=group_dict.name) }}
+  {{ h.build_nav_icon(group_type + '.bulk_process', _('Datasets'), id=group_dict.name) }}
+  {{ h.build_nav_icon(group_type + '.members', _('Members'), id=group_dict.name) }}
+{% endblock %}

--- a/ckanext/ontario_theme/templates/internal/organization/read_base.html
+++ b/ckanext/ontario_theme/templates/internal/organization/read_base.html
@@ -12,3 +12,10 @@
     {% link_for _('Edit'), named_route='organization.edit', id=c.group_dict.name, class_='btn btn-default btn-secondary', icon='wrench'  %}
   {% endif %}
 {% endblock %}
+
+{# Override CKAN: Do not pass any icons to nav bar menu items #}
+{% block content_primary_nav %}
+  {{ h.build_nav_icon(group_type + '.read', _('Datasets'), id=group_dict.name) }}
+  {{ h.build_nav_icon(group_type + '.activity', _('Activity Stream'), id=group_dict.name, offset=0) }}
+  {{ h.build_nav_icon(group_type + '.about', _('About'), id=group_dict.name) }}
+{% endblock %}

--- a/ckanext/ontario_theme/templates/internal/package/read_base.html
+++ b/ckanext/ontario_theme/templates/internal/package/read_base.html
@@ -6,6 +6,13 @@
   {% endif %}
 {% endblock %}
 
+{# Override CKAN: Do not pass any icons to nav bar menu items #}
+{% block content_primary_nav %}
+  {{ h.build_nav_icon(dataset_type ~ '.read', _('Dataset'), id=pkg.id if is_activity_archive else pkg.name) }}
+  {{ h.build_nav_icon(dataset_type ~ '.groups', _('Groups'), id=pkg.id if is_activity_archive else pkg.name) }}
+  {{ h.build_nav_icon(dataset_type ~ '.activity', _('Activity Stream'), id=pkg.id if is_activity_archive else pkg.name) }}
+{% endblock %}
+
 {% block package_info %}
   <div class="module module-narrow module-shallow context-info">
     <h2 class="module-heading">{{ _("Keep updated") }}</h2>

--- a/ckanext/ontario_theme/templates/internal/package/snippets/resource_views_list_item.html
+++ b/ckanext/ontario_theme/templates/internal/package/snippets/resource_views_list_item.html
@@ -1,0 +1,6 @@
+{# Override CKAN: Remove Data Explorer icon from tab #}
+<li class="{% if is_selected %} active{% endif %}" data-id="{{ view.id }}">
+  <a href="{{ url }}" data-id="{{ view.id }}">
+    {{ view.title }}
+  </a>
+</li>


### PR DESCRIPTION
## What this PR accomplishes
Remove the little icons beside the inner tab navigation (e.g. little clocks, edit pencils, etc), as per the figma design.

## What needs review
- confirm the icons are gone from the tab navigation
- check that there aren't any others that I have missed