### PR TITLE
Fixes internal 500 error when using load_organization_data.py

### DIFF
--- a/ckanext/ontario_theme/resource_upload.py
+++ b/ckanext/ontario_theme/resource_upload.py
@@ -168,5 +168,6 @@ class ResourceUpload(DefaultResourceUpload):
         if url and not (resource.get('url_type') == 'upload') and not resource.get('format'):
             resource['format'] = 'WEB'
 
-        if not (resource.get('format') == 'GeoJSON'):
-            resource['format'] = resource['format'].upper()
+        if resource.get('format') and not (resource.get('format') == 'GeoJSON'):
+            resource_format = resource.get('format')
+            resource['format'] = resource_format.upper()

--- a/ckanext/ontario_theme/resource_upload.py
+++ b/ckanext/ontario_theme/resource_upload.py
@@ -169,5 +169,4 @@ class ResourceUpload(DefaultResourceUpload):
             resource['format'] = 'WEB'
 
         if resource.get('format') and not (resource.get('format') == 'GeoJSON'):
-            resource_format = resource.get('format')
-            resource['format'] = resource_format.upper()
+            resource['format'] = resource.get('format').upper()


### PR DESCRIPTION
## What this PR accomplishes & issue(s) addressed

- When running the load_organizations_data.py, all resources being loaded will get an internal 500 error. 
- This PR includes a minor fix and a check for packages with resources

## What needs review

- Running load_organization_data.py, you do not get an internal 500 error
- Add a resource, input a random/unique lowercase file format. On the dataset page, in the formats facet box on the dataset search page, and in the api `/api/3/action/resource_show?id=<id>`, the format is in all uppercase.