### PR TITLE
CKAN 2.9 placeholder cross browser compatibility

### DIFF
--- a/ckanext/ontario_theme/fanstatic/common.css
+++ b/ckanext/ontario_theme/fanstatic/common.css
@@ -345,13 +345,13 @@ input[type=reset].ontario-search-reset.home{
     padding-right: 8rem;
   }
 }
-::placeholder{
+input[placeholder] {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  color: #999999;
   opacity: 1;
 }
+
 :-ms-input-placeholder {
   /* Internet Explorer 10-11 */
   color: #999999;


### PR DESCRIPTION
## What this PR accomplishes

Provides cross-browser support for placeholder styling

## Issue(s) addressed

The French placeholder text is too long for mobile. This issue was previously fixed in #286 but the solution on worked for Firefox. This PR is to align other browsers with Firefox.

## What needs review

In browsers, such as Edge, Safari, Firefox, and Chrome, long placeholders throughout the site should have an ellipsis and not be abruptly cut off. 

**(Left is the issue being fixed and right is what the PR accomplishes)**
![screenshot](https://user-images.githubusercontent.com/60950452/225347457-bb908ce4-932e-4e2c-a715-724a564d68be.png)

