### PR TITLE
[Task]: Remove the RSS box from the Dataset page

### DIFF
--- a/ckanext/ontario_theme/templates/internal/package/read_base.html
+++ b/ckanext/ontario_theme/templates/internal/package/read_base.html
@@ -19,21 +19,6 @@
 
 {% block secondary %}
   <aside class="dataset-aside secondary col-xs-12 col-lg-4 right-col dataset-font">
-    {% block package_info %}
-      <div class="module module-narrow module-shallow context-info">
-        <h2 class="ontario-h4">{{ _("Keep updated") }}</h2>
-        <section>
-          <p>{{ _("Subscribe to updates to this dataset using RSS.") }}</p>
-          <p>
-            <a href="/feeds/custom.atom?q=name:{{ pkg.name }}"
-               class="btn btn-primary">
-              <i class="fa fa-rss"></i> {{ _('Subscribe') }}
-            </a>
-          </p>
-        </section>
-      </div>
-    {% endblock package_info %}
-
     {% block package_organization %}
       {% if pkg.organization %}
         {% set org = h.get_organization(pkg.organization.id) %}


### PR DESCRIPTION
## What this PR accomplishes

- Removes RSS box from the Dataset page

## Issue(s) addressed

-RSS function has an extremely low engagement rate and is an unfamiliar functionality to the majority of our users. Removing the “Keep updated“ box from the right side bar will allow for more important content to take it’s place

## What needs review

- User doesn’t see the “Keep updated“ box on the Dataset page