### PR TITLE
allow only write-access users to see resources in non-open pkgs

### DIFF
--- a/ckanext/ontario_theme/templates/internal/package/snippets/resources_list.html
+++ b/ckanext/ontario_theme/templates/internal/package/snippets/resources_list.html
@@ -1,69 +1,77 @@
 {#
   Complete override of template to change "Data and resources" to just data...
 #}
+  <section id="dataset-resources" class="resources">
+    <h2>{{ _('Data') }}</h2>
+    {% block resource_list %}
+      {% snippet "package/snippets/ontario_theme_access_level.html",
+        pkg=pkg, dataset_type=dataset_type, schema=schema, resources=resources %}
 
-<section id="dataset-resources" class="resources">
-  <h2>{{ _('Data') }}</h2>
-  {% block resource_list %}
-    {% snippet "package/snippets/ontario_theme_access_level.html",
-      pkg=pkg, dataset_type=dataset_type, schema=schema, resources=resources %}
-
-    {% if resources %}
-        {% block resource_list_inner %}
-          {% set can_edit = h.check_access('package_update', {'id':pkg.id }) %}
-          {% for resource in resources %}
-            {% do resource.update({"data_range": h.ontario_theme_get_date_range(resource.data_range_start|default("N/A"),resource.data_range_end|default("N/A"))}) %}          
-          {% endfor %}
-          {% for group in resources|selectattr("type","equalto","data")|groupby("data_range")|sort(attribute="grouper", reverse=True) %}
-
-            {% if group.list[0].data_range != "N/A - N/A" %}
-              <h3>{{group.list[0].data_range}}</h3>
-            {% else %}
-              <h3>{{ _("No date range") }}</h3>
-            {% endif %}
-            <ul class="{% block resource_list_class %}resource-list{% endblock %}">
-            {% for r in group.list|selectattr("format", "equalto", "CSV") %}
-              {% snippet 'package/snippets/resource_item.html', pkg=pkg, res=r, can_edit=can_edit, schema=schema %}
-            {% endfor %} 
-            {% for r in group.list|selectattr("format", "equalto", "JSON") %}
-              {% snippet 'package/snippets/resource_item.html', pkg=pkg, res=r, can_edit=can_edit, schema=schema %}
+      {# can_edit is True only for users with write access
+        (i.e. sysadmins and org admins)
+      #}
+      {% set can_edit = h.check_access('package_update', {'id':pkg.id }) %}
+      
+      {# If package access level is not open (i.e. restricted or under review),
+        only allow users with write access (i.e. sysadmins and org admins) to
+        view the resource list.
+      #}
+      {% if pkg['access_level'] == 'open' or can_edit %}
+        {% if resources %}
+          {% block resource_list_inner %}
+            {% for resource in resources %}
+              {% do resource.update({"data_range": h.ontario_theme_get_date_range(resource.data_range_start|default("N/A"),resource.data_range_end|default("N/A"))}) %}          
             {% endfor %}
-            {% for r in group.list|selectattr("format", "equalto", "KML") %}
-              {% snippet 'package/snippets/resource_item.html', pkg=pkg, res=r, can_edit=can_edit, schema=schema %}
+            {% for group in resources|selectattr("type","equalto","data")|groupby("data_range")|sort(attribute="grouper", reverse=True) %}
+              {% if group.list[0].data_range != "N/A - N/A" %}
+                <h3>{{group.list[0].data_range}}</h3>
+              {% else %}
+                <h3>{{ _("No date range") }}</h3>
+              {% endif %}
+              <ul class="{% block resource_list_class %}resource-list{% endblock %}">
+              {% for r in group.list|selectattr("format", "equalto", "CSV") %}
+                {% snippet 'package/snippets/resource_item.html', pkg=pkg, res=r, can_edit=can_edit, schema=schema %}
+              {% endfor %} 
+              {% for r in group.list|selectattr("format", "equalto", "JSON") %}
+                {% snippet 'package/snippets/resource_item.html', pkg=pkg, res=r, can_edit=can_edit, schema=schema %}
+              {% endfor %}
+              {% for r in group.list|selectattr("format", "equalto", "KML") %}
+                {% snippet 'package/snippets/resource_item.html', pkg=pkg, res=r, can_edit=can_edit, schema=schema %}
+              {% endfor %}
+              {% for r in group.list|rejectattr("format", "equalto", "CSV")|rejectattr("format", "equalto", "JSON")|rejectattr("format", "equalto", "KML")|rejectattr("format", "equalto", "XLS")|rejectattr("format", "equalto", "XLSX") %}
+                {% snippet 'package/snippets/resource_item.html', pkg=pkg, res=r, can_edit=can_edit, schema=schema %}
+              {% endfor %}
+              {% for r in group.list|selectattr("format", "equalto", "XLSX") %}
+                {% snippet 'package/snippets/resource_item.html', pkg=pkg, res=r, can_edit=can_edit, schema=schema %}
+              {% endfor %}
+              {% for r in group.list|selectattr("format", "equalto", "XLS") %}
+                {% snippet 'package/snippets/resource_item.html', pkg=pkg, res=r, can_edit=can_edit, schema=schema %}
+              {% endfor %}
+              </ul>
             {% endfor %}
-            {% for r in group.list|rejectattr("format", "equalto", "CSV")|rejectattr("format", "equalto", "JSON")|rejectattr("format", "equalto", "KML")|rejectattr("format", "equalto", "XLS")|rejectattr("format", "equalto", "XLSX") %}
-              {% snippet 'package/snippets/resource_item.html', pkg=pkg, res=r, can_edit=can_edit, schema=schema %}
-            {% endfor %}
-            {% for r in group.list|selectattr("format", "equalto", "XLSX") %}
-              {% snippet 'package/snippets/resource_item.html', pkg=pkg, res=r, can_edit=can_edit, schema=schema %}
-            {% endfor %}
-            {% for r in group.list|selectattr("format", "equalto", "XLS") %}
-              {% snippet 'package/snippets/resource_item.html', pkg=pkg, res=r, can_edit=can_edit, schema=schema %}
-            {% endfor %}
+          {% endblock %}
+          <h2>{{ _("Supporting Files") }}</h2>
+          {% if resources | rejectattr("type","equalto","data") | list | length > 0 %}
+            <ul class="resource-list">
+                {% set can_edit = h.check_access('package_update', {'id':pkg.id }) %}
+                {% for resource in resources|rejectattr("type","equalto","data") %}
+                  {% snippet 'package/snippets/resource_item.html', pkg=pkg, res=resource, can_edit=can_edit, schema=schema %}
+                {% endfor %}
             </ul>
-          {% endfor %}
-        {% endblock %}
-      <h2>{{ _("Supporting Files") }}</h2>
-      {% if resources | rejectattr("type","equalto","data") | list | length > 0 %}
-        <ul class="resource-list">
-            {% set can_edit = h.check_access('package_update', {'id':pkg.id }) %}
-            {% for resource in resources|rejectattr("type","equalto","data") %}
-              {% snippet 'package/snippets/resource_item.html', pkg=pkg, res=resource, can_edit=can_edit, schema=schema %}
-            {% endfor %}
-        </ul>
-      {% else %}
-        <p class="empty">{{ _('This dataset has no supporting files') }}</p>
-      {% endif %}
-    {% else %}
-      {% if h.check_access('resource_create', {'package_id': pkg['id']}) %}
-        {% trans url=h.url_for(pkg.type ~ '_resource.new', id=pkg.name) %}
-          <p class="empty">This dataset has no data, <a href="{{ url }}">why not add some?</a></p>
-        {% endtrans %}
-      {% else %}
-        {% if not pkg['access_level'] %}
-          <p class="empty">{{ _('This dataset has no data') }}</p>
+          {% else %}
+            <p class="empty">{{ _('This dataset has no supporting files') }}</p>
+          {% endif %}
+        {% else %}
+          {% if h.check_access('resource_create', {'package_id': pkg['id']}) %}
+            {% trans url=h.url_for(pkg.type ~ '_resource.new', id=pkg.name) %}
+              <p class="empty">This dataset has no data, <a href="{{ url }}">why not add some?</a></p>
+            {% endtrans %}
+          {% else %}
+            {% if not pkg['access_level'] %}
+              <p class="empty">{{ _('This dataset has no data') }}</p>
+            {% endif %}
+          {% endif %}
         {% endif %}
       {% endif %}
-    {% endif %}
-  {% endblock %}
-</section>
+    {% endblock %}
+  </section>


### PR DESCRIPTION
## What this PR accomplishes
If a package is not open (i.e. restricted or under review), users who are do not have write access (i.e. users who are not sysadmins or org admins) should not be able to see the resource list. 

## What needs review
Please confirm that the resource list of a package with access level that is not open is only displayed for sysadmins or org admins.