### PR TITLE
Ckan 2.9 upgrade dataset

### DIFF
--- a/ckanext/ontario_theme/fanstatic/common.css
+++ b/ckanext/ontario_theme/fanstatic/common.css
@@ -68,6 +68,117 @@
 .ontario-form-group:last-of-type .ontario-checkboxes,.ontario-form-group:last-of-type .ontario-radios{
   margin-bottom:0
 }
+
+/* ========================================================================
+   Buttons - Design System
+   ======================================================================== */
+.ontario-button:focus,.ontario-button:active{
+    box-shadow:0 0 0 4px #009ADB;
+    outline:4px solid transparent;
+    transition:box-shadow .1s ease-in-out
+}
+.ontario-button{
+    border:none;
+    border-radius:4px;
+    box-sizing:border-box;
+    box-shadow:none;
+    display:inline-block;
+    font-size:1.125rem;
+    font-family:"Open Sans","Helvetica Neue",Helvetica,Arial,sans-serif;
+    font-weight:600;
+    line-height:1.5555555556;
+    margin:0 calc(1rem + 0.75rem) 1.5rem 0;
+    min-width:10rem;
+    padding:.625rem 1.5rem;
+    text-align:center;
+    text-decoration:none;
+    cursor:pointer
+}
+@media screen and (max-width: 40em){
+    .ontario-button{
+        margin-right:0;
+        display:block;
+        width:100%
+    }
+}
+.ontario-button .ontario-icon{
+    margin-right:4px
+}
+/* color changed from design system #3c7fa3*/
+.ontario-button--primary{
+    background-color:#3c7fa3;
+    color:#fff
+}
+.ontario-button--primary:hover{
+    background-color:#00478f;
+    color:#fff
+}
+.ontario-button--primary:focus{
+    background-color:#00478f;
+    color:#fff;
+    transition:background-color .2s ease-out,box-shadow .1s ease-in-out
+}
+.ontario-button--primary:active{
+    background-color:#002142;
+    color:#fff;
+    transition:background-color 0s,box-shadow .1s ease-in-out
+}
+.ontario-button--primary:visited{
+    color:#fff
+}
+.ontario-button--secondary{
+    background-color:#fff;
+    border:2px solid #3c7fa3;
+    color:#3c7fa3;
+    padding-top:.5rem;
+    padding-bottom:.5rem
+}
+.ontario-button--secondary:hover{
+    background-color:#e0f0ff;
+    border-color:#00478f;
+    color:#00478f
+}
+.ontario-button--secondary:focus{
+    background-color:#e0f0ff;
+    border-color:#00478f;
+    color:#00478f;
+    transition:background-color .2s ease-out,box-shadow .1s ease-in-out
+}
+.ontario-button--secondary:active{
+    background-color:#c2e0ff;
+    border-color:#002142;
+    color:#002142;
+    transition:background-color 0s,box-shadow .1s ease-in-out
+}
+.ontario-button--secondary:visited{
+    color:#3c7fa3;
+}
+.ontario-button--tertiary{
+    background-color:transparent;
+    color:#3c7fa3;
+    text-decoration:underline
+}
+.ontario-button--tertiary:hover{
+    background-color:#e8e8e8;
+    color:#00478f;
+    text-decoration:underline
+}
+.ontario-button--tertiary:focus{
+    background-color:#e8e8e8;
+    color:#00478f;
+    text-decoration:underline;
+    transition:background-color .2s ease-out,box-shadow .1s ease-in-out
+}
+.ontario-button--tertiary:active{
+    background-color:#d1d1d1;
+    color:#002142;
+    text-decoration:underline;
+    transition:background-color 0s,box-shadow .1s ease-in-out
+}
+.ontario-button--tertiary:visited{
+    color:#3c7fa3;
+}
+
 /* ========================================================================
     Search - Design System
     ======================================================================== */ 
@@ -430,8 +541,9 @@ a:focus {
   border-bottom: none;
 }
 .ontario-module-h3 {
-  font-size: 18px;
-  line-height: 1.3;
+  font-size: 22px;
+  font-weight: 600;
+  line-height: 25.6px;
   word-break: break-word;
   hyphens: auto;
 }
