### PR TITLE
Fixes language label on wrapping and space after resource title

### DIFF
--- a/ckanext/ontario_theme/fanstatic/common.css
+++ b/ckanext/ontario_theme/fanstatic/common.css
@@ -1556,12 +1556,14 @@ via submission form. Copied from DS.*/
 .label.label-english,
 .label.label-french,
 .label.label-english_and_french {
+  display: inline-block;
   background-color: #f2f2f2;
   font-size: 20px;
   font-weight: 700;
   color: #1a1a1a;
   border-radius: 4px;
-  margin: 5px 5px 5px 0;
+  margin-right: 5px;
+  margin-top: 3.5px;
   border: solid 2px #fff;
 }
 
@@ -1570,6 +1572,7 @@ via submission form. Copied from DS.*/
 }
 
 .resource-item-title {
+  display: inline;
   font-weight: 700;
   font-size: 20px;
   line-height: 27px;
@@ -1643,7 +1646,6 @@ via submission form. Copied from DS.*/
 
   .resource-info {
     display: flow-root;
-    margin-bottom: 10px;
   }
 }
 

--- a/ckanext/ontario_theme/templates/internal/package/snippets/resource_item.html
+++ b/ckanext/ontario_theme/templates/internal/package/snippets/resource_item.html
@@ -22,9 +22,7 @@
       <div class="resource-info">
         <a class="resource-item-title"
           href="{{ url }}"
-          title="{{ res.name or res.description }}">
-          {{ h.resource_display_name(res) | truncate(50) }}
-        </a>
+          title="{{ res.name or res.description }}">{{ h.resource_display_name(res)|truncate(50) }}</a>
         {% if res.language %}
           <span class="label label-{{ res.language }}">
             {{ h.scheming_choices_label(


### PR DESCRIPTION
## What this PR accomplishes & Issue(s) addressed

- On Firefox, when the language label jumps to the next line it leaves a tiny grey box behind
- There is an extra space after the resource title that is being underlined.

## What needs review

Dataset page:
- On Firefox, when the language label is wrapping to the next line, there is no trailing grey box
- There is no extra space after the resource title