### PR TITLE
Ckan 2.9 Filter modal bug

### DIFF
--- a/ckanext/ontario_theme/fanstatic/common.css
+++ b/ckanext/ontario_theme/fanstatic/common.css
@@ -306,6 +306,10 @@ input[type=reset].ontario-search-reset:focus{
     background: none; /* turn off background for homepage searchbar */
   }
 
+  .secondary.col-sm-3.filter-results {
+    z-index: 6;
+  }
+
 /* ================================
   Custom overrides - text inputs
   ================================= */

--- a/ckanext/ontario_theme/templates/internal/package/search.html
+++ b/ckanext/ontario_theme/templates/internal/package/search.html
@@ -75,7 +75,8 @@ in the core template for search.html.
   {% endblock %}
 {% endblock %}
 
-{% block secondary_content %}
+{% block secondary %}
+<aside class="secondary col-sm-3 filter-results">
   <div class="filters">
     <div>
       <section class="module module-narrow module-shallow">
@@ -139,4 +140,5 @@ in the core template for search.html.
   </div>
   <a class="close no-text hide-filters"><i class="fa fa-times-circle"></i><span class="text">close</span></a>
 </div>
+</aside>
 {% endblock %}


### PR DESCRIPTION
## Issue addressed

The filter modal is blocked by the navigation bar and users are incapable of closing the modal without refreshing the page. This problem is only on the dataset search page on screen widths < 765px. (For individual group and Ministry pages the filter results button is too low on the page to cause this problem)

## What needs review

On 765px and smaller screens, the navigation bar should be behind the modal on the dataset search page. The individual group and Ministry pages should be tested as well.