### PR TITLE
DATA-1171: Additional Information dates are in incorrect format on dataset page

### DIFF
--- a/ckanext/ontario_theme/templates/external/scheming/package/snippets/additional_info.html
+++ b/ckanext/ontario_theme/templates/external/scheming/package/snippets/additional_info.html
@@ -29,7 +29,11 @@
         <th scope="row" class="dataset-label">{{ h.scheming_language_text(field.label) }}</th>
         <td class="dataset-details"
             {% if field.display_property -%}property="{{ field.display_property }}"{%- endif %}>
-          {%- snippet 'scheming/snippets/display_field.html', field=field, data=pkg_dict, schema=schema -%}
+          {% if field.preset == "date" %}
+            {{ h.render_datetime(pkg_dict[field.field_name]) }}
+          {% else %}
+            {%- snippet 'scheming/snippets/display_field.html', field=field, data=pkg_dict, schema=schema -%}
+          {% endif %}
         </td>
       </tr>
     {%- endif -%}

--- a/ckanext/ontario_theme/templates/internal/scheming/package/resource_read.html
+++ b/ckanext/ontario_theme/templates/internal/scheming/package/resource_read.html
@@ -211,60 +211,58 @@
                         {{ h.render_datetime(res.data_last_updated) or h.render_datetime(res.last_modified) or h.render_datetime(res.revision_timestamp) or h.render_datetime(res.created) or _('unknown') }}
                       </td>
                     </tr>
-                      {%- endblock resource_last_updated -%}
-                      {%- block resource_created -%}
+                  {%- endblock resource_last_updated -%}
+                  {%- block resource_created -%}
+                    <tr>
+                      <th scope="row">{{ _('Created') }}</th>
+                      <td>{{ h.render_datetime(res.created) or _('unknown') }}</td>
+                    </tr>
+                  {%- endblock resource_created -%}
+                  {%- block resource_format -%}
+                    <tr>
+                      <th scope="row">{{ _('Format') }}</th>
+                      <td>{{ res.mimetype_inner or res.mimetype or res.format or _('unknown') }}</td>
+                    </tr>
+                    {# Add resource size if known. This extends scheming's template. #}
+                    {% if not res.mimetype and not res.size %}
+                      {% set exclude_fields = exclude_fields.append('size') %}
+                    {% else %}
+                      <tr>
+                        <th scope="row">{{ _('File size') }}</th>
+                        <td>{{ h.ontario_theme_abbr_localised_filesize(res.size)|safe if res.size else _('unknown size') }}</td>
+                      </tr>
+                    {% endif %}
+                  {%- endblock resource_format -%}
+                  {%- block resource_license -%}
+                    {% set license = h.ontario_theme_get_license(pkg.license_id) %}
+                    <tr>
+                      <th scope="row">{{ _('Licence') }}</th>
+                      <td>{{ h.get_translated(license, 'title') }}</td>
+                    </tr>
+                  {%- endblock resource_license -%}
+                  {%- block resource_fields -%}
+                    {%- for field in schema.resource_fields -%}
+                      {%- if field.field_name not in exclude_fields and res[field.field_name] and (res[field.field_name] != {'fr': '', 'en': ''}) -%}
                         <tr>
-                          <th scope="row">{{ _('Created') }}</th>
-                          <td>{{ h.render_datetime(res.created) or _('unknown') }}</td>
+                          <th scope="row">{{- h.scheming_language_text(field.label) -}}</th>
+                          <td>
+                            {%- if field.preset == "date" -%}
+                              {{- h.render_datetime(res[field.field_name]) -}}
+                            {%- else -%}
+                              {%- snippet "scheming/snippets/display_field.html", field=field, data=res, entity_type='dataset', object_type=dataset_type -%}
+                            {%- endif -%}
+                          </td>
                         </tr>
-                      {%- endblock resource_created -%}
-                      {%- block resource_format -%}
-                        <tr>
-                          <th scope="row">{{ _('Format') }}</th>
-                          <td>{{ res.mimetype_inner or res.mimetype or res.format or _('unknown') }}</td>
-                        </tr>
-                        {# Add resource size if known. This extends scheming's template. #}
-                        {% if not res.mimetype and not res.size %}
-                          {% set exclude_fields = exclude_fields.append('size') %}
-                        {% else %}
-                          <tr>
-                            <th scope="row">{{ _('File size') }}</th>
-                            <td>{{ h.ontario_theme_abbr_localised_filesize(res.size)|safe if res.size else _('unknown size') }}</td>
-                          </tr>
-                        {% endif %}
-                      {%- endblock resource_format -%}
-                      {%- block resource_license -%}
-                        {% set license = h.ontario_theme_get_license(pkg.license_id) %}
-                        <tr>
-                          <th scope="row">{{ _('Licence') }}</th>
-                          <td>{{ h.get_translated(license, 'title') }}</td>
-                        </tr>
-                      {%- endblock resource_license -%}
-                      {%- block resource_fields -%}
-                        {%- for field in schema.resource_fields -%}
-                          {%- if field.field_name not in exclude_fields and res[field.field_name] and (res[field.field_name] != {'fr': '', 'en': ''}) -%}
-                            <tr>
-                              <th scope="row">{{- h.scheming_language_text(field.label) -}}</th>
-                              <td>
-                                {%- if field.preset == "date" -%}
-                                  {{- h.render_datetime(res[field.field_name]) -}}
-                                {%- else -%}
-                                  {%- snippet "scheming/snippets/display_field.html", field=field, data=res, entity_type='dataset', object_type=dataset_type -%}
-                                {%- endif -%}
-                              </td>
-                            </tr>
-                          {%- endif -%}
-                        {%- endfor -%}
-                      {%- endblock resource_fields -%}
-                    </tbody>
-                  </table>
-                </div>
-              {% endblock resource_additional_information_inner %}
-          {% endif %}
-        {% endblock resource_additional_information %}
-      {% endblock primary_content %}
-    <div class="col-xs-12">
-      {% snippet 'home/snippets/ontario_theme_contact_us.html' %}
-    </div>
+                      {%- endif -%}
+                    {%- endfor -%}
+                  {%- endblock resource_fields -%}
+                </tbody>
+              </table>
+            </div>
+          {% endblock resource_additional_information_inner %}
+        {% endif %}
+      {% endblock resource_additional_information %}
+    {% endblock primary_content %}
+    <div class="col-xs-12">{% snippet 'home/snippets/ontario_theme_contact_us.html' %}</div>
   {% endif %}
 {% endblock primary %}


### PR DESCRIPTION
## What this PR accomplishes

- The user will see the dates in format "Month Day, Year" in the dataset additional information table

## Issue(s) addressed

- Date format across the website should be “Month Day, Year”
- formatted html

## What needs review

- Dataset with any of the following metadata should be in "Month Day, Year" format instead of "YYYY-MM-DD" in additional information table
   - Last Validated Date (current_as_of)
   - Opened date (opened_date)