### PR TITLE
Ckan 2.9 callout fix

### DIFF
--- a/ckanext/ontario_theme/plugin.py
+++ b/ckanext/ontario_theme/plugin.py
@@ -419,36 +419,27 @@ def extract_package_name(url):
     import re
 
     package_pattern = "\/dataset\/([-a-z-0-9A-Z\n\r]*)"
-    
+    resource_pattern = "\/resource\/([-a-z-0-9A-Z\n\r]*)"
+    get_resource_name = re.compile(resource_pattern).findall(url)
     get_package_name = re.compile(package_pattern).findall(url)
     
-    if len(get_package_name) > 0:
+    if len(get_resource_name) > 0:
+        try:
+            resource_name = toolkit.get_action('resource_show') (
+                data_dict={'id': get_resource_name[0]}
+                )
+            resource_type = resource_name['type']
+            resource_name = resource_name['name']
+            if not resource_type and not resource_name:
+                resource_name = "Supporting File"
+            return resource_name or resource_type
+        except ckan.logic.NotFound:
+            return False
+    elif len(get_package_name) > 0:
         return get_package_name[0]
     else:
         return False
 
-def extract_resource_name(url):
-    ''' Returns the resource name if url is for 
-        a resource page
-
-        Returns resource type or "Supporting File" if there is no resource name 
-    '''
-    import re
-
-    resource_pattern = "\/resource\/([-a-z-0-9A-Z\n\r]*)"
-    get_resource_name = re.compile(resource_pattern).findall(url)
-
-    if len(get_resource_name) > 0:
-        resource_name = toolkit.get_action('resource_show') (
-            data_dict={'id': get_resource_name[0]}
-            )
-        resource_type = resource_name['type']
-        resource_name = resource_name['name']
-        if resource_type == "":
-            resource_name = "Supporting File"
-        return resource_name or resource_type
-    else:
-        return False 
 def get_translated_lang(data_dict, field, specified_language):
     try:
         return data_dict[field + u'_translated'][specified_language]
