### PR TITLE
change group name in group url in homepage

### DIFF
--- a/ckanext/ontario_theme/templates/internal/home/snippets/ontario_theme_covid_datasets.html
+++ b/ckanext/ontario_theme/templates/internal/home/snippets/ontario_theme_covid_datasets.html
@@ -3,7 +3,7 @@
 Renders a list of the 10 most popular COVID datasets
 
 #}
-{% set covid_datasets = h.ontario_theme_get_group_datasets('2019-novel-coronavirus') %}
+{% set covid_datasets = h.ontario_theme_get_group_datasets('covid-19') %}
 {% for dataset in covid_datasets %}
   <div class="row">
     <div class="col-md-10 col-sm-10 col-xs-10 c-small-text">
@@ -17,7 +17,7 @@ Renders a list of the 10 most popular COVID datasets
   </div>
 {% endfor %}
 <div class="show-more">
-  {% trans url=h.url_for('group.read', id="2019-novel-coronavirus") %}
+  {% trans url=h.url_for('group.read', id="covid-19") %}
     <a href="{{ url }}">Show more</a>
   {% endtrans %}
 </div>


### PR DESCRIPTION
## What this PR accomplishes
Changes the group name for the homepage link for covid to reflect the new name.

## What needs review
The group name in Stage and Test has been changed to the new name. Test that this fix ensures that covid datasets are linked to the correct group page from the home page.