### PR TITLE
Ckan 2.9 French breadcrumb translation

### DIFF
--- a/ckanext/ontario_theme/templates/internal/package/base.html
+++ b/ckanext/ontario_theme/templates/internal/package/base.html
@@ -5,7 +5,7 @@
     {% set dataset = h.dataset_display_name(pkg) %}
     {% set organization_dict = h.get_organization(pkg.organization.name) %}
     {% if pkg.organization %}
-      {% set organization = h.get_translated(pkg.organization, 'title') or h.get_translated(organization_dict, 'title') %}
+      {% set organization = h.get_translated(organization_dict, 'title') or organization_dict['title'] %}
       {% set group_type = pkg.organization.type %}
       <li>{% link_for _('Ministries'), named_route='organization.index', named_route=group_type + '_index' %}</li>
       <li id='ministry-name' ministry-name="{{pkg.organization.title}}" ministry-name-fr="{{ h.ontario_theme_get_translated_lang(organization_dict, 'title', 'fr') }}">{% link_for organization|truncate(30), named_route='organization.read', id=pkg.organization.name, named_route=group_type + '.read' %}</li>

--- a/ckanext/ontario_theme/templates/internal/package/base.html
+++ b/ckanext/ontario_theme/templates/internal/package/base.html
@@ -5,7 +5,7 @@
     {% set dataset = h.dataset_display_name(pkg) %}
     {% set organization_dict = h.get_organization(pkg.organization.name) %}
     {% if pkg.organization %}
-      {% set organization = h.get_translated(pkg.organization, 'title') or pkg.organization.name %}
+      {% set organization = h.get_translated(pkg.organization, 'title') or h.get_translated(organization_dict, 'title') %}
       {% set group_type = pkg.organization.type %}
       <li>{% link_for _('Ministries'), named_route='organization.index', named_route=group_type + '_index' %}</li>
       <li id='ministry-name' ministry-name="{{pkg.organization.title}}" ministry-name-fr="{{ h.ontario_theme_get_translated_lang(organization_dict, 'title', 'fr') }}">{% link_for organization|truncate(30), named_route='organization.read', id=pkg.organization.name, named_route=group_type + '.read' %}</li>


### PR DESCRIPTION
## What this PR accomplishes

- Translates the breadcrumb for Ministries when in dataset pages

## What needs review

- That the breadcrumb for Ministries is translated when toggled in French mode, specifically when navigating to an individual dataset from a Ministry or from the dataset search page