### PR TITLE
add checks to resource name and type

### DIFF
--- a/ckanext/ontario_theme/plugin.py
+++ b/ckanext/ontario_theme/plugin.py
@@ -678,11 +678,13 @@ def extract_package_name(url):
             resource_name = toolkit.get_action('resource_show') (
                 data_dict={'id': get_resource_name[0]}
                 )
-            resource_type = resource_name['type']
-            resource_name = resource_name['name']
-            if not resource_type and not resource_name:
-                resource_name = "Supporting File"
-            return resource_name or resource_type
+            if not resource_name['type'] and not resource_name['name']:
+                return "Unnamed Supporting File"
+            if 'name' in resource_name:
+                if len(resource_name['name']) > 0:
+                    return resource_name['name']
+                else:
+                    return "Unnamed Data File"
         except ckan.logic.NotFound:
             return False
     elif len(get_package_name) > 0:

--- a/ckanext/ontario_theme/plugin.py
+++ b/ckanext/ontario_theme/plugin.py
@@ -683,12 +683,12 @@ def extract_package_name(url):
                     if not resource_name['type']:
                         return "Unnamed Supporting File"
                     else:
-                        return "Unnamed " + resource_name['type']
+                        return "Unnamed " + resource_name['type'] + " file"
                 elif 'resource_type' in resource_name:
                     if not resource_name['resource_type']:
                         return "Unnamed Supporting File"
                     else:
-                        return "Unnamed " + resource_name['resource_type']
+                        return "Unnamed " + resource_name['resource_type'] + " file"
             
             if 'name' in resource_name:
                 if len(resource_name['name']) > 0:

--- a/ckanext/ontario_theme/plugin.py
+++ b/ckanext/ontario_theme/plugin.py
@@ -678,8 +678,18 @@ def extract_package_name(url):
             resource_name = toolkit.get_action('resource_show') (
                 data_dict={'id': get_resource_name[0]}
                 )
-            if not resource_name['type'] and not resource_name['name']:
-                return "Unnamed Supporting File"
+            if 'name' in resource_name and not resource_name['name']:
+                if 'type' in resource_name:
+                    if not resource_name['type']:
+                        return "Unnamed Supporting File"
+                    else:
+                        return "Unnamed " + resource_name['type']
+                elif 'resource_type' in resource_name:
+                    if not resource_name['resource_type']:
+                        return "Unnamed Supporting File"
+                    else:
+                        return "Unnamed " + resource_name['resource_type']
+            
             if 'name' in resource_name:
                 if len(resource_name['name']) > 0:
                     return resource_name['name']


### PR DESCRIPTION
## What this PR accomplishes
Places checks on `resource_name` attributes in function `extract_package_name()` that was causing errors in the `uwsgi.ERR` log file.

## What needs review
To make sure the code checks for all possibilities, upload new resources with different combinations of name and type and make sure there are no errors in `uwsgi.ERR` or on the page:
- no name, no type 
- no name, but type Data
- no name, but type Information
- add a name, but no type
- add a name and a type (try different types)

Test the above for uploaded CSV resources and for link URLs.
