### PR TITLE
Creates WEB resource format type

### DIFF
--- a/ckanext/ontario_theme/fanstatic/common.css
+++ b/ckanext/ontario_theme/fanstatic/common.css
@@ -2195,6 +2195,11 @@ screen and (min-width: 96em) {
   background-color: #ddedc7;
 }
 
+.label[data-format="web"],
+.label[data-format*="web"] {
+  background-color: #ebe7db;
+}
+
 /* default button background colour */
 .label-default {
   background-color: #f2f2f2;

--- a/ckanext/ontario_theme/resource_upload.py
+++ b/ckanext/ontario_theme/resource_upload.py
@@ -164,3 +164,6 @@ class ResourceUpload(DefaultResourceUpload):
                       
         elif self.clear:
             resource['url_type'] = ''
+
+        if url and not (resource.get('url_type') == 'upload') and not resource.get('format'):
+            resource['format'] = 'WEB'

--- a/ckanext/ontario_theme/resource_upload.py
+++ b/ckanext/ontario_theme/resource_upload.py
@@ -167,3 +167,6 @@ class ResourceUpload(DefaultResourceUpload):
 
         if url and not (resource.get('url_type') == 'upload') and not resource.get('format'):
             resource['format'] = 'WEB'
+
+        if not (resource.get('format') == 'GeoJSON'):
+            resource['format'] = resource['format'].upper()

--- a/ckanext/ontario_theme/templates/internal/scheming/package/resource_read.html
+++ b/ckanext/ontario_theme/templates/internal/scheming/package/resource_read.html
@@ -222,7 +222,7 @@
                           <td>{{ res.mimetype_inner or res.mimetype or res.format or _('unknown') }}</td>
                         </tr>
                         {# Add resource size if known. This extends scheming's template. #}
-                        {% if res.format == "WEB" %}
+                        {% if not res.mimetype and not res.size %}
                           {% set exclude_fields = exclude_fields.append('size') %}
                         {% else %}
                           <tr>

--- a/ckanext/ontario_theme/templates/internal/scheming/package/resource_read.html
+++ b/ckanext/ontario_theme/templates/internal/scheming/package/resource_read.html
@@ -222,10 +222,14 @@
                           <td>{{ res.mimetype_inner or res.mimetype or res.format or _('unknown') }}</td>
                         </tr>
                         {# Add resource size if known. This extends scheming's template. #}
-                        <tr>
-                          <th scope="row">{{ _('File size') }}</th>
-                          <td>{{ h.localised_filesize(res.size) if res.size else _('unknown size') }}</td>
-                        </tr>
+                        {% if res.format == "WEB" %}
+                          {% set exclude_fields = exclude_fields.append('size') %}
+                        {% else %}
+                          <tr>
+                            <th scope="row">{{ _('File size') }}</th>
+                            <td>{{ h.localised_filesize(res.size) if res.size else _('unknown size') }}</td>
+                          </tr>
+                        {% endif %}
                       {%- endblock resource_format -%}
                       {%- block resource_license -%}
                         {% set license = h.ontario_theme_get_license(pkg.license_id) %}


### PR DESCRIPTION
## What this PR accomplishes

- Creates the "WEB" file type format label and adds `#ebe7db` colour to the label
- Capitalizes inputted file types (except GeoJSON) for new resources. (Does not apply to existing resources)
- Removes file size from the resource additional information table for remote hosted resources
- Attaches the "WEB" label to resources hosted remotely with no file type format listed
- "WEB" label is discoverable
- The Format in the Additional Information table is now “WEB”

## Issue(s) addressed

- Currently, if the Format field is left blank, it will be listed on the Dataset page with file type label “Other”
- The “Format” field of Resources that are hosted remotely via the “Link” button should default to “Web” if the user does not input anything.
- The “File size” field in the Additional Information table of the resource page should not be shown for resources that are hosted remotely. Currently, the file size is always listed as “Unknown size”
- Users who add remote resources can specify any format in the Format field of the resource upload form, with no constraints on capitalization.

## What needs review

- On the dataset search page, there should be no blank "Resource Formats:" texts
- "WEB" should be a file type format and should be in the colour `#ebe7db` 
   - check dataset search page, individual dataset page, and resource additional information table
- "WEB" should be listed as a Format option in the left hand search facets and should work as expected
- Inputting a Format type in the format field of link, the inputted file format label should appear
- Inputting any format type in any case converts it to all uppercase
- GeoJSON is not capitalized
- File sizes are removed for links in the resource additional information table 
- Editing a resource with an uploaded file will not change the file type format to "WEB"