@@ -734,7 +725,6 @@ type data_last_updated
     def get_helpers(self):
         return {'ontario_theme_get_license': get_license,
                 'ontario_theme_extract_package_name': extract_package_name,
-                'ontario_theme_extract_resource_name': extract_resource_name,
                 'ontario_theme_get_translated_lang': get_translated_lang,
                 'ontario_theme_get_popular_datasets': get_popular_datasets,
                 'ontario_theme_get_group': get_group,

--- a/ckanext/ontario_theme/plugin.py
+++ b/ckanext/ontario_theme/plugin.py
@@ -416,6 +416,12 @@ def get_license(license_id):
     return Package.get_license_register().get(license_id)
 
 def extract_package_name(url):
+    ''' Returns the package name or gets resource name if url is for
+        a dataset or resource page
+
+        Returns resource type or "Supporting file" if there is no resource name and
+        no resource type
+    '''
     import re
 
     package_pattern = "\/dataset\/([-a-z-0-9A-Z\n\r]*)"

--- a/ckanext/ontario_theme/plugin.py
+++ b/ckanext/ontario_theme/plugin.py
@@ -416,28 +416,39 @@ def get_license(license_id):
     return Package.get_license_register().get(license_id)
 
 def extract_package_name(url):
-    ''' Returns the package name or gets resource name if url is for 
-        a dataset or resource page
-
-        Returns "Data" if there is no resource name 
-    '''
     import re
+
     package_pattern = "\/dataset\/([-a-z-0-9A-Z\n\r]*)"
-    resource_pattern = "\/resource\/([-a-z-0-9A-Z\n\r]*)"
-    get_resource_name = re.compile(resource_pattern).findall(url)
+    
     get_package_name = re.compile(package_pattern).findall(url)
     
+    if len(get_package_name) > 0:
+        return get_package_name[0]
+    else:
+        return False
+
+def extract_resource_name(url):
+    ''' Returns the resource name if url is for 
+        a resource page
+
+        Returns resource type or "Supporting File" if there is no resource name 
+    '''
+    import re
+
+    resource_pattern = "\/resource\/([-a-z-0-9A-Z\n\r]*)"
+    get_resource_name = re.compile(resource_pattern).findall(url)
+
     if len(get_resource_name) > 0:
         resource_name = toolkit.get_action('resource_show') (
             data_dict={'id': get_resource_name[0]}
             )
+        resource_type = resource_name['type']
         resource_name = resource_name['name']
-        return resource_name or "Data"
-    elif len(get_package_name) > 0:
-        return get_package_name[0]
+        if resource_type == "":
+            resource_name = "Supporting File"
+        return resource_name or resource_type
     else:
         return False 
-
 def get_translated_lang(data_dict, field, specified_language):
     try:
         return data_dict[field + u'_translated'][specified_language]
@@ -723,6 +734,7 @@ type data_last_updated
     def get_helpers(self):
         return {'ontario_theme_get_license': get_license,
                 'ontario_theme_extract_package_name': extract_package_name,
+                'ontario_theme_extract_resource_name': extract_resource_name,
                 'ontario_theme_get_translated_lang': get_translated_lang,
                 'ontario_theme_get_popular_datasets': get_popular_datasets,
                 'ontario_theme_get_group': get_group,

--- a/ckanext/ontario_theme/templates/internal/package/snippets/report_an_error.html
+++ b/ckanext/ontario_theme/templates/internal/package/snippets/report_an_error.html
@@ -1,4 +1,4 @@
-{% set resource_name = h.ontario_theme_extract_resource_name(h.current_url()) %}
+{% set resource_name = h.ontario_theme_extract_package_name(h.current_url()) %}
 {% set survey_params = { "page": h.current_url(), "id": resource_name }  %}
 
 <div class="ontario-callout ontario-border-highlight--purple">

--- a/ckanext/ontario_theme/templates/internal/package/snippets/report_an_error.html
+++ b/ckanext/ontario_theme/templates/internal/package/snippets/report_an_error.html
@@ -1,5 +1,5 @@
-{% set resource_name = h.ontario_theme_extract_package_name(h.current_url()) %}
-{% set survey_params = { "page": h.current_url(), "id": resource_name }  %}
+{% set package_name = h.ontario_theme_extract_package_name(h.current_url()) %}
+{% set survey_params = { "page": h.current_url(), "id": package_name }  %}
 
 <div class="ontario-callout ontario-border-highlight--purple">
     <h2 class="ontario-callout__title ontario-h5">{{ _("Report an error with this data") }}</h2>

--- a/ckanext/ontario_theme/templates/internal/package/snippets/report_an_error.html
+++ b/ckanext/ontario_theme/templates/internal/package/snippets/report_an_error.html
@@ -1,5 +1,5 @@
-{% set package_name = h.ontario_theme_extract_package_name(h.current_url()) %}
-{% set survey_params = { "page": h.current_url(), "id": package_name }  %}
+{% set resource_name = h.ontario_theme_extract_resource_name(h.current_url()) %}
+{% set survey_params = { "page": h.current_url(), "id": resource_name }  %}
 
 <div class="ontario-callout ontario-border-highlight--purple">
     <h2 class="ontario-callout__title ontario-h5">{{ _("Report an error with this data") }}</h2>


### PR DESCRIPTION
## Issue(s) addressed

Fixes adding a new resource 502 gateway error caused by callout
Displays resource type if no name is provided and if no name and no type is provided for a resource, "Supporting file" is displayed as the id in the URL

## What needs review

Users can add new resources without a 502 error
Survey URL id parameter displays resource type if there is no resource name entered, but there is a resource type.
Survey URL id parameter displays "Supporting file" when there is no resource type and no resource name.
Survey URL id parameter displays resource name, when name is provided.