### PR TITLE
Remove image profile pic from groups

### DIFF
--- a/ckanext/ontario_theme/templates/internal/group/snippets/group_item.html
+++ b/ckanext/ontario_theme/templates/internal/group/snippets/group_item.html
@@ -1,8 +1,12 @@
 {% ckan_extends %}
 
+{% block image %}
+{% endblock %}
+
 {% block title %}
   <h3 class="media-heading">{{ h.get_translated(group,"title") }}</h3>
 {% endblock %}
+
 {% block description %}
   {% if h.get_translated(group,"description") %}
     <p>{{ h.markdown_extract(h.get_translated(group,"description"), extract_length=80) }}</p>

--- a/ckanext/ontario_theme/templates/internal/group/snippets/info.html
+++ b/ckanext/ontario_theme/templates/internal/group/snippets/info.html
@@ -1,5 +1,9 @@
 {% ckan_extends %}
 
+{# Make block image empty to prevent code for image from loading #}
+{% block image %}
+{% endblock %}
+
 {% block heading %}
 <h1 class="heading">
   {{ h.get_translated(group, "title") }}

--- a/ckanext/ontario_theme/templates/internal/snippets/group.html
+++ b/ckanext/ontario_theme/templates/internal/snippets/group.html
@@ -13,9 +13,6 @@ Example:
 {% with truncate=truncate or 0, url=h.url_for('group.read', id=group.name) %}
   <section class="module module-narrow module-shallow group">
     <div class="module-content media media-vertical">
-      <a class="media-image" href="{{ url }}">
-        <img src="{{ group.image_display_url or h.url_for_static('/base/images/placeholder-group.png') }}" class="img-responsive" width="200" height="125" alt="{{ group.name }}" />
-      </a>
       <div class="media-content">
         <h3 class="media-heading"><a href={{ url }}>{{ h.get_translated(group, "title") or group.name }}</a></h3>
         {% if h.get_translated(group, "description") %}


### PR DESCRIPTION
## What this PR accomplishes
Removes block that displays a profile image from the Groups pages

## What needs review
Confirm that no image is displayed on any Group page