### PR TITLE
Fix broken sort and define different default sort order

### DIFF
--- a/ckanext/ontario_theme/plugin.py
+++ b/ckanext/ontario_theme/plugin.py
@@ -394,6 +394,18 @@ def get_keyword_count(keyword_lang, language):
 
     return keyword_count_by_lang
 
+def sort_page_items(obj, fields_dict):
+    '''Helper to return the page items object sorted by title_translated
+    for the current language.
+    '''
+    field = fields_dict['field']
+    lang = fields_dict['lang']
+    reverse = fields_dict['reverse']
+    return sorted(obj, 
+                  key=lambda x: x[field][lang], 
+                  reverse=reverse)
+
+
 def get_popular_datasets():
     '''Helper to return most popular datasets, based on ckan core tracking feature
     '''
@@ -720,7 +732,8 @@ type data_last_updated
                 'ontario_theme_home_block_image': home_block_image,
                 'ontario_theme_home_block_link': home_block_link,
                 'ontario_theme_get_group_datasets': get_group_datasets,
-                'ontario_theme_get_keyword_count': get_keyword_count
+                'ontario_theme_get_keyword_count': get_keyword_count,
+                'ontario_theme_sort_page_items': sort_page_items
                 }
 
     # IBlueprint

--- a/ckanext/ontario_theme/templates/internal/organization/index.html
+++ b/ckanext/ontario_theme/templates/internal/organization/index.html
@@ -50,7 +50,12 @@
   {% block organizations_list %}
     {% if c.page.items or request.params %}
       {% if c.page.items %}
-        {% snippet "organization/snippets/organization_list.html", organizations=c.page.items %}
+        {# Custom sort by language for name ascending and descending #}
+        {% set current_lang = request.environ.CKAN_LANG %}
+        {% set reverse = True if 'desc' in request.params['sort'] else False %}
+        {% set fields_dict = {'field': 'title_translated','lang': current_lang, 'reverse': reverse} %}
+        {% set sorted_org = h.ontario_theme_sort_page_items(c.page.items, fields_dict) %}
+        {% snippet "organization/snippets/organization_list.html", organizations=sorted_org %}
       {% endif %}
     {% else %}
       <p class="empty">

--- a/ckanext/ontario_theme/templates/internal/organization/index.html
+++ b/ckanext/ontario_theme/templates/internal/organization/index.html
@@ -36,6 +36,10 @@
       {% set type = 'ministry' %}
       {% set searchbar_title = _('Search ministries') + _(':') %}
       {% set hidden_searchbar_title = _('Search ministries') %}
+      {% set sorting = [
+        (_('Name Ascending'), 'name asc'),
+        (_('Name Descending'), 'name desc') ]
+      %}
       {% snippet 'snippets/search_form.html', searchbar_title=searchbar_title, hidden_searchbar_title=hidden_searchbar_title, form_id=form_id, type=type, query=query, sorting=sorting, sorting_selected=c.sort_by_selected, count=c.page.item_count, placeholder=placeholder, sr_input_text=sr_input_text, sr_submit_text=sr_submit_text, facets=facets, show_empty=request.params, error=c.query_error, fields=c.fields %}
     {% endblock %}
   </div>

--- a/ckanext/ontario_theme/templates/internal/organization/read.html
+++ b/ckanext/ontario_theme/templates/internal/organization/read.html
@@ -21,6 +21,9 @@ Override CKAN's read.html to add some new facets.
     (_('Last Modified'), 'metadata_modified desc'),
     (_('Popular'), 'views_recent desc') if g.tracking_enabled else (false, false) ]
   %}
+  {% if not sort_by_selected %}
+    {% set sort_by_selected = 'metadata_modified desc' %}
+  {% endif %}
   {% snippet 'snippets/search_form.html', form_id='organization-datasets-search-form', type='dataset', query=q, sorting=sorting, sorting_selected=sort_by_selected, count=page.item_count, facets=facets, placeholder=_('Search datasets'), show_empty=request.params, fields=fields %}
 {% endblock %}
 

--- a/ckanext/ontario_theme/templates/internal/package/search.html
+++ b/ckanext/ontario_theme/templates/internal/package/search.html
@@ -62,6 +62,7 @@ in the core template for search.html.
     <div class="module-content">
       {% block package_search_results_list %}
         {{ super() }}
+        {{ h.snippet('snippets/package_list.html', packages=packages) }}
       {% endblock %}
     </div>
 

--- a/ckanext/ontario_theme/templates/internal/package/search.html
+++ b/ckanext/ontario_theme/templates/internal/package/search.html
@@ -48,7 +48,13 @@ in the core template for search.html.
       {% set type = dataset_type %}
       {% set searchbar_title = _('Search ' + dataset_type + 's') + _(':') %}
       {% set hidden_searchbar_title = _('Search ' + dataset_type + 's') %}
