### PR TITLE
[Task]: Removes algorithm/ai label from dataset search page

### DIFF
--- a/ckanext/ontario_theme/templates/internal/snippets/package_item.html
+++ b/ckanext/ontario_theme/templates/internal/snippets/package_item.html
@@ -18,9 +18,6 @@
 
     {% block heading_title %}
       {% link_for h.truncate(h.get_translated(package, 'title'), truncate_title),named_route=('%s.read' % package.type), id=package.name %}
-      {% if package.get("asset_type") == "ai" %}
-        <div class="label label-info">{{ _('Algorithm/AI') }}</div>
-      {% endif %}
       {% if package.get("harvester", False) == 'ontario-data-catalogue' %}
         <div class="badge badge-harvest pull-right" data-harvest={{ package['harvester'] }}>
           {{ _('ON External') }}


### PR DESCRIPTION
## What this PR accomplishes & Issue(s) addressed

- Remove Algorithm / AI label from the datasets

## What needs review

- The blue "Algorithm/AI" label does not appear next to the titles of the Datasets on the Datasets search page or Individual Ministries and Groups pages.