### PR TITLE
prevent orgs from being sorted on initial launch

### DIFF
--- a/ckanext/ontario_theme/plugin.py
+++ b/ckanext/ontario_theme/plugin.py
@@ -557,17 +557,26 @@ def get_all_organizations(**kwargs):
     # Get the id of all organizations in the catalogue.
     all_organization_names = toolkit.get_action('organization_list')(data_dict={})
     
-    # Filter only those organizations whose names matching those in 
-    # collection_names. Then use helper function h.get_organization() 
-    # to extract the full details for each organization, matching on 'id'.
-    org_array = []
-    for name in collection_names:
-        for idx in range(len(all_organization_names)):
-            if name == all_organization_names[idx]:
-                organization_obj = toolkit.get_action('organization_show')(data_dict={'id':name})
-                organization_id = organization_obj['id']
-                org_array.append(h.get_organization(organization_id))
-    
+    # When there are no organizations in the catalogue (e.g. when application is 
+    # first installed and database not yet indexed), the below try will fail and
+    # and empty array will be returned, preventing the template from calling 
+    # the sort method on organizations.
+    try:
+        this_name = all_organization_names[0]
+        if toolkit.get_action('organization_show')(data_dict={'id':this_name}):
+            # Filter only those organizations whose names matching those in 
+            # collection_names. Then use helper function h.get_organization() 
+            # to extract the full details for each organization, matching on 'id'.
+            org_array = []
+            for name in collection_names:
+                for idx in range(len(all_organization_names)):
+                    if name == all_organization_names[idx]:
+                        organization_obj = toolkit.get_action('organization_show')(data_dict={'id':name})
+                        organization_id = organization_obj['id']
+                        org_array.append(h.get_organization(organization_id))
+    except:
+        org_array = []
+
     return org_array
 
 def sort_by_title_translated(item_list, **kwargs):

--- a/ckanext/ontario_theme/templates/internal/organization/index.html
+++ b/ckanext/ontario_theme/templates/internal/organization/index.html
@@ -75,15 +75,18 @@
         {# Get all organization returned by query #}
         {% set org_list = h.ontario_theme_get_all_organizations(collection_names=c.page.collection) %}
         
-        {# Sort org_list by title_translated as per current language #}
-        {% set current_lang = request.environ.CKAN_LANG %}
-        {% set reverse = True if 'desc' in request.params['sort'] else False %}
-        {% set sorted_org = h.ontario_theme_sort_by_title_translated(org_list,                                                                                                              
-                                                                     current_page=c.page.page,
-                                                                     items_per_page=c.page.items_per_page,
-                                                                     lang=current_lang, 
-                                                                     reverse=reverse) %}
-        {% snippet "organization/snippets/organization_list.html", organizations=sorted_org %}
+        {# Prevent any organization sorting when there are no organizations #}
+        {% if org_list | length > 0  %}
+          {# Sort org_list by title_translated as per current language #}
+          {% set current_lang = request.environ.CKAN_LANG %}
+          {% set reverse = True if 'desc' in request.params['sort'] else False %}
+          {% set sorted_org = h.ontario_theme_sort_by_title_translated(org_list,                                                                                                              
+                                                                      current_page=c.page.page,
+                                                                      items_per_page=c.page.items_per_page,
+                                                                      lang=current_lang, 
+                                                                      reverse=reverse) %}
+          {% snippet "organization/snippets/organization_list.html", organizations=sorted_org %}
+        {% endif %}
       {% endif %}
     {% else %}
       <p class="empty">


### PR DESCRIPTION
## What this PR accomplishes
Prevents the function that sorts organization names from being called when there are no organizations in the application.

## What needs review

- Check on the pre-launch version that the Ministries tab does not crash.
- Check on local version that Ministry sort and search still works the same