### PR TITLE
Ckan 2.9 keyword text

### DIFF
--- a/ckanext/ontario_theme/plugin.py
+++ b/ckanext/ontario_theme/plugin.py
@@ -1030,8 +1030,8 @@ type data_last_updated
         facets_dict['access_level'] = toolkit._('Access Level')
         facets_dict['asset_type'] = toolkit._('Asset Type')
         facets_dict['update_frequency'] = toolkit._('Update Frequency')
-        facets_dict['keywords_en'] = toolkit._('Keywords')
-        facets_dict['keywords_fr'] = toolkit._('Keywords')
+        facets_dict['keywords_en'] = toolkit._('Topics')
+        facets_dict['keywords_fr'] = toolkit._('Topics')
         facets_dict.pop('tags', None) # Remove tags in favor of keywords
         facets_dict['organization_jurisdiction'] = toolkit._('Jurisdiction')
         facets_dict['organization_category'] = toolkit._('Category')

--- a/ckanext/ontario_theme/templates/internal/snippets/ontario_theme_keywords_facet.html
+++ b/ckanext/ontario_theme/templates/internal/snippets/ontario_theme_keywords_facet.html
@@ -6,11 +6,9 @@ language.
 #}
 
 {% if h.lang() == 'en' %}
-  {% set keyword_title = 'Topics' %}
   {{ h.snippet('snippets/facet_list.html',
-  title=keyword_title, name='keywords_en', extras=extras) }}
+  title=c.facet_titles['keywords_en'], name='keywords_en', extras=extras) }}
 {% elif h.lang() == 'fr' %}
-  {% set keyword_title = 'Sujets' %}
   {{ h.snippet('snippets/facet_list.html',
-  title=keyword_title, name='keywords_fr', extras=extras) }}
+  title=c.facet_titles['keywords_fr'], name='keywords_fr', extras=extras) }}
 {% endif %}


### PR DESCRIPTION
## Issue(s) addressed

- changes "keywords"/"mot clées" to "topics"/"sujets" in search results box

## What needs review

- In the search results box and the filter headings "topics"/"sujets" should be displayed instead of "keywords"/"mot clées"

### Note:
I am not taking into account pluralization.