### PR TITLE
Removes API link at bottom of dataset search page

### DIFF
--- a/ckanext/ontario_theme/templates/internal/package/search.html
+++ b/ckanext/ontario_theme/templates/internal/package/search.html
@@ -94,8 +94,8 @@ in the core template for search.html.
     {% endblock %}
   </section>
 
+  {# Override CKAN block to remove API link #}
   {% block package_search_results_api %}
-    {{ super() }}
   {% endblock %}
 {% endblock %}
 


### PR DESCRIPTION
## What this PR accomplishes
Removes the API link at the bottom of the datasets search page:
![Screen Shot 2023-03-21 at 15 25 26](https://user-images.githubusercontent.com/1254764/226719324-9d4cfd2a-785f-4675-93a1-f391d8adc64e.png)


## What needs review
Verify that this line is gone from the bottom of the dataset search page.