-      {% snippet 'snippets/search_form.html', searchbar_title=searchbar_title, hidden_searchbar_title=hidden_searchbar_title, form_id=form_id, type=type, query=query, sorting=sorting, sorting_selected=c.sort_by_selected, count=c.page.item_count, placeholder=placeholder, sr_input_text=sr_input_text, sr_submit_text=sr_submit_text, facets=facets, show_empty=request.params, error=c.query_error, fields=c.fields %}
+      <!-- override default sort order 'score desc, metadata_modified desc' to 'metadata_modified desc' -->
+      {% set default_order = 'metadata_modified desc' %}
+      <!-- define sort_order to default_order when first landing on page, otherwise
+           set to user menu selection stored in request.params['sort']
+       -->
+      {% set sort_order = default_order if not request.params else request.params['sort'] %}
+      {% snippet 'snippets/search_form.html', searchbar_title=searchbar_title, hidden_searchbar_title=hidden_searchbar_title, form_id=form_id, type=type, query=query, sorting=sorting, sorting_selected=sort_order, count=c.page.item_count, placeholder=placeholder, sr_input_text=sr_input_text, sr_submit_text=sr_submit_text, facets=facets, show_empty=request.params, error=c.query_error, fields=c.fields %}
     {% endblock %}
   </div>
 {% endblock %}

--- a/ckanext/ontario_theme/templates/internal/snippets/package_list.html
+++ b/ckanext/ontario_theme/templates/internal/snippets/package_list.html
@@ -1,0 +1,34 @@
+{#
+    Displays a list of datasets.
+    
+    packages       - A list of packages to display.
+    list_class     - The class name for the list item.
+    item_class     - The class name to use on each item.
+    hide_resources - If true hides the resources (default: false).
+    banner         - If true displays a popular banner (default: false).
+    truncate       - The length to trucate the description to (default: 180)
+    truncate_title - The length to truncate the title to (default: 80).
+    
+    Overrides CKAN file by adding custom name sort by language.
+    
+#}
+{% block package_list %}
+    {% if packages %}
+        <ul class="{{ list_class or 'dataset-list list-unstyled' }}">
+        {% block package_list_inner %}
+            {# Custom sort by language for name ascending and descending #}
+            {% if 'name' in request.params['sort'] %}
+                {% set current_lang = request.environ.CKAN_LANG %}
+                {% set reverse = True if 'desc' in request.params['sort'] else False %}
+                {% set fields_dict = {'field': 'title_translated','lang': current_lang, 'reverse': reverse} %}
+                {% set packages = h.ontario_theme_sort_page_items(packages, fields_dict) %}
+            {% endif %}
+            {% for package in packages %}
+                {% snippet 'snippets/package_item.html', package=package, item_class=item_class, hide_resources=hide_resources, banner=banner, truncate=truncate, truncate_title=truncate_title %}
+            {% endfor %}
+        {% endblock %}
+    </ul>
+    {% endif %}
+{% endblock %}
+
+    


### PR DESCRIPTION
## What this PR accomplishes
1. Defines a helper function `sort_page_items()` to alphabetically sort dataset names and ministry names in English or French _before_ they are looped through on the display pages (`organization_list.html` and `package_list.html`).
2. Overrides CKAN's default sort order `'score desc, metadata_modified desc'` to `'metadata_modified desc'` (i.e. **Last modified**) in the Ontario theme templates for datasets. The default sort order is invoked when `request.params.get('sort')` is empty, i.e., when first landing on the page. A sort order subsequently selected from the **Order by** drop-down menu after landing on the page will be stored in `request.params.get('sort')` and will then be used to sort. (For reference: CKAN's default sort order is defined in the core CKAN [package_search() function in get.py](https://github.com/ckan/ckan/blob/ckan-2.9.7/ckan/logic/action/get.py#L1842).) 

## Issues addressed
1. broken sort: **Name ascending** and **Name descending** do not work properly for Ministries and Datasets, in both languages
3. change default sort order to:
- **Name ascending** as default for Organizations (Ministries) and Groups
- **Last modified** as default for Datasets

## What needs review
- verify that Ministries are correctly ordered by **Name ascending** and **Name descending** in English and French
- verify that datasets are correctly ordered by **Last modified** / **Modifié le** when first landing on either the Datasets page or when clicking on a Ministry in the Ministries page to open a list of datasets for that ministry

Note: In French, accented first characters such as `É` are alphabetically after `A-Z` characters.