### PR TITLE
fix api modal layout for safari by adding min-width

### DIFF
--- a/ckanext/ontario_theme/fanstatic/common.css
+++ b/ckanext/ontario_theme/fanstatic/common.css
@@ -1822,6 +1822,11 @@ ul.nav-tabs li a,
   width: fit-content;
 }
 
+/* Add min-width to layout table properly in Safari */
+#collapse-endpoints table {
+  min-width: 100%;
+}
+
 /* Break the URLs so they fit the panel width and the width of screen */
 #collapse-querying .panel-body,
 .resource-url-analytics {


### PR DESCRIPTION
## What this PR accomplishes
Fixes improper formatting of the API modal in Safari browser.

## What needs review
- Open the API modal in Safari browser and verify that the formatting is ok.
- Check that the fix does not mess up the API modal in other browsers