### PR TITLE
CKAN 2.9 Ministry search page bug

### DIFF
--- a/ckanext/ontario_theme/templates/internal/organization/index.html
+++ b/ckanext/ontario_theme/templates/internal/organization/index.html
@@ -68,7 +68,7 @@
 </div>
 <div class="container">
 <div class="row">
-  <div class="col-md-12">
+  <div class="col-xs-12">
       {% snippet 'home/snippets/ontario_theme_contact_us.html' %}
   </div>
 </div>


### PR DESCRIPTION
## Issue addressed

On mobile and tablet, the Ministries on the Ministry search page were not clickable. The survey feedback link was creating this bug.

## What needs review

On mobile and tablet, the Ministries on the Ministry search page are clickable and redirect to the individual Ministry's page