@@ -486,6 +598,139 @@ via submission form. Copied from DS.*/
 .ministry-contact {
 	margin-top: 28px;
 	margin-bottom: 28px;
+}
+
+.resource-item {
+  padding-top: 15px;
+	padding-bottom: 15px;
+}
+
+.resource-item-description{
+  font-weight: 400;
+  font-size: 18px;
+  line-height: 24.51px;
+  color: #1a1a1a;
+}
+.label.label-english,
+.label.label-french,
+.label.label-english_and_french {
+  background-color: #f2f2f2;
+  font-size: 20px;
+  font-weight: 700;
+  color: #1a1a1a;
+  border-radius: 2px;
+  margin-left: 10px;
+  margin-bottom: 5px;
+}
+
+.resource-item-title{
+  font-weight: 700;
+  font-size: 20px;
+  line-height: 27px;
+  color: #000000;
+  text-decoration: none;
+}
+
+.resource-item-title:hover{
+  color: #000000;
+}
+
+.dataset-font{
+  font-size: 19px;
+  line-height: 25.6px;
+  font-weight: 400;
+}
+.right-col{
+  float: right;
+  max-width: 350px;
+}
+.aside-heading {
+  color: #4d4d4d;
+  font-size: 19px;
+  line-height: 25.6px;
+  font-weight: 600;
+}
+
+.right-col h3 {
+  color: #000000;
+}
+
+.right-col a.btn.btn-primary{
+  font-size: 20px;
+  line-height: 27.24px;
+  font-weight: 700;
+}
+
+.right-col .module.module-narrow.module-shallow{
+  padding: 30px;
+}
+.package-z-index{
+  z-index: 2;
+  position: relative;
+}
+
+section.additional-info table.table {
+  border: none;
+}
+section.additional-info table.table thead {
+  display: none;
+}
+section.additional-info table.table td {
+  border: none;
+}
+section.additional-info table.table tbody tr:nth-child(even) th,
+section.additional-info table.table tbody tr:nth-child(even) td {
+  background-color: #f9f9f9;
+}
+section.additional-info table.table tbody tr th:first-child,
+section.additional-info table.table tbody tr td:first-child{
+  padding-top: 10px;
+}
+section.additional-info table.table tbody tr th:last-child,
+section.additional-info table.table tbody tr td:last-child{
+  padding-bottom: 10px;
+}
+section.additional-info table.table tbody tr th{
+  padding: 5px 15px 5px 30px;
+  font-weight: 700;
+  font-size: 20px;
+  line-height: 32.6px;
+  color: #4d4d4d;
+}
+section.additional-info table.table tbody tr td{
+  padding: 5px 30px 5px 0px;
+  font-weight: 400;
+  font-size: 20px;
+  line-height: 32.6px;
+  color: #4d4d4d;
+}
+section.additional-info table.table tbody tr th,
+section.additional-info table.table tbody tr td {
+  border: none;
+}
+section.additional-info table.table tbody tr td.dataset-details {
+  width: 75%;
+}
+
+section#dataset-resources .dataset-font{
+  color: #4d4d4d;
+}
+
+section#dataset-resources > h2{
+  margin-top: 35px;
+  margin-bottom: 20px;
+}
+
+.date-range{
+  font-weight: 600;
+  font-size: 24px;
+  line-height: 25.6px;
+  color: #4d4d4d;
+  margin-top: 10px;
+}
+
+.module.module-narrow.module-shallow.license{
+  margin-bottom: 0;
 }
 /* ========================================================================
    Custom overrides - links

--- a/ckanext/ontario_theme/fanstatic/common.css
+++ b/ckanext/ontario_theme/fanstatic/common.css
@@ -483,6 +483,10 @@ via submission form. Copied from DS.*/
     line-height: 1.5;
   }
 }
+.ministry-contact {
+	margin-top: 28px;
+	margin-bottom: 28px;
+}
 /* ========================================================================
    Custom overrides - links
    ======================================================================== */

