### PR TITLE
CKAN 2.9 file type labels

### DIFF
--- a/ckanext/ontario_theme/fanstatic/common.css
+++ b/ckanext/ontario_theme/fanstatic/common.css
@@ -1259,3 +1259,90 @@ via submission form. Copied from DS.*/
 .ontario-border-highlight--purple{
     border-color:#92278f !important
 }
+/* ========================================================================
+   File type labels
+   ======================================================================== */
+.dataset-resources li a {
+  background-color: #aaaaaa;
+  color: #FFFFFF;
+}
+.label.label-default {
+  color:#000;
+  font-weight: 600;
+}
+.label[data-format=html],
+.label[data-format*=html] {
+  background-color: #FEDFF0;
+}
+.label[data-format=json],
+.label[data-format*=json] {
+  background-color: #FEE1D9;
+}
+.label[data-format=xml],
+.label[data-format*=xml] {
+  background-color: #F8E5C3;
+}
+.label[data-format=text],
+.label[data-format*=text],
+.label[data-format=txt],
+.label[data-format*=txt] {
+  background-color: #C5EEFA;
+}
+.label[data-format=doc],
+.label[data-format*=doc] {
+  background-color: #DBE9F5;
+}
+.label[data-format=csv],
+.label[data-format*=csv] {
+  background-color: #F0E7CC;
+}
+.label[data-format=xls],
+.label[data-format*=xls] {
+  background-color: #D1EFD4;
+}
+.label[data-format=zip],
+.label[data-format*=zip] {
+  background-color: #CCCCCC;
+}
+.label[data-format=api],
+.label[data-format*=api] {
+  background-color: #ec96be;
+}
+.label[data-format=pdf],
+.label[data-format*=pdf] {
+  background-color: #FFE0E2;
+}
+.label[data-format=other],
+.label[data-format*=other] {
+  background-color: #F2F2F2;
+}
+.label[data-format=mdb],
+.label[data-format*=mdb] {
+  background-color: #F1E3F2;
+}
+.label[data-format=rdf],
+.label[data-format*=rdf],
+.label[data-format*=nquad],
+.label[data-format*=ntriples],
+.label[data-format*=turtle] {
+  background-color: #0b4498;
+}
+.format-label[data-format=kml],
+.format-label[data-format*=kml] {
+  width: 31px;
+  height: 35px;
+  background-position: -383px -62px;
+  background-color: #CFEDED;
+}
+.format-label[data-format=shp],
+.format-label[data-format*=shp] {
+  width: 31px;
+  height: 35px;
+  background-position: -414px -62px;
+  background-color: #DDEDC7;
+}
+/* default button background colour */
+.label-default {
+  background-color: #FCAF17;
+  color: #000;
+}

--- a/ckanext/ontario_theme/fanstatic/common.css
+++ b/ckanext/ontario_theme/fanstatic/common.css
@@ -1267,7 +1267,7 @@ via submission form. Copied from DS.*/
   color: #FFFFFF;
 }
 .dataset-resources li {
-  margin-right: 14px;
+  margin-right: 16px;
 }
 .dataset-resources {
   margin-top: 13px;

--- a/ckanext/ontario_theme/fanstatic/common.css
+++ b/ckanext/ontario_theme/fanstatic/common.css
@@ -1266,9 +1266,17 @@ via submission form. Copied from DS.*/
   background-color: #aaaaaa;
   color: #FFFFFF;
 }
