### PR TITLE
Fixes deprecated warning in uwsgi.ERR

### DIFF
--- a/ckanext/ontario_theme/templates/internal/scheming/package/resource_read.html
+++ b/ckanext/ontario_theme/templates/internal/scheming/package/resource_read.html
@@ -237,7 +237,7 @@
                     {% set license = h.ontario_theme_get_license(pkg.license_id) %}
                     <tr>
                       <th scope="row">{{ _('Licence') }}</th>
-                      <td>{{ h.get_translated(license, 'title') }}</td>
+                      <td>{{ h.get_translated(license._data, 'title') }}</td>
                     </tr>
                   {%- endblock resource_license -%}
                   {%- block resource_fields -%}

--- a/ckanext/ontario_theme/templates/internal/scheming/package/resource_read.html
+++ b/ckanext/ontario_theme/templates/internal/scheming/package/resource_read.html
@@ -237,7 +237,7 @@
                         {% set license = h.ontario_theme_get_license(pkg.license_id) %}
                         <tr>
                           <th scope="row">{{ _('Licence') }}</th>
-                          <td>{{ h.get_translated(license, 'title') }}</td>
+                          <td>{{ h.get_translated(license._data, 'title') }}</td>
                         </tr>
                       {%- endblock resource_license -%}
                       {%- block resource_fields -%}

--- a/ckanext/ontario_theme/templates/internal/snippets/translate_facets.html
+++ b/ckanext/ontario_theme/templates/internal/snippets/translate_facets.html
@@ -5,6 +5,6 @@
 #}
 {% set scheming_choices = scheming_choices or h.scheming_field_by_name(fields, name).choices or None %}
 {% do item.update({'display_name': h.scheming_choices_label(scheming_choices, item.display_name)}) if scheming_choices %}
-{% do item.update({'display_name': h.get_translated( h.ontario_theme_get_license(item.name), "title" )}) if name == "license_id" %}
+{% do item.update({'display_name': h.get_translated( h.ontario_theme_get_license(item.name)._data, "title" )}) if name == "license_id" %}
 {% do item.update({'display_name': h.get_translated( h.get_organization(item.name), "title") or item.display_name}) if name == "organization" %}
 {% do item.update({'display_name': h.get_translated( h.ontario_theme_get_group(item.name), "title") or item.display_name}) if name == "groups" %}


### PR DESCRIPTION
## What this PR accomplishes

- Uses attribute access for ckan.model.license but adding `,_data` to additional information and facet licence references

## Issue(s) addressed

- Stops the following warning from populating in uwsgi.ERR:
``` 
Function __getitem__() in module ckan.model.license has been deprecated and will be removed in a later release of ckan. License.__getitem__() is deprecated and will be removed in a future version of CKAN. Instead, please use attribute access. 
```


## What needs review

- While navigating the site, everything works and the warning no longer appears in the logs.