### PR TITLE
About and Help page padding

### DIFF
--- a/ckanext/ontario_theme/fanstatic/common.css
+++ b/ckanext/ontario_theme/fanstatic/common.css
@@ -1723,3 +1723,8 @@ section#dataset-resources > h2{
   background-color: #F8E5C3;
   color: #000;
 }
+
+/* About and Help page header */
+.module h1 {
+  margin: 2.5rem 0 1.5rem 0;
+}

--- a/ckanext/ontario_theme/fanstatic/external/ontario_theme.css
+++ b/ckanext/ontario_theme/fanstatic/external/ontario_theme.css
@@ -598,9 +598,6 @@ div#topics div.row {
 /* =====================================================
    Typography
    ===================================================== */
-#about h2 {
-  margin-top: 30px;
-}
 #about .metadata-item,
 #about .format-item {
   border-bottom: solid 1px #ccc;

--- a/ckanext/ontario_theme/templates/external/home/help.html
+++ b/ckanext/ontario_theme/templates/external/home/help.html
@@ -8,8 +8,8 @@
 
 {% block primary %}
   <article class="module">
-    <div class="module-content">
-      <h1 class="page-heading">{{ _('Help') }}</h1>
+    <div class="col-xs-12">
+      <h1>{{ _('Help') }}</h1>
     
       {% trans %}<p>Need more help or want to learn more about the data catalogue? <a href="https://www.ontario.ca/feedback/contact-us?id=532365&nid=138269">Contact us</a> — we’ll gladly answer any questions you might have!</p>{% endtrans %}
 

--- a/ckanext/ontario_theme/templates/internal/home/about.html
+++ b/ckanext/ontario_theme/templates/internal/home/about.html
@@ -4,7 +4,9 @@
   {% if g.site_about %}
     {{ h.render_markdown(g.site_about, False, True) }}
   {% else %}
-    <h1 class="page-heading">{{ _('About') }}</h1>
-    {% snippet 'home/snippets/about_text.html' %}
+    <h1 class="col-xs-12">{{ _('About') }}</h1>
+    <div class="col-xs-12">
+      {% snippet 'home/snippets/about_text.html' %}
+    </div>
   {% endif %}
 {% endblock %}


### PR DESCRIPTION
## What this PR accomplishes & Issue(s) addressed

- Padding has disappeared on mobile About and Help pages. Please restore to 15px padding left/right

## What needs review

- Padding in mobile for both the About and Help pages should be 15px on the left and right and aligns with the navigation bar
