### PR TITLE
Fixes ministry activity stream from overlapping with heading

### DIFF
--- a/ckanext/ontario_theme/fanstatic/common.css
+++ b/ckanext/ontario_theme/fanstatic/common.css
@@ -413,7 +413,6 @@ input[type="reset"].ontario-search-reset:focus {
 #dataset-search-form,
 #organization-search-form,
 #group-search-form {
-  margin: 0 0 45px 0;
   background: #f2f2f2;
   padding: 20px 16px;
   border-radius: 5px;
@@ -783,10 +782,6 @@ a:focus {
   margin-top: 0;
 }
 
-.primary.ministry-page {
-  padding-top: unset;
-}
-
 .inline-dl dt:before {
   content: "";
   display: block;
@@ -801,6 +796,35 @@ a:focus {
 .inline-dl {
   font-size: 20px;
   line-height: 25.6px;
+}
+
+.wrapper div.page-header {
+  border: none;
+  background: none;
+}
+
+.wrapper div.page-header ul.nav.nav-tabs {
+  width: 100%;
+}
+
+.wrapper div.page-header ul.nav.nav-tabs li a {
+  color: #666666;
+  border: none;
+}
+
+.wrapper div.page-header ul.nav.nav-tabs li a:hover {
+  border: none;
+}
+
+.wrapper div.page-header ul.nav.nav-tabs li.active a {
+  border: none;
+  border-bottom: solid 2px #1080A6;
+  color: #1080A6;
+}
+
+.page-header .content_action {
+  margin-top: 10px;
+  margin-bottom: 10px;
 }
 
 /* ========================================================================
@@ -2114,7 +2138,7 @@ screen and (min-width: 96em) {
 }
 
 /* ========================================================================
-   Dataset Search Page - Package Items
+   Search Page - Package Items
    ======================================================================== */
 .package-item-category {
   color: #4d4d4d;
@@ -2167,6 +2191,10 @@ screen and (min-width: 96em) {
 .packages_access_level {
   font-size: 20px;
   font-weight: 400;
+}
+
+.dataset-item {
+  border-bottom: 1px solid #ccc;
 }
 
 /* ========================================================================
@@ -2393,8 +2421,13 @@ body {
   right: unset;
 }
 
-.row .page_primary_action {
-  margin-right: 15px;
+.ontario-row .page_primary_action {
+  margin-right: 16px;
+}
+
+li.media-item.ministry-item {
+  margin-left: unset;
+  padding: 15px;
 }
 
 /* ========================================================================   

--- a/ckanext/ontario_theme/templates/internal/organization/activity_stream.html
+++ b/ckanext/ontario_theme/templates/internal/organization/activity_stream.html
@@ -1,0 +1,7 @@
+{% ckan_extends %}
+
+{% block primary_content_inner %}
+  <div class="ontario-columns">
+    {% snippet 'snippets/activity_stream.html', activity_stream=activity_stream, id=id, object_type='organization' %}
+  </div>
+{% endblock primary_content_inner %}

--- a/ckanext/ontario_theme/templates/internal/organization/index.html
+++ b/ckanext/ontario_theme/templates/internal/organization/index.html
@@ -13,7 +13,7 @@
 
 {% block ontario_theme_search_form %}
   {# Custom block for search form. #}
-  <div class="row no-padding">
+  <div class="ontario-row no-padding">
     <div class="page_primary_action">
       <div class="add-organization">
         {% if h.check_access('organization_create') %}
@@ -74,7 +74,7 @@
 {% endblock pre_primary %}
 
 {% block primary %}
-  <div class="col-sm-9 col-xs-12" role="main">
+  <div class="ontario-small-12 ontario-medium-9" role="main">
     {% block primary_content_inner %}
       {% block organizations_list %}
         {% if c.page.items or request.params %}
@@ -110,11 +110,7 @@
       {% endblock page_pagination %}
     {% endblock primary_content_inner %}
   </div>
-  <div class="container">
-    <div class="row">
-      <div class="col-xs-12">{% snippet 'home/snippets/ontario_theme_contact_us.html' %}</div>
-    </div>
-  </div>
+  <div class="ontario-columns ontario-small-12">{% snippet 'home/snippets/ontario_theme_contact_us.html' %}</div>
 {% endblock primary %}
 
 {% block secondary %}

--- a/ckanext/ontario_theme/templates/internal/organization/read_base.html
+++ b/ckanext/ontario_theme/templates/internal/organization/read_base.html
@@ -5,7 +5,7 @@
     {% block primary_content %}
       <article class="module">
         {% block page_header %}
-          <header class="page-header col-xs-12 ministry-page-header">
+          <div class="ontario-columns page-header ontario-small-12 ministry-page-header">
             <div class="content_action">
               {% block content_action %}
                 {% if h.check_access('organization_update', {'id': c.group_dict.id}) %}
@@ -22,10 +22,10 @@
                 {{ h.build_nav_icon(group_type + '.about', _('About'), id=group_dict.name) }}
               {% endblock content_primary_nav %}
             </ul>
-          </header>
+          </div>
         {% endblock page_header %}
 
-        <div>
+        <div class="ontario-small-12">
           {% if self.page_primary_action() | trim %}
             <div class="page_primary_action">
               {% block page_primary_action %}

--- a/ckanext/ontario_theme/templates/internal/package/search.html
+++ b/ckanext/ontario_theme/templates/internal/package/search.html
@@ -9,7 +9,7 @@ in the core template for search.html.
 {% ckan_extends %}
 
 {% block ontario_theme_search_form %}
-  <div class="row no-padding">
+  <div class="ontario-row no-padding">
     {# Lifting these block above main content. #}
     {% block page_primary_action %}
       {{ super() }}

--- a/ckanext/ontario_theme/templates/internal/page.html
+++ b/ckanext/ontario_theme/templates/internal/page.html
@@ -33,7 +33,7 @@
           {# Custom block for search form. #}
         {% endblock ontario_theme_search_form %}
 
-        <div class="row wrapper
+        <div class="wrapper ontario-row
                     {% block wrapper_class %}
                     {% endblock wrapper_class %}
                     {% if self.secondary()|trim == '' or c.action=='resource_read' %}no-nav{% endif %}">

--- a/ckanext/ontario_theme/templates/internal/scheming/organization/about.html
+++ b/ckanext/ontario_theme/templates/internal/scheming/organization/about.html
@@ -3,32 +3,34 @@
 {% set exclude_fields = ["name", "title_translated", "org_contact", "image_url", "description_translated"] %}
 {% set current_lang = request.environ.CKAN_LANG %}
 {% block primary_content_inner %}
-  {% block organization_extras %}
-    <dl class="inline-dl">
-      {% set about_fields = c.scheming_fields|rejectattr("field_name", "in", exclude_fields ) | list %}
-      {% for f in about_fields %}
-        <dt>{{ h.scheming_language_text(f.label) }}{{ _(':') }}</dt>
-        <dd>
-          {% set translated_labels = f.choices|selectattr("value", "equalto", c.group_dict[f.field_name] )|map(attribute='label') %}
-          {{ translated_labels|map(attribute=current_lang)|join }}
-        </dd>
-      {% endfor %}
-    </dl>
-  {% endblock organization_extras %}
+  <div class="ontario-columns">
+    {% block organization_extras %}
+      <dl class="inline-dl">
+        {% set about_fields = c.scheming_fields|rejectattr("field_name", "in", exclude_fields ) | list %}
+        {% for f in about_fields %}
+          <dt>{{ h.scheming_language_text(f.label) }}{{ _(':') }}</dt>
+          <dd>
+            {% set translated_labels = f.choices|selectattr("value", "equalto", c.group_dict[f.field_name] )|map(attribute='label') %}
+            {{ translated_labels|map(attribute=current_lang)|join }}
+          </dd>
+        {% endfor %}
+      </dl>
+    {% endblock organization_extras %}
 
-  {% block organization_contact %}
-    {% set contact_page = h.scheming_language_text(c.group_dict['org_contact']) %}
-    {% if contact_page %}
-      <h3>
-        {% trans %}
-          For more information
-        {% endtrans %}
-      </h3>
-      <a href="{{ contact_page }}" class="inline-dl">
-        {% trans %}
-          Contact
-        {% endtrans %}
-      {{ h.get_translated(c.group_dict, "title") }}</a>
-    {% endif %}
-  {% endblock organization_contact %}
+    {% block organization_contact %}
+      {% set contact_page = h.scheming_language_text(c.group_dict['org_contact']) %}
+      {% if contact_page %}
+        <h3>
+          {% trans %}
+            For more information
+          {% endtrans %}
+        </h3>
+        <a href="{{ contact_page }}" class="inline-dl">
+          {% trans %}
+            Contact
+          {% endtrans %}
+        {{ h.get_translated(c.group_dict, "title") }}</a>
+      {% endif %}
+    {% endblock organization_contact %}
+  </div>
 {% endblock primary_content_inner %}


### PR DESCRIPTION
## What this PR accomplishes

- Removes CKAN core grid system from Ministry page 
- Removes CKAN core grid system from page.html
- Adds subsequent DS grid to pages affected
- Removes hidden h1 from activity stream page
- Fixes spacing

## Issue(s) addressed

- ministry’s activity stream page heading overlaps with the activity stream
- the navigation tabs are unusable

## What needs review

- Page alignment is correct on both left and right
- ministry’s activity stream page heading no longer overlaps with the activity stream
- the navigation tabs work as expected