### PR TITLE
CKAN 2.9: Header design review updates

### DIFF
--- a/ckanext/ontario_theme/fanstatic/common.css
+++ b/ckanext/ontario_theme/fanstatic/common.css
@@ -670,7 +670,7 @@ a:focus {
 .ontario-navigation .ontario-header-button {
   visibility: hidden;
   position: absolute;
-  right: 1rem;
+  right: 0.5rem;
   z-index: 6;
 }
 .ontario-header__menu-toggler {
@@ -794,6 +794,11 @@ the menu dropdowm. Datasets and ministries are displayed in the medium screen na
   }
   .account-text{
     display:none;
+  }
+}
+@media screen and (max-width: 40em) {
+  .ontario-navigation .ontario-header-button {
+    right: 1rem;
   }
 }
 /* ========================================================================

--- a/ckanext/ontario_theme/templates/internal/header.html
+++ b/ckanext/ontario_theme/templates/internal/header.html
@@ -81,10 +81,7 @@
         </div>
         <div class="ontario-columns ontario-small-6 ontario-application-header__lang-toggle">
           <a href="{{ h.url_for(h.current_url(), locale=toggle_to) }}" title="{{ toggle_to }}" class="ontario-header__language-toggler ontario-header-button ontario-header-button--without-outline">
-              <abbr title="Français" class="ontario-show-for-small-only">
-                {{'FR' if current_lang =='en' else 'EN'}}
-              </abbr>
-              <span class="ontario-show-for-medium">
+              <span>
                 {{'Français' if current_lang =='en' else 'English'}}
               </span>
           </a>
@@ -161,7 +158,7 @@
           </svg>
           <span class="menu-text">{{_("Menu")}}</span>
         </button>
-        <div class="ontario-navigation__container ontario-hide-for-large-only">
+        <div class="ontario-navigation__container ontario-hide-for-large">
           <ul>
             {{ h.build_nav_main(
               ('dataset.search', _('Datasets')),
@@ -173,4 +170,5 @@
       </nav>
     </div>
   </div>
+  <div class="ontario-overlay"></div>
 {% endblock %}


### PR DESCRIPTION
## What this PR accomplishes

Updates the header according to the designers suggestions

## Issue(s) addressed

- Francais link on mobile should remain a full word “Francais“ with no underline
- The Design System suggest having an overlay under the menu drop down to show the hierarchy of the elements. On tablet and mobile the screen is being darkened. 
- Menu button moving to the left and right when pressing it to open and close the drop down

## What needs review

- French link is correctly displaying “Francais“ with no underline 
- When clicking to open the menu, there is an overlay on the page. 
- Transition between the open menu and close menu buttons are seamless.