### PR TITLE
DATA-1145 GeoJSON format is not displayed correctly on dataset page

### DIFF
--- a/ckanext/ontario_theme/resource_upload.py
+++ b/ckanext/ontario_theme/resource_upload.py
@@ -92,6 +92,8 @@ class ResourceUpload(DefaultResourceUpload):
                 if 'zip' in self.mimetype:
                     _check_zip_mimetype(self)
 
+                # Fix for geojson, python-magic identifies geojson
+                # files as the plain json mimetype 
                 if self.filename.rsplit('.', 1)[1] == 'geojson':
                     self.mimetype = 'application/geo+json'
 

--- a/ckanext/ontario_theme/resource_upload.py
+++ b/ckanext/ontario_theme/resource_upload.py
@@ -45,7 +45,7 @@ def accepted_resource_formats():
         file_resource_formats = json.loads(format_file.read())
 
         for format_line in file_resource_formats:
-            resource_exts.append(format_line[0])
+            resource_exts.append(format_line[0].upper())
             resource_types.append(format_line[2])
     return resource_exts, resource_types
 
@@ -53,10 +53,7 @@ def allowed_ext(filename):
     '''Returns boolean. Checks if the file extension is acceptable.
     '''
     resource_exts, resource_types = accepted_resource_formats()
-    if filename.rsplit('.', 1)[1] == 'geojson':
-        return 'GeoJSON' in resource_exts
-    else:
-        return filename.rsplit('.', 1)[1].upper() in resource_exts
+    return filename.rsplit('.', 1)[1].upper() in resource_exts
 
 def allowed_mimetype(magic_mimetype):
     '''Returns boolean. Checks if the magic mimetype is acceptable.
@@ -174,5 +171,5 @@ class ResourceUpload(DefaultResourceUpload):
         if url and not (resource.get('url_type') == 'upload') and not resource.get('format'):
             resource['format'] = 'WEB'
 
-        if resource.get('format') and not (resource.get('format') == 'GeoJSON'):
+        if resource.get('format'):
             resource['format'] = resource.get('format').upper()

--- a/ckanext/ontario_theme/resource_upload.py
+++ b/ckanext/ontario_theme/resource_upload.py
@@ -45,7 +45,7 @@ def accepted_resource_formats():
         file_resource_formats = json.loads(format_file.read())
 
         for format_line in file_resource_formats:
-            resource_exts.append(format_line[0].upper())
+            resource_exts.append(format_line[0])
             resource_types.append(format_line[2])
     return resource_exts, resource_types
 
@@ -53,7 +53,10 @@ def allowed_ext(filename):
     '''Returns boolean. Checks if the file extension is acceptable.
     '''
     resource_exts, resource_types = accepted_resource_formats()
-    return filename.rsplit('.', 1)[1].upper() in resource_exts
+    if filename.rsplit('.', 1)[1] == 'geojson':
+        return 'GeoJSON' in resource_exts
+    else:
+        return filename.rsplit('.', 1)[1].upper() in resource_exts
 
 def allowed_mimetype(magic_mimetype):
     '''Returns boolean. Checks if the magic mimetype is acceptable.
@@ -91,7 +94,10 @@ class ResourceUpload(DefaultResourceUpload):
                 # If zip file, check mimetypes of each file
                 if 'zip' in self.mimetype:
                     _check_zip_mimetype(self)
-                            
+
+                if self.filename.rsplit('.', 1)[1] == 'geojson':
+                    self.mimetype = 'application/geo+json'
+
                 if not allowed_mimetype(self.mimetype):
                     alert_invalidfile(resource, self.filename)
             except IOError as e:

--- a/ckanext/ontario_theme/templates/internal/package/snippets/resource_item.html
+++ b/ckanext/ontario_theme/templates/internal/package/snippets/resource_item.html
@@ -8,7 +8,7 @@
 <li class="resource-item row" data-id="{{ res.id }}">
   <div class="col-md-6 col-xs-12">
     {% block resource_item_title %}
-      {% if res.format in h.dict_list_reduce(pkg.resources, 'format') and res.format | length < 5 %}
+      {% if res.format in h.dict_list_reduce(pkg.resources, 'format') and res.format %}
         <div class="label-div">
           <span class="label label-default"
                 property="dc:format"


### PR DESCRIPTION
## What this PR accomplishes & Issue(s) addressed

- Displays correct mimetype in the additional information page on the resource page `application/geo+json`
- Displays correct label on dataset page

## What needs review

- Additional information table on resource page has correct mimetype
- The GeoJSON file label is displayed, as opposed to “Other” on the dataset page

**Notes**

- if you change an existing resource, you will have to rebuild the search index