### PR TITLE
Fix broken group page

### DIFF
--- a/ckanext/ontario_theme/templates/internal/group/snippets/group_list.html
+++ b/ckanext/ontario_theme/templates/internal/group/snippets/group_list.html
@@ -28,7 +28,11 @@
             {% endif %}
 
             {% for group in groups %}
-              {% set this_group_title_translated = group['title_translated'][current_lang] %}
+                {% if group['title_translated'][current_lang] %}
+                    {% set this_group_title_translated = group['title_translated'][current_lang] %}
+                {% else %}
+                    {% set this_group_title_translated = group['title'] %}
+                {% endif %}
              {% snippet "group/snippets/group_item.html", group=group, position=loop.index %}
             {% endfor %}
         {% endblock %}


### PR DESCRIPTION
## What this PR accomplishes
Fixes the broken group page by adding a check to use group title if no titles are translated.

## What needs review
Confirm that group page displays when a group does not have a `title_translated` field.