### PR TITLE
[Task]: AI and COVID-19 group pages minor markup fixes

### DIFF
--- a/ckanext/ontario_theme/templates/internal/scheming/group/about.html
+++ b/ckanext/ontario_theme/templates/internal/scheming/group/about.html
@@ -1,26 +1,9 @@
 {% ckan_extends %}
 
-{%- set exclude_fields = ["title", "name", "image_url", "description_translated", "title_translated"] -%}
 {% block primary_content_inner %}
-  <h1>
-    {% block page_heading %}
-      {{ h.get_translated(c.group_dict, "title") }}
-    {% endblock page_heading %}
-  </h1>
   {% block organization_description %}
     {% if h.get_translated(c.group_dict, "description") %}
-      {{ h.render_markdown(h.get_translated(c.group_dict, "description")) }}
+      {{ h.render_markdown(h.get_translated(c.group_dict, "description"), allow_html=true) }}
     {% endif %}
   {% endblock organization_description %}
-
-  <dl>
-    {% for f in c.scheming_fields %}
-      {% if f.field_name not in exclude_fields %}
-        <dt>{{ h.scheming_language_text(f.label) }}:</dt>
-        <dd>
-          {{ c.group_dict[f.field_name] or ("&nbsp;"|safe) }}
-        </dd>
-      {% endif %}
-    {% endfor %}
-  </dl>
 {% endblock primary_content_inner %}


### PR DESCRIPTION
## What this PR accomplishes

- Allows HTML tags in the groups markdown tag. This is to only allow for abbreviations to be added using `<abbr>` tags
- Removes the `<h1>` in the body, as there is already an `<h1>` on the page.

## Issue(s) addressed

- Allowing the HTML tags will allow me to go in and add the necessary abbreviation tags to the AI group description. Once that is done, the ticket will be ready for QA by designers

## What needs review

- There is only 1 `<h1>` tag on the groups about page. 
- Adding inline HTML tags in the groups description works.