### PR TITLE
make Relevance the default sort order

### DIFF
--- a/ckanext/ontario_theme/templates/internal/group/read.html
+++ b/ckanext/ontario_theme/templates/internal/group/read.html
@@ -23,9 +23,9 @@ block. super() will end up calling the facets twice.
     (_('Last Modified'), 'metadata_modified desc'),
     (_('Popular'), 'views_recent desc') if g.tracking_enabled else (false, false) ]
   %}
-  {# Make 'Last modified' the default selection when first landing on page #}
+  {# Make 'Relevance' the default selection when first landing on page #}
   {% if not sort_by_selected %}
-    {% set sort_by_selected = 'metadata_modified desc' %}
+    {% set sort_by_selected = 'score desc, metadata_modified desc' %}
   {% endif %}
   {% set form_id = 'group-datasets-search-form' %}
   <form id="{{ form_id }}" class="search-form" method="get" data-module="select-switch" novalidate>

--- a/ckanext/ontario_theme/templates/internal/organization/read.html
+++ b/ckanext/ontario_theme/templates/internal/organization/read.html
@@ -22,9 +22,9 @@ Override CKAN's read.html to add some new facets.
     (_('Popular'), 'views_recent desc') if g.tracking_enabled else (false, false) ]
   %}
 
-  {# Make 'Last modified' the default selection when first landing on page #}
+  {# Make 'Relevance' the default selection when first landing on page #}
   {% if not sort_by_selected %}
-    {% set sort_by_selected = 'metadata_modified desc' %}
+    {% set sort_by_selected = 'score desc, metadata_modified desc' %}
   {% endif %}
   {% set searchbar_text = gettext('Search %(ministry)s datasets', ministry=ministry) %}
   {% set searchbar_title = searchbar_text + _(':') %}

--- a/ckanext/ontario_theme/templates/internal/package/search.html
+++ b/ckanext/ontario_theme/templates/internal/package/search.html
@@ -47,12 +47,12 @@ in the core template for search.html.
       {% set type = dataset_type %}
       {% set searchbar_title = input_text + _(':') %}
       {# Set default sort order. If no sort order has been selected in 
-         the Order By dropdown menu, use 'metadata_modified desc' (Last Modified).
+         the Order By dropdown menu, use 'score desc, metadata_modified desc' (Relevance).
       #}
       {% if request['params'] and 'sort' in request['params'] %}
         {% set sort_order = request.params['sort'] %}
       {% else %}
-        {% set sort_order = 'metadata_modified desc' %}
+        {% set sort_order = 'score desc, metadata_modified desc' %}
       {% endif %}
       <form id="{{ form_id }}" class="search-form" method="get" data-module="select-switch" novalidate>
         {% snippet 'snippets/search_form.html', 


### PR DESCRIPTION
## What this PR accomplishes
Sets the default sort order of datasets to Relevance instead of Last Modified.

## What needs review
Check that Relevance is the default sort order of datasets when:

1. First landing on the Dataset search page
2. Opening a dataset from the Ministry search page
3. Selecting a Group from the Groups page

Also check:
- if the user selects own sort order, that sort order is preserved after interactions such as using the search bar or paginating through the list of datasets
- equivalent functionality of all of the above in French