### PR TITLE
CKAN 2.9 group search

### DIFF
--- a/ckanext/ontario_theme/fanstatic/common.css
+++ b/ckanext/ontario_theme/fanstatic/common.css
@@ -281,6 +281,9 @@ input[type=reset].ontario-search-reset.home{
   overflow:hidden;
   margin-bottom:2px
 }
+#group-search-form .ontario-search-container{
+  z-index: 2;
+}
 
 /* ========================================================================
    Page Alerts - Design System


### PR DESCRIPTION
## What this PR accomplishes

Increases the z-index of the group search bar to be above the secondary column. The secondary's z-index was blocking the left side of the input field.

## Issue(s) addressed

The search bar on the Groups page only accepts input if the mouse is about 1/3 the distance from the left of the input box. 

## What needs review

The search bar on the groups page can accept input at any point on the input box and the cursor is in input style.