+.dataset-resources li {
+  margin-right: 14px;
+}
+.dataset-resources {
+  margin-top: 13px;
+}
 .label.label-default {
   color:#000;
   font-weight: 600;
+  font-size: 15px;
+  padding: 0.4em 1em;
 }
 .label[data-format=html],
 .label[data-format*=html] {

--- a/ckanext/ontario_theme/fanstatic/external/ontario_theme.css
+++ b/ckanext/ontario_theme/fanstatic/external/ontario_theme.css
@@ -483,72 +483,11 @@ div.card p {
   background-color: #aaaaaa;
   color: #FFFFFF;
 }
-.label {
-  color: #FFFFFF;
-}
 .label.right {
   float: right;
 }
-.label[data-format=html],
-.label[data-format*=html] {
-  background: linear-gradient(0deg, rgba(0, 0, 0, 0.2), rgba(85, 161, 206, 0.8)), #55a1ce;
-}
-.label[data-format=json],
-.label[data-format*=json],
-.label[data-format=xml],
-.label[data-format*=xml] {
-  background: linear-gradient(0deg, rgba(0, 0, 0, 0.2), rgba(239, 113, 0, 0.8)), #ef7100;
-}
-.label[data-format=text],
-.label[data-format*=text],
-.label[data-format=txt],
-.label[data-format*=txt],
-.label[data-format=doc],
-.label[data-format*=doc] {
-  background: linear-gradient(0deg, rgba(0, 0, 0, 0.2), rgba(116, 203, 236, 0.8)), #74cbec;
-}
-.label[data-format=csv],
-.label[data-format*=csv] {
-  background: linear-gradient(0deg, rgba(0, 0, 0, 0.2), rgba(133, 106, 0, 0.8)), #856A00;
-}
-.label[data-format=xls],
-.label[data-format*=xls] {
-  background: linear-gradient(0deg, rgba(0, 0, 0, 0.2), rgba(45, 181, 93, 0.8)), #2db55d;
-}
-.label[data-format=zip],
-.label[data-format*=zip] {
-  background: linear-gradient(0deg, rgba(0, 0, 0, 0.2), rgba(104, 104, 104, 0.8)), #686868;
-}
-.label[data-format=api],
-.label[data-format*=api] {
-  background: linear-gradient(0deg, rgba(0, 0, 0, 0.2), rgba(236, 150, 190, 0.8)), #ec96be;
-}
-.label[data-format=pdf],
-.label[data-format*=pdf] {
-  background: linear-gradient(0deg, rgba(0, 0, 0, 0.2), rgba(224, 5, 30, 0.8)), #e0051e;
-}
-.label[data-format=other],
-.label[data-format*=other] {
-  background: linear-gradient(0deg, rgba(0, 0, 0, 0.2), rgba(252, 175, 23, 0.8)), #fcaf17;
-}
-.label[data-format=rdf],
-.label[data-format*=rdf],
-.label[data-format*=nquad],
-.label[data-format*=ntriples],
-.label[data-format*=turtle] {
-  background: linear-gradient(0deg, rgba(0, 0, 0, 0.2), rgba(11, 68, 152, 0.8)), #0b4498;
-}
-.format-label[data-format=kml],
-.format-label[data-format*=kml] {
-  width: 31px;
-  height: 35px;
-  background-position: -383px -62px;
-}
-.format-label[data-format=shp],
-.format-label[data-format*=shp] {
-  width: 31px;
-  height: 35px;
-  background-position: -414px -62px;
+.label {
+  color: #FFFFFF;
 }
 .open,
 .under_review,

--- a/ckanext/ontario_theme/fanstatic/external/ontario_theme.css
+++ b/ckanext/ontario_theme/fanstatic/external/ontario_theme.css
@@ -486,9 +486,6 @@ div.card p {
 .label.right {
   float: right;
 }
-.label {
-  color: #FFFFFF;
-}
 .open,
 .under_review,
 .to_be_opened,

--- a/ckanext/ontario_theme/templates/internal/package/snippets/resource_item.html
+++ b/ckanext/ontario_theme/templates/internal/package/snippets/resource_item.html
@@ -15,7 +15,7 @@
         {% if res.format in h.dict_list_reduce(pkg.resources, 'format') and res.format | length < 5 %}
             <span class="label label-default" property="dc:format" data-format="{{ res.format.lower() or 'data' }}">{{ h.get_translated(res, 'format') }}</span> 
         {% else %}
-          <span class="label label-default" data-format="other">other</span>
+          <span class="label label-default" data-format="other">Other</span>
         {% endif %}
         {{ h.resource_display_name(res) | truncate(50) }}
         {% if res.size %}


### PR DESCRIPTION
## What this PR accomplishes

Update the file type labels

## Issue(s) addressed

- update the color of file type labels and remove the pseudo 3D styling to keep them as plain rectangles with rounded corners 
- Font color #000, font weight: 600

## What needs review

- File type labels are in the correct colour and font weight on the dataset search and individual dataset/ministry/group page

### Notes:

- Padding and font sizes/font weight are different on the Figma (I added the Figma to the ticket for visual color reference) but the ticket only asks for the color and font weight changed. This may be something to add to dataset search page, if needed. As this PR only reflects the ticket.