### PR TITLE
[Task]: Header change IDC

### DIFF
--- a/ckanext/ontario_theme/templates/external/home/snippets/ontario_theme_intro.html
+++ b/ckanext/ontario_theme/templates/external/home/snippets/ontario_theme_intro.html
@@ -5,7 +5,13 @@ Renders a hard coded site description/introduction.
 #}
 {% set stats = h.get_site_statistics() %}
 <div>
-  <h1>{{ _("Ontario Data Catalogue") }}</h1>
+  <h1>
+    {% if g.site_title == "Internal Data Catalogue" %}
+      {{ g.site_title }}
+    {% else %}
+      {{ _('Ontario Data Catalogue') }}
+    {% endif %}
+  </h1>
 </div>
 <div class="greet">
   <p class="ontario-lead-statement">

--- a/ckanext/ontario_theme/templates/external/home/snippets/ontario_theme_intro.html
+++ b/ckanext/ontario_theme/templates/external/home/snippets/ontario_theme_intro.html
@@ -6,7 +6,7 @@ Renders a hard coded site description/introduction.
 {% set stats = h.get_site_statistics() %}
 <div>
   <h1>
-    {% if g.site_title == "Internal Data Catalogue" %}
+    {% if g.site_title != "Ontario Data Catalogue" %}
       {{ g.site_title }}
     {% else %}
       {{ _('Ontario Data Catalogue') }}


### PR DESCRIPTION
## What this PR accomplishes & Issue(s) addressed

- interim solution for IDC title change, consequently the titles for other environments (except prod).

## What needs review
(editing title in Admin config UI)
- sites with title "Ontario Data Catalogue" display the correct title and translation
- sites that do not have title "Ontario Data Catalogue" display the site title.