### PR TITLE
Task: Switches show more to a tertiary button

### DIFF
--- a/ckanext/ontario_theme/fanstatic/common.css
+++ b/ckanext/ontario_theme/fanstatic/common.css
@@ -205,7 +205,7 @@
 }
 
 .ontario-button--tertiary:visited {
-  color: #3c7fa3;
+  color: #06c;
 }
 
 /* ========================================================================
@@ -1707,6 +1707,8 @@ via submission form. Copied from DS.*/
 }
 
 .resource-button-tertiary,
+.resource-button-tertiary:visited,
+.resource-button-secondary:visited,
 .resource-button-secondary {
   color: #3c7fa3;
 }
@@ -1900,6 +1902,12 @@ ul.nav-tabs li a,
 .nav-item a {
   text-decoration: none;
 }
+
+a.ontario-button.ontario-button--tertiary,
+a.ontario-button.ontario-button--tertiary:hover {
+  text-decoration: underline;
+}
+
 
 /* ========================================================================
    Custom overrides - datafile pages
@@ -2834,11 +2842,6 @@ label::after {
   padding-left: 30px;
 }
 
-.filters .module-narrow .module-footer {
-  padding-left: 20px;
-  padding-right: 20px;
-}
-
 .filter-results .context-info .module-content,
 .secondary.ontario-columns.ontario-small-3.filter-results {
   padding-left: unset;
@@ -2852,12 +2855,6 @@ label::after {
 @media screen and (min-width: 64em) {
   .filters .module-narrow .nav-item > a {
     padding-left: 46px;
-  }
-
-  .filters .module-narrow .module-footer,
-  .group-packages .filters .module-narrow .module-footer {
-    padding-left: 40px;
-    padding-right: 40px;
   }
 }
 

--- a/ckanext/ontario_theme/templates/internal/snippets/facet_list.html
+++ b/ckanext/ontario_theme/templates/internal/snippets/facet_list.html
@@ -50,12 +50,12 @@
           {% if h.has_more_facets(name, c.search_facets) %}
             <a href="{{ h.remove_url_param('_%s_limit' % name, replace=0, extras=extras, alternative_url=alternative_url) }}"
                role="button"
-               class="facets-show-more ontario-button ontario-button--secondary">{{ _('Show more') }}</a>
+               class="facets-show-more ontario-button ontario-button--tertiary">{{ _('Show more') }}</a>
           {% endif %}
         {% else %}
           <a href="{{ h.remove_url_param('_%s_limit' % name, extras=extras, alternative_url=alternative_url) }}"
              role="button"
-             class="facets-show-more ontario-button ontario-button--secondary">{{ _('Show less') }}</a>
+             class="facets-show-more ontario-button ontario-button--tertiary">{{ _('Show less') }}</a>
         {% endif %}
       </p>
     {% else %}


### PR DESCRIPTION
## What this PR accomplishes

- Switches show more button in facets to a tertiary button
- Changes colour of visited links for buttons to the same colour as the normal state.


## What needs review

- Facet lists have the show more button as a tertiary button
- Buttons that have been visited show the text in the same colour as the normal state on the facets and on the dataset page