--- a/ckanext/ontario_theme/fanstatic/external/ontario_theme.css
+++ b/ckanext/ontario_theme/fanstatic/external/ontario_theme.css
@@ -549,10 +549,7 @@ div.card p {
 .open,
 .under_review,
 .to_be_opened,
-.restricted,
-.label-french,
-.label-english,
-.label-english_and_french {
+.restricted{
   color: #4d4d4d;
 }
 .open {
@@ -567,15 +564,7 @@ div.card p {
 .restricted {
   background-color: #fad2d2;
 }
-.label-french {
-  background: #d2d1eb;
-}
-.label-english {
-  background-color: #dff3f3;
-}
-.label-english_and_french {
-  background-color: #e6fad2;
-}
+
 .label-info {
   color: #4d4d4d;
   border: solid 1px #1080A6;

--- a/ckanext/ontario_theme/templates/external/package/snippets/ontario_theme_access_level.html
+++ b/ckanext/ontario_theme/templates/external/package/snippets/ontario_theme_access_level.html
@@ -1,9 +1,9 @@
 {#
   Custom snippet to display access level information to users
 #}
-
 {% if h.scheming_field_by_name(schema.dataset_fields, 'access_level') and
     pkg.access_level %}
+  {% if pkg['access_level'] == 'restricted' or pkg['access_level'] == 'under_review' %}
     <div class="new-alert alert-{{pkg['access_level']}} alert-large alert-clear">
     {% if pkg['access_level'] == 'open' %}
       <strong>{{ _("Data Available") }}</strong>
@@ -13,28 +13,29 @@
         <a href="{{ license_url }}">[See the licence for how you're allowed to use this data.]</a>
         {% endtrans %}
       </p>
-    {% elif pkg['access_level'] == 'restricted' %} 
-      <strong>{{ _("Data Not Available") }}</strong>    
-      <p>
-        {% trans %}
-          This data is not and will not be made available. 
-          Data in this record cannot be released because of legal, privacy, security, 
-          confidentiality or commercially-sensitive reasons, as outlined by the 
-          <a href="https://www.ontario.ca/page/ontarios-open-data-directive">Open Data Directive</a>.
-        {% endtrans %}
-      </p>
+    {% elif pkg['access_level'] == 'restricted' %}
+        <strong>{{ _("Data Not Available") }}</strong>    
+        <p>
+          {% trans %}
+            This data is not and will not be made available. 
+            Data in this record cannot be released because of legal, privacy, security, 
+            confidentiality or commercially-sensitive reasons, as outlined by the 
+            <a href="https://www.ontario.ca/page/ontarios-open-data-directive">Open Data Directive</a>.
+          {% endtrans %}
+        </p>
         <p>
           <strong>{{ _("Why?") }} </strong> 
           {{ h.scheming_choices_label(h.scheming_field_choices(h.scheming_field_by_name(schema.dataset_fields,"exemption")),pkg['exemption']) }} - {{ h.scheming_language_text(pkg['exemption_rationale']) }}
         </p>
-    {% elif pkg['access_level'] == 'under_review' %} 
-      <strong>{{ _("Data Not Available") }}</strong>     
-      <p>
-        {% trans %}
-          This data might be made available in the future. We are reviewing the data in this record to determine if it can be made open.
-          <a href="http://www.ontario.ca/page/ontarios-open-data-directive">[Learn more]</a>
-        {% endtrans %}
-      </p>
+    {% elif pkg['access_level'] == 'under_review' %}
+        <strong>{{ _("Data Not Available") }}</strong>     
+        <p>
+          {% trans %}
+            This data might be made available in the future. We are reviewing the data in this record to determine if it can be made open.
+            <a href="http://www.ontario.ca/page/ontarios-open-data-directive">[Learn more]</a>
+          {% endtrans %}
+        </p>
     {% endif %}
     </div>
+  {% endif %}
 {% endif %}

--- a/ckanext/ontario_theme/templates/external/scheming/package/read.html
+++ b/ckanext/ontario_theme/templates/external/scheming/package/read.html
@@ -17,7 +17,6 @@
       {{ h.render_markdown(h.scheming_language_text(pkg['notes_translated'])) }}
     </div>
   {% endif %}
-  <h2>{% trans %}For more information{% endtrans %} </h2>
   {% set contact_name = h.get_translated(pkg, 'maintainer') %}
   {% set contact_email = pkg.maintainer_email %}
   {% if (not contact_name) and (not contact_email) %}
@@ -29,30 +28,32 @@
     {% endif %}
   {% endif %}
 
-  <div>
-    {% if contact_name %}  
-      {{contact_name}}
-    {% endif %}
-    {% if contact_name and contact_email %}
-      &nbsp;|&nbsp;
-    {% endif %}
-    {% if contact_page %}
+  <div class="ministry-contact">
+	<b>{% trans %}Ministry contact: {% endtrans %} </b>
+	{% if contact_email %}
+	  {% if contact_name %}
+      <a href="mailto:{{contact_email}}?subject={{pkg.title}}">
+        {{contact_name}}
+      </a>
+	  {% endif %}
+	  {% if not contact_name %}
+    	<a href="mailto:{{contact_email}}?subject={{pkg.title}}">
+      	{{contact_email}}
+    	</a>
+	  {% endif %}
+	{% endif %}
+	{% if contact_page %}
     <a href="{{contact_page}}">
-      {% trans %}Contact{% endtrans %} {{ h.get_translated(organization, 'title') }}
-    </a>
+      {{ h.get_translated(organization, 'title') }}
+	  </a>
     {% endif %}
-    {% if contact_email %}  
-    <a href="mailto:{{contact_email}}?subject={{pkg.title}}">
-      {{contact_email}}
-    </a>
-    {% endif %}
-
   </div>
 {% endblock %}
 
 {% block package_tags %}
   {# Remove tags in favor of keywords. #}
 {% endblock %}
+
 
 {% block package_additional_info %}
   {% snippet "scheming/package/snippets/additional_info.html",

--- a/ckanext/ontario_theme/templates/external/scheming/package/snippets/additional_info.html
+++ b/ckanext/ontario_theme/templates/external/scheming/package/snippets/additional_info.html
@@ -22,8 +22,10 @@
 
 {% block package_additional_info %}
   {%- for field in schema.dataset_fields -%}
-    {%- if field.field_name not in exclude_fields
-        and field.display_snippet is not none -%}
+  {%- if field.field_name not in exclude_fields
+    and field.display_snippet is not none
+    and pkg_dict[field.field_name] 
+    and (pkg_dict[field.field_name] != {'fr': '', 'en': ''})-%}
       <tr>
         <th scope="row" class="dataset-label">{{
           h.scheming_language_text(field.label) }}</th>

--- a/ckanext/ontario_theme/templates/internal/package/read.html
+++ b/ckanext/ontario_theme/templates/internal/package/read.html
@@ -1,6 +1,27 @@
 {% extends "package/read_base.html" %}
 
+{% block primary %}
+<article class="module package-z-index">
+  <header class="page-header col-sm-8">
+    <div class="content_action">
+      {% block content_action %}
+      {% if h.check_access('package_update', {'id':pkg.id }) %}
+      {% link_for _('Edit'), named_route='dataset.edit', id=pkg.name, class_='btn btn-secondary', icon='wrench' %}
+      {% endif %}
+      {% endblock %}
+    </div>
+    <ul class="nav nav-tabs">
+      {% block content_primary_nav %}
+      {{ h.build_nav_icon(dataset_type ~ '.read', _('Dataset'), id=pkg.id if is_activity_archive else pkg.name) }}
+      <!--{{ h.build_nav_icon(dataset_type ~ '.groups', _('Groups'), id=pkg.id if is_activity_archive else pkg.name) }}-->
+      {{ h.build_nav_icon(dataset_type ~ '.activity', _('Activity Stream'), id=pkg.id if is_activity_archive else pkg.name) }}
+      {% endblock %}
+    </ul>
+  </header>
+{# Override CKAN: Do not pass any icons to nav bar menu items #}
+
 {% block primary_content_inner %}
+<div class="col-sm-8 col-xs-12">
   {% if pkg.get("asset_type") == "algorithm" %}
 	<div class="new-alert alert-info alert-algorithms alert-huge alert-clear">
 		<strong>{% trans %}Algorithm/AI Asset{% endtrans %}</strong>
@@ -42,7 +63,7 @@
     </h1>
     {% block package_notes %}
       {% if pkg.notes %}
-        <div class="notes embedded-content">
+        <div class="notes embedded-content dataset-font">
           {{ h.render_markdown(h.get_translated(pkg, 'notes')) }}
         </div>
       {% endif %}
@@ -54,26 +75,29 @@
   {% block package_additional_info %}
     {% snippet "package/snippets/additional_info.html", pkg_dict=pkg %}
   {% endblock %}
-
-  {% block package_resources %}
-    {% snippet "package/snippets/resources_list.html", pkg=pkg, resources=pkg.resources, is_activity_archive=is_activity_archive %}
-  {% endblock %}
-
-  {% block package_tags %}
-    {% snippet "package/snippets/tags.html", tags=pkg.tags %}
-  {% endblock %}
-
-  <div class="ontario-callout ontario-border-highlight--purple">
-    <h2 class="ontario-callout__title ontario-h5">{{ _("Report an error with this data") }}</h2>
-    <p>{% trans %}Fill out a <a href="https://www.ontario.ca/form/report-data-error">Data Catalogue error report</a> to let us know if there are issues with the resources in this dataset.{% endtrans %}</p>
-  </div>
-
-  <div class="container">
-  <div class="row">
-    <div class="col-md-12">
-      {% snippet 'home/snippets/ontario_theme_contact_us.html' %}
+  </div>  
+  <div class="col-xs-12">
+    {% block package_resources %}
+      {% snippet "package/snippets/resources_list.html", pkg=pkg, resources=pkg.resources, is_activity_archive=is_activity_archive %}
+    {% endblock %}
+  
+    {% block package_tags %}
+      {% snippet "package/snippets/tags.html", tags=pkg.tags %}
+    {% endblock %}
+  
+    <div class="ontario-callout ontario-border-highlight--purple">
+      <h2 class="ontario-callout__title ontario-h5">{{ _("Report an error with this data") }}</h2>
+      <p>{% trans %}Fill out a <a href="https://www.ontario.ca/form/report-data-error">Data Catalogue error report</a> to let us know if there are issues with the resources in this dataset.{% endtrans %}</p>
+    </div>
+  
+    <div class="container">
+    <div class="row">
+      <div class="col-md-12">
+        {% snippet 'home/snippets/ontario_theme_contact_us.html' %}
+      </div>
+    </div>
     </div>
   </div>
-  </div>
-
+{% endblock %}
+</article>
 {% endblock %}

--- a/ckanext/ontario_theme/templates/internal/package/read.html
+++ b/ckanext/ontario_theme/templates/internal/package/read.html
@@ -1,8 +1,7 @@
-{% ckan_extends %}
-
+{% extends "package/read_base.html" %}
 
 {% block primary_content_inner %}
-	{% if pkg.get("asset_type") == "algorithm" %}
+  {% if pkg.get("asset_type") == "algorithm" %}
 	<div class="new-alert alert-info alert-algorithms alert-huge alert-clear">
 		<strong>{% trans %}Algorithm/AI Asset{% endtrans %}</strong>
 		<p>
@@ -11,6 +10,70 @@
 			{% endtrans %}
 	    </p>  
 	</div>
-	{% endif %}
-	{{ super() }}
+  {% endif %}
+  {{ super() }}
+  {% block package_description %}
+    {% if pkg.private %}
+      <span class="dataset-private label label-inverse pull-right">
+        <i class="fa fa-lock"></i>
+        {{ _('Private') }}
+      </span>
+    {% endif %}
+    {% block package_archive_notice %}
+      {% if is_activity_archive %}
+        <div class="alert alert-danger">
+          {% trans url=h.url_for(pkg.type ~ '.read', id=pkg.id) %}
+          You're currently viewing an old version of this dataset. To see the
+          current version, click <a href="{{ url }}">here</a>.
+          {% endtrans %}
+        </div>
+      {% endif %}
+    {% endblock %}
+    <h1>
+      {% block page_heading %}
+        {{ h.dataset_display_name(pkg) }}
+        {% if pkg.state.startswith('draft') %}
+          [{{ _('Draft') }}]
+        {% endif %}
+        {% if pkg.state == 'deleted' %}
+          [{{ _('Deleted') }}]
+        {% endif %}
+      {% endblock %}
+    </h1>
+    {% block package_notes %}
+      {% if pkg.notes %}
+        <div class="notes embedded-content">
+          {{ h.render_markdown(h.get_translated(pkg, 'notes')) }}
+        </div>
+      {% endif %}
+    {% endblock %}
+    {# FIXME why is this here? seems wrong #}
+    <span class="insert-comment-thread"></span>
+  {% endblock %}
+ 
+  {% block package_additional_info %}
+    {% snippet "package/snippets/additional_info.html", pkg_dict=pkg %}
+  {% endblock %}
+
+  {% block package_resources %}
+    {% snippet "package/snippets/resources_list.html", pkg=pkg, resources=pkg.resources, is_activity_archive=is_activity_archive %}
+  {% endblock %}
+
+  {% block package_tags %}
+    {% snippet "package/snippets/tags.html", tags=pkg.tags %}
+  {% endblock %}
+
+  <div class="ontario-callout ontario-border-highlight--purple">
+    <h2 class="ontario-callout__title ontario-h5">{{ _("Report an error with this data") }}</h2>
+    <p>{% trans %}Fill out a <a href="https://www.ontario.ca/form/report-data-error">Data Catalogue error report</a> to let us know if there are issues with the resources in this dataset.{% endtrans %}</p>
+  </div>
+
+  <div class="container">
+  <div class="row">
+    <div class="col-md-12">
+      {% snippet 'home/snippets/ontario_theme_contact_us.html' %}
+    </div>
+  </div>
+  </div>
+
 {% endblock %}

--- a/ckanext/ontario_theme/templates/internal/package/read_base.html
+++ b/ckanext/ontario_theme/templates/internal/package/read_base.html
@@ -9,7 +9,7 @@
 {# Override CKAN: Do not pass any icons to nav bar menu items #}
 {% block content_primary_nav %}
   {{ h.build_nav_icon(dataset_type ~ '.read', _('Dataset'), id=pkg.id if is_activity_archive else pkg.name) }}
-  {{ h.build_nav_icon(dataset_type ~ '.groups', _('Groups'), id=pkg.id if is_activity_archive else pkg.name) }}
+  <!--{{ h.build_nav_icon(dataset_type ~ '.groups', _('Groups'), id=pkg.id if is_activity_archive else pkg.name) }}-->
   {{ h.build_nav_icon(dataset_type ~ '.activity', _('Activity Stream'), id=pkg.id if is_activity_archive else pkg.name) }}
 {% endblock %}
 

--- a/ckanext/ontario_theme/templates/internal/package/read_base.html
+++ b/ckanext/ontario_theme/templates/internal/package/read_base.html
@@ -1,22 +1,11 @@
 {% ckan_extends %}
 
-{% block content_action %}
-  {% if h.check_access('package_update', {'id':pkg.id }) %}
-    {% link_for _('Edit'), named_route='dataset.edit', id=pkg.name, class_='btn btn-secondary', icon='wrench' %}
-  {% endif %}
-{% endblock %}
-
-{# Override CKAN: Do not pass any icons to nav bar menu items #}
-{% block content_primary_nav %}
-  {{ h.build_nav_icon(dataset_type ~ '.read', _('Dataset'), id=pkg.id if is_activity_archive else pkg.name) }}
-  <!--{{ h.build_nav_icon(dataset_type ~ '.groups', _('Groups'), id=pkg.id if is_activity_archive else pkg.name) }}-->
-  {{ h.build_nav_icon(dataset_type ~ '.activity', _('Activity Stream'), id=pkg.id if is_activity_archive else pkg.name) }}
-{% endblock %}
-
+{% block secondary %}
+<aside class="secondary col-sm-4 right-col dataset-font">
 {% block package_info %}
   <div class="module module-narrow module-shallow context-info">
-    <h2 class="module-heading">{{ _("Keep updated") }}</h2>
-    <section class="module-content">
+    <h2 class="aside-heading">{{ _("Stay updated via RSS") }}</h2>
+    <section>
       <p>
         {{ _("Subscribe to updates to this dataset using RSS.") }}
       </p>
@@ -27,4 +16,17 @@
       </p>
     </section>
   </div>
+{% endblock %}
+
+  {% block package_organization %}
+    {% if pkg.organization %}
+      {% set org = h.get_organization(pkg.organization.id) %}
+      {% snippet "snippets/organization.html", organization=org, has_context_title=true %}
+    {% endif %}
+  {% endblock %}
+
+  {% block package_license %}
+    {% snippet "snippets/license.html", pkg_dict=pkg %}
+  {% endblock %}
+</aside>
 {% endblock %}

--- a/ckanext/ontario_theme/templates/internal/package/snippets/resource_item.html
+++ b/ckanext/ontario_theme/templates/internal/package/snippets/resource_item.html
@@ -11,36 +11,32 @@
 <li class="resource-item row" data-id="{{ res.id }}">
   <div class="col-md-6 col-xs-12">
     {% block resource_item_title %}
-      <a class="heading" href="{{ url }}" title="{{ res.name or res.description }}">
-        {% if res.format in h.dict_list_reduce(pkg.resources, 'format') and res.format | length < 5 %}
-            <span class="label label-default" property="dc:format" data-format="{{ res.format.lower() or 'data' }}">{{ h.get_translated(res, 'format') }}</span> 
-        {% else %}
-          <span class="label label-default" data-format="other">other</span>
-        {% endif %}
+    {% if res.format in h.dict_list_reduce(pkg.resources, 'format') and res.format | length < 5 %}
+    <span class="label label-default" property="dc:format" data-format="{{ res.format.lower() or 'data' }}">{{ h.get_translated(res, 'format') }}</span> 
+    {% else %}
+    <span class="label label-default" data-format="other">other</span>
+    {% endif %}
+      <a class="resource-item-title" href="{{ url }}" title="{{ res.name or res.description }}">
         {{ h.resource_display_name(res) | truncate(50) }}
-        {% if res.size %}
-          <span class="text-muted small"> 
-            ({{ h.localised_filesize(res.size) }})
-          </span>
-        {% endif %}
         {{ h.popular('views', res.tracking_summary.total, min=10) }}
       </a>
+      {% if res.language %}
+            <span class="label label-{{res.language}}">
+              {{ h.scheming_choices_label(
+              h.scheming_field_choices(h.scheming_field_by_name(schema.resource_fields, 'language')), res.language) }}
+            </span>
+      {% endif %}
     {% endblock %}
     {% block resource_item_description %}
       {% if res.data_last_updated or res.language %}
-        <p class="description details"> 
+        <p class="description details resource-item-description"> 
           {% if res.data_last_updated %}
-            {{ _("Last Updated") }}: {{ h.render_datetime(res.data_last_updated) }} | 
+            {{ _("Last Updated") }}: {{ h.render_datetime(res.data_last_updated) }} 
           {% endif %}
-          {% if res.language %}
-            <span class="label label-{{res.language}}">
-              {{ h.scheming_choices_label(
-  h.scheming_field_choices(h.scheming_field_by_name(schema.resource_fields, 'language')), res.language) }}
-            </span>
-          {% endif %}
+          
         </p>
       {% endif %}    
-      <p class="description">
+      <p class="description resource-item-description">
         {% if res.description %}
           {{ h.markdown_extract(h.get_translated(res, 'description'), extract_length=80) }}
         {% endif %}
@@ -52,13 +48,18 @@
       {% if not url_is_edit %}
       <div>
         {% block resource_item_explore_links %}
-            <a href="{{ url }}" class="btn btn-primary">
+            <a href="{{ url }}" class="ontario-button ontario-button--secondary">
               {% if res.format == "CSV" %}
                 <i class="fa fa-bar-chart-o"></i>
                 {{ _('Preview') }}
               {% else %}
                 <i class="fa fa-info-circle"></i>
                 {{ _('About') }}
+              {% endif %}
+              <br>
+              {% if res.language and res.language != 'english_and_french'%}
+                  {{ h.scheming_choices_label(
+                    h.scheming_field_choices(h.scheming_field_by_name(schema.resource_fields, 'language')), res.language) }}
               {% endif %}
             </a>
           {% if res.url and h.is_url(res.url) %}
@@ -69,19 +70,32 @@
             {% else %}
               {% set this_group = '' %}
             {% endif %}
-            <a href="{{ res.url }}" class="resource-url-analytics btn btn-primary dataset-download-link" onclick="trackDownload('{{ res.url }}', '{{ this_org }}', '{{ pkg.title }}', '{{ this_group }}');return true;">
+            <a href="{{ res.url }}" class="resource-url-analytics ontario-button ontario-button--primary dataset-download-link" onclick="trackDownload('{{ res.url }}', '{{ this_org }}', '{{ pkg.title }}', '{{ this_group }}');return true;">
               {% if res.has_views or res.url_type == 'upload' %}
                 <i class="fa fa-arrow-circle-o-down"></i>
                 {{ _('Download') }}
+                <br>
+                {% if res.language and res.language != 'english_and_french'%}
+                {{ h.scheming_choices_label(
+                  h.scheming_field_choices(h.scheming_field_by_name(schema.resource_fields, 'language')), res.language) }}
+                {% endif %}
+                {% if res.size %}
+                ({{ h.localised_filesize(res.size) }})
+                {% endif %}
               {% else %}
                 <i class="fa fa-external-link"></i>
                 {{ _('Open') }}
+                <br>
+                {% if res.language and res.language != 'english_and_french'%}
+                {{ h.scheming_choices_label(
+                h.scheming_field_choices(h.scheming_field_by_name(schema.resource_fields, 'language')), res.language) }}
+                {% endif %}
               {% endif %}
             </a>
           {% endif %}
           {% set can_edit = h.check_access('package_update', {'id':pkg.id }) and h.check_access('resource_update', res) %}
           {% if can_edit %}
-            <a href="{{ h.url_for(pkg.type ~ '_resource.edit', id=pkg.name, resource_id=res.id) }}" class="btn btn-primary">
+            <a href="{{ h.url_for(pkg.type ~ '_resource.edit', id=pkg.name, resource_id=res.id) }}" class="ontario-button ontario-button--tertiary">
               <i class="fa fa-pencil-square-o"></i>
               {{ _('Edit') }}
             </a>

--- a/ckanext/ontario_theme/templates/internal/package/snippets/resources_list.html
+++ b/ckanext/ontario_theme/templates/internal/package/snippets/resources_list.html
@@ -3,11 +3,13 @@
 #}
 
 <section id="dataset-resources" class="resources">
-  <h2>{{ _('Data') }}</h2>
+	<h2>{{ _(h.dataset_display_name(pkg)) }}</h2>
+  <p class="dataset-font">
+    {{ _("Learn more about ")}} <a href="/{{ request.environ.CKAN_LANG }}/about#training-materials">{{ _("accessing data using different file types.")}}</a>
+  </p> 
   {% block resource_list %}
     {% snippet "package/snippets/ontario_theme_access_level.html",
       pkg=pkg, dataset_type=dataset_type, schema=schema, resources=resources %}
-
     {% if resources %}
         {% block resource_list_inner %}
           {% set can_edit = h.check_access('package_update', {'id':pkg.id }) %}
@@ -17,9 +19,9 @@
           {% for group in resources|selectattr("type","equalto","data")|groupby("data_range")|sort(attribute="grouper", reverse=True) %}
 
             {% if group.list[0].data_range != "N/A - N/A" %}
-              <h3>{{group.list[0].data_range}}</h3>
-            {% else %}
-              <h3>{{ _("No date range") }}</h3>
+			  <p class="date-range">{{ _("Date range")+_(":")}} {{h.render_datetime(group.list[0].data_range_start)}} - {{h.render_datetime(group.list[0].data_range_end)}}</p>
+        {% else %}
+              <p class="date-range">{{ _("No date range") }}</p>
             {% endif %}
             <ul class="{% block resource_list_class %}resource-list{% endblock %}">
             {% for r in group.list|selectattr("format", "equalto", "CSV") %}
@@ -41,6 +43,7 @@
               {% snippet 'package/snippets/resource_item.html', pkg=pkg, res=r, can_edit=can_edit, schema=schema %}
             {% endfor %}
             </ul>
+            <hr>
           {% endfor %}
         {% endblock %}
       <h2>{{ _("Supporting Files") }}</h2>

--- a/ckanext/ontario_theme/templates/internal/snippets/license.html
+++ b/ckanext/ontario_theme/templates/internal/snippets/license.html
@@ -19,9 +19,12 @@
 
 <!-- This block is for the license section in the sidebar on
      the dataset page, not the table on the resource page -->
+{% block license_title %}
+  <h2 class="aside-heading"> <i class="fa fa-lock"></i> {{ _('License') }}</h2>
+{% endblock %}
 {% block license_content %}
   {% if license %}
-  <p class="module-content">
+  <p>
     {% block license_content_inner %}
       {{ license_string_from_license(license._data) }}
       {% if pkg_dict.isopen %}
@@ -31,7 +34,7 @@
       {% endif %}
     {% endblock %}
   </p>
-  <p class="module-content">
+  <p>
     {% if h.get_translated(license._data, 'description') %}
       {{ h.get_translated(license._data, 'description') }}
     {% endif %}

--- a/ckanext/ontario_theme/templates/internal/snippets/organization.html
+++ b/ckanext/ontario_theme/templates/internal/snippets/organization.html
@@ -2,9 +2,9 @@
 {% block info %}
   <div class="module module-narrow module-shallow context-info">
     {% if has_context_title %}
-      <h2 class="module-heading">{{ _('Ministry') }}</h2>
+      <h2 class="aside-heading">{{ _('Ministry') }}</h2>
     {% endif %}
-    <section class="module-content">
+    <section>
       {% block inner %}
       {% block heading %}
 	  <h3 class="ontario-module-h3">{{ h.get_translated(organization, "title") or organization.name }}

--- a/ckanext/ontario_theme/templates/internal/snippets/organization.html
+++ b/ckanext/ontario_theme/templates/internal/snippets/organization.html
@@ -1,41 +1,53 @@
 {% ckan_extends %}
-
-{% block heading %}
-  <h3 class="ontario-module-h3">{{ h.get_translated(organization, "title") or organization.name }}
-    {% if organization.state == 'deleted' %}
-      [{{ _('Deleted') }}]
+{% block info %}
+  <div class="module module-narrow module-shallow context-info">
+    {% if has_context_title %}
+      <h2 class="module-heading">{{ _('Ministry') }}</h2>
     {% endif %}
-  </h3>
-{% endblock %}
-
-{% block description %}
-  {% if h.get_translated(organization,"description") %}
-    <p>
-      {{ h.markdown_extract(h.get_translated(organization,"description"), 180) }}
-      {% link_for _('read more'), named_route='organization.about', id=organization.name %}
-    </p>
-  {% else %}
-    <p class="empty">{{ _('There is no description for this ministry.') }}</p>
-  {% endif %}
-{% endblock %}
-
-{% block nums %}
-  <div class="nums">
-    <dl>
-      <dt>{{ _('Datasets') }}</dt>
-      <dd>{{ h.SI_number_span(organization.package_count) }}</dd>
-    </dl>
+    <section class="module-content">
+      {% block inner %}
+      {% block heading %}
+	  <h3 class="ontario-module-h3">{{ h.get_translated(organization, "title") or organization.name }}
+		{% if organization.state == 'deleted' %}
+		  [{{ _('Deleted') }}]
+		{% endif %}
+	  </h3>
+	  {% endblock %}
+      {% block description %}
+	  {% if h.get_translated(organization,"description") %}
+		<p>
+		  {{ h.markdown_extract(h.get_translated(organization,"description"), 180) }}
+		  {% link_for _('read more'), named_route='organization.about', id=organization.name %}
+		</p>
+	  {% else %}
+		<p class="empty">{{ _('There is no description for this ministry.') }}</p>
+	  {% endif %}
+	  {% endblock %}
+      {% if show_nums %}
+        {% block nums %}
+	  <div class="nums">
+		<dl>
+		  <dt>{{ _('Datasets') }}</dt>
+		  <dd>{{ h.SI_number_span(organization.package_count) }}</dd>
+		</dl>
+	  </div>
+	  {% endblock %}
+        {% block follow %}
+	  <hr />
+	  <h2 class="module-heading">{{ _("Keep updated") }}</h2>
+	  <p>
+		{{ _("Subscribe to updates to this ministry using RSS.") }}
+	  </p>
+	  <p>
+		<a href="/feeds/organization/{{ organization.name }}.atom" class="btn btn-primary">
+		  <i class="fa fa-rss"></i> {{ _('Subscribe') }}
+		</a>
+	  </p>
+	  {% endblock %}
+      {% endif %}
+      {% endblock %}
+    </section>
   </div>
-{% endblock %}
-{% block follow %}
-  <hr />
-  <h2 class="module-heading">{{ _("Keep updated") }}</h2>
-  <p>
-    {{ _("Subscribe to updates to this ministry using RSS.") }}
-  </p>
-  <p>
-    <a href="/feeds/organization/{{ organization.name }}.atom" class="btn btn-primary">
-      <i class="fa fa-rss"></i> {{ _('Subscribe') }}
-    </a>
-  </p>
-{% endblock %}
+  {% endblock %}
+
+


### PR DESCRIPTION
### What this PR accomplishes
[DATA-546](https://ontariodigital.atlassian.net/browse/DATA-546)
- Moves left-hand items to the right side
- Removes the images associated with ministries
- Removes the “Groups” tab from the navigation bar
- Moves the “Additional Information” section above the resources
- Suppresses empty metadata fields in the "Additional Information" section.
- Removes the green box with checkmark that says "Data available"
- Changes the heading Data to the dataset name
- Adds a ministry contact link at the bottom of the dataset description - (DATA-632)
- Changes the date range format to Month Day, Year

### What still needs to be done
- There are a few files where I have commented out previous code instead of removing it.
- Translations have not been added to the .po / .pot files, nor has it been compiled.
- ` h.render_datetime` is behaving unexpectedly when changing the date range format (it displays the day before the actual dates).