### PR TITLE
[Task}: Remove "datasets with data" sort option

### DIFF
--- a/ckanext/ontario_theme/templates/internal/package/search.html
+++ b/ckanext/ontario_theme/templates/internal/package/search.html
@@ -35,7 +35,6 @@ in the core template for search.html.
               (_('Name Descending'), 'name desc'),
               (_('Last Modified'), 'metadata_modified desc'),
               (_('Recently Created'), 'dataset_published_date desc'),
-              (_('Datasets With Data'), 'num_resources desc, metadata_modified desc'),
             (_('Popular'), 'views_recent desc') if g.tracking_enabled else (false, false) ] %}
       <!-- arguments for DS search bar -->
       {% set input_text = _('Search ' + dataset_type + 's') %}


### PR DESCRIPTION
## What this PR accomplishes

- Removes "datasets with data" sort option

## Issue(s) addressed

- “Datasets with data” has been removed from our filters as it’s not well utilized; so having the option to sort by “Datasets with data” is now redundant.

## What needs review

- You can not sort by "Datasets with data" in search