### PR TITLE
Logout button fails

### DIFF
--- a/ckanext/ontario_theme/templates/internal/header.html
+++ b/ckanext/ontario_theme/templates/internal/header.html
@@ -68,7 +68,7 @@
 
                   {% block header_account_log_out_link %}
                     <li>
-                      <a href="{{ h.url_for('/user/_logout') }}" title="{{ _('Log out') }}">
+                      <a href="{{ h.url_for('/user/logout') }}" title="{{ _('Log out') }}">
                         <i class="fa fa-sign-out" aria-hidden="true"></i>
                         <span class="text account-text">{{ _('Log out') }}</span>
                       </a>


### PR DESCRIPTION
## What this PR accomplishes

- Redirects users to the logout page after pressing the logout button

## Issue(s) addressed

- Logout button erroneously had a '_' at the beginning of the logout html file in the relative path, causing issues with actually logging users out when the button was pressed.

## What needs review

- On test or stage (because local works fine), users should be redirected to the logout page after clicking the logout button. 
- Hovering over the logout button, the path should end with `user/logout` (no '_')