### PR TITLE
Redesign the access level & AI callout boxes

### DIFF
--- a/ckanext/ontario_theme/fanstatic/common.css
+++ b/ckanext/ontario_theme/fanstatic/common.css
@@ -677,6 +677,34 @@ input[placeholder] {
   fill: #1080a6;
 }
 
+/* ========================================================================
+   Page Alerts - ODC
+   ======================================================================== */
+.odc-alert {
+  padding: 20px;
+  margin-bottom: 30px;
+}
+
+.odc-alert-restricted {
+  background-color: #fceff0;
+  border: 1px solid #cd0000;
+}
+
+.odc-alert-under_review {
+  background-color: #f1e3f2;
+  border: 1px solid #92278F;
+}
+
+.odc-alert-algorithm {
+  background-color: #DBE9F5;
+  border: 1px solid #3193CC;
+}
+
+.odc-alert-under_review p,
+.odc-alert-algorithm p:last-child {
+  margin-bottom: 0;
+}
+
 /* ===============================
    Custom overrides - page alerts
    =============================== */

--- a/ckanext/ontario_theme/templates/external/package/snippets/ontario_theme_access_level.html
+++ b/ckanext/ontario_theme/templates/external/package/snippets/ontario_theme_access_level.html
@@ -4,7 +4,7 @@
 {% set directive_url=_("https://www.ontario.ca/page/ontarios-digital-and-data-directive-2021") %}
 {% if h.scheming_field_by_name(schema.dataset_fields, 'access_level') and pkg.access_level %}
   {% if pkg['access_level'] == 'restricted' or pkg['access_level'] == 'under_review' %}
-    <div class="new-alert alert-{{ pkg['access_level'] }} alert-large alert-clear">
+    <div class="odc-alert odc-alert-{{ pkg['access_level'] }}">
       {% if pkg['access_level'] == 'open' %}
         <strong>{{ _("Data Available") }}</strong>
         <p>
@@ -15,7 +15,7 @@
           {% endtrans %}
         </p>
       {% elif pkg['access_level'] == 'restricted' %}
-        <strong>{{ _("Data Not Available") }}</strong>
+        <h2 class="ontario-h5">{{ _("Data Not Available") }}</h2>
         <p>
           {% trans directive_url=directive_url %}
             This data is not and will not be made available.
@@ -24,13 +24,13 @@
             <a href="{{ directive_url }}">Digital and Data Directive</a>.
           {% endtrans %}
         </p>
-        <p>
+        <span>
           <strong>{{ _("Why?") }}</strong>
           {{ h.scheming_choices_label(h.scheming_field_choices(h.scheming_field_by_name(schema.dataset_fields,"exemption")),pkg['exemption']) }}
           - {{ h.scheming_language_text(pkg['exemption_rationale']) }}
-        </p>
+        </span>
       {% elif pkg['access_level'] == 'under_review' %}
-        <strong>{{ _("Data Not Available") }}</strong>
+        <h2 class="ontario-h5">{{ _("Data Not Available") }}</h2>
         <p>
           {% trans directive_url=directive_url %}
             This data might be made available in the future. We are reviewing the data in this record to determine if it can be

--- a/ckanext/ontario_theme/templates/internal/package/read.html
+++ b/ckanext/ontario_theme/templates/internal/package/read.html
@@ -23,16 +23,16 @@
     {% block primary_content_inner %}
       <div class="col-lg-8 col-xs-12">
         {% if pkg.get("asset_type") == "ai" %}
-          <div class="new-alert alert-info alert-algorithms alert-huge alert-clear">
-            <strong>
+          <div class="odc-alert odc-alert-algorithm">
+            <p class="ontario-h5">
               {{ _("Artificial Intelligence (<abbr>AI</abbr>)") }}
-            </strong>
+            </p>
             <p>
               {{ _('This record describes an <abbr title="Artificial Intelligence">AI</abbr> asset. It does not describe a dataset.') }}
+              <a href="{{ h.url_for('group.about', id='artificial-intelligence') }}">
+                {{ _('Learn more about how Ontario uses <abbr title="Artificial Intelligence">AI</abbr> in government.') }}
+              </a>
             </p>
-            <a href="{{ h.url_for('group.about', id='artificial-intelligence') }}">
-              {{ _('Learn more about how Ontario uses <abbr title="Artificial Intelligence">AI</abbr> in government.') }}
-            </a>
           </div>
         {% endif %}
         {{ super() }}
@@ -61,6 +61,7 @@
               {% if pkg.state == 'deleted' %}[{{ _('Deleted') }}]{% endif %}
             {% endblock page_heading %}
           </h1>
+          {% snippet "package/snippets/ontario_theme_access_level.html", pkg=pkg, dataset_type=dataset_type, schema=schema, resources=resources %}
           {% block package_notes %}
             {% if pkg.notes %}
               <div class="notes embedded-content dataset-font">{{ h.render_markdown(h.get_translated(pkg, 'notes')) }}</div>

--- a/ckanext/ontario_theme/templates/internal/package/snippets/resources_list.html
+++ b/ckanext/ontario_theme/templates/internal/package/snippets/resources_list.html
@@ -8,8 +8,6 @@
     {{ _("Learn more about ") }} <a href="{{ h.url_for('home.about', _anchor='training-materials') }}">{{ _("accessing data using different formats.") }}</a>
   </p>
   {% block resource_list %}
-    {% snippet "package/snippets/ontario_theme_access_level.html",
-    pkg=pkg, dataset_type=dataset_type, schema=schema, resources=resources %}
     {# can_edit is True only for users with write access
       (i.e. sysadmins and org admins)
     #}

--- a/ckanext/ontario_theme/templates/internal/package/snippets/resources_list.html
+++ b/ckanext/ontario_theme/templates/internal/package/snippets/resources_list.html
@@ -3,10 +3,6 @@
 #}
 {% set current_lang = request.environ.CKAN_LANG %}
 <section id="dataset-resources" class="resources">
-  <h2>{{ _(h.dataset_display_name(pkg)) }}</h2>
-  <p class="dataset-font">
-    {{ _("Learn more about ") }} <a href="{{ h.url_for('home.about', _anchor='training-materials') }}">{{ _("accessing data using different formats.") }}</a>
-  </p>
   {% block resource_list %}
     {# can_edit is True only for users with write access
       (i.e. sysadmins and org admins)
@@ -18,6 +14,10 @@
     #}
     {% if pkg['access_level'] == 'open' or can_edit %}
       {% if resources %}
+        <h2>{{ _(h.dataset_display_name(pkg)) }}</h2>
+        <p class="dataset-font">
+          {{ _("Learn more about ") }} <a href="{{ h.url_for('home.about', _anchor='training-materials') }}">{{ _("accessing data using different formats.") }}</a>
+        </p>
         {% block resource_list_inner %}
           {% set can_edit = h.check_access('package_update', {'id':pkg.id }) %}
           {% for resource in resources %}
@@ -106,7 +106,7 @@
       {% endif %}
     {% endif %}
   {% endblock resource_list %}
-  <meta itemprop="dateModified" content="{{ pkg.metadata_modified }}"/>
-  <meta itemprop="identifier" content="{{ pkg.name }}"/>
-  <link itemprop="url" content="{{ h.url_for('dataset.read', id=pkg.name) }}"/>
+  <meta itemprop="dateModified" content="{{ pkg.metadata_modified }}" />
+  <meta itemprop="identifier" content="{{ pkg.name }}" />
+  <link itemprop="url" content="{{ h.url_for('dataset.read', id=pkg.name) }}" />
 </section>


### PR DESCRIPTION
## What this PR accomplishes

- Redesigns the restricted and under review callouts
- Redesigns the AI callout
- Remove heading for restricted and under review datasets

## Issue(s) addressed

- DATA-1094

## What needs review

- Restricted dataset: bgcolor: #FCEFF0 , border: #CD0000 1px
- Under review dataset: bgcolor: #F1E3F2 , border: #92278F 1px
- The callout box design (not content) looks like in the mock up (see ticket)