### PR TITLE
[Task]: Groups page should be aligned to the Ministries page

### DIFF
--- a/ckanext/ontario_theme/fanstatic/common.css
+++ b/ckanext/ontario_theme/fanstatic/common.css
@@ -771,6 +771,10 @@ a:focus {
   line-height: 45px;
 }
 
+a.ministry-heading {
+  text-decoration: none;
+}
+
 .ministry-item.media-item:first-child {
   border-top: 1px solid #dddddd;
 }
@@ -3058,9 +3062,12 @@ label::after {
    ======================================================================== */
 .group-search-table-thead-th {
   display: table-cell;
-  font-size: 22px;
   font-weight: 700;
-  padding-bottom: 30px;
+  text-align: left;
+  padding: 1.75rem 1rem 1.75rem 1.5rem;
+  margin: 0;
+  font-size: 22px;
+  line-height: 1.5rem;
 }
 
 .group-search-table-thead {
@@ -3078,13 +3085,14 @@ label::after {
   line-height: 45px;
 }
 
-.group-search-table-tbody > .group-search-table-row > .group-search-table-cell {
-  padding-top: 1.5rem;
-  padding-bottom: 2.5rem;
+.group-search-table-cell {
+  padding: 1.1875rem 1rem 1.1875rem 1.5rem;
+  text-align: left;
+  letter-spacing: .025rem;
   border-top: solid 1px #ccc;
 }
 
-.group-search-table-tbody > .group-search-table-row > .group-search-table-cell.group-search-table-td {
+.group-search-table-cell.group-search-table-td {
   padding-left: 25px;
 }
 
@@ -3098,7 +3106,8 @@ label::after {
   width: 100%;
 }
 
-.group-search-table-row {
+.group-search-table-row,
+.group-search-table-cell-row {
   display: table-row;
 }
 
@@ -3108,4 +3117,29 @@ label::after {
 
 .group-search-table-tbody {
   display: table-row-group;
+}
+
+.group-search-table-cell-row:hover {
+  background-color: #f2f2f2;
+}
+
+.group-search-table-cell-row:hover a {
+  text-decoration: underline;
+  color: #00478f;
+}
+
+.group-search-table-cell-row:hover span {
+  font-weight: 700;
+}
+
+.group-search-table-thead-th.ontario-table-cell--numeric {
+  padding: 1.75rem 1.5rem 1.75rem 1rem;
+  text-align: right;
+}
+
+.group-search-table-cell.group-search-table-td.ontario-table-cell--numeric {
+  padding: 1.1875rem 1.5rem 1.1875rem 1rem;
+  text-align: right;
+  font-family: "Courier Prime", Courier, "Courier New", monospace;
+  font-size: 18px;
 }

--- a/ckanext/ontario_theme/fanstatic/common.css
+++ b/ckanext/ontario_theme/fanstatic/common.css
@@ -765,40 +765,6 @@ a:focus {
 /* ========================================================================
    Custom overrides - ministry page
    ======================================================================== */
-.ministry-heading,
-.group-search-heading {
-  font-weight: 700;
-  font-size: 18px;
-}
-
-.ministry-heading,
-.group-search-heading {
-  color: #0066cc;
-}
-
-.ministry-heading:visited,
-.group-search-heading:visited {
-  color: #551a8b;
-}
-
-.ministry-heading:hover,
-.group-search-heading:hover {
-  color: #00478f;
-}
-
-.ministry-heading:active,
-.group-search-heading:active {
-  color: #002142;
-}
-
-.ministry-item.media-item:first-child {
-  border-top: 1px solid #dddddd;
-}
-
-.media-item:last-child {
-  border-bottom: none;
-}
-
 .ontario-module-h3 {
   font-size: 20px;
   font-weight: 600;
@@ -3087,10 +3053,35 @@ label::after {
 }
 
 /* ========================================================================
-   Group Search Page - Table view
+   Group & Ministries Search Page - Table view
    ======================================================================== */
+.ministry-heading,
+.group-search-heading {
+  font-weight: 700;
+  font-size: 18px;
+}
 
-.group-search-table-thead-th {
+.ministry-heading,
+.group-search-heading {
+  color: #0066cc;
+}
+
+.ministry-heading:visited,
+.group-search-heading:visited {
+  color: #551a8b;
+}
+
+.ministry-heading:hover,
+.group-search-heading:hover {
+  color: #00478f;
+}
+
+.ministry-heading:active,
+.group-search-heading:active {
+  color: #002142;
+}
+
+.search-table-thead-th {
   display: table-cell;
   font-weight: 700;
   text-align: left;
@@ -3099,89 +3090,63 @@ label::after {
   line-height: 1.5rem;
 }
 
-.group-search-table-thead {
+.search-table-thead {
   display: table-header-group;
 }
 
-.group-search-table-row {
+.search-table-cell {
+  display: table-cell;
+}
+
+.search-table-tbody {
+  display: table-row-group;
+}
+
+.search-table-row {
   font-size: 18px;
 }
 
-.group-search-table-cell-row {
-  text-decoration: none;
-}
-
-.group-search-table-cell-row .group-search-count,
-.group-search-table-cell-row p {
+.search-table-cell-row .search-count,
+.search-table-cell-row p {
   color: #000;
 }
 
-.group-search-table-cell {
+.search-table-cell {
   padding: 2.1875rem 1rem 2.1875rem 1rem;
   text-align: left;
   letter-spacing: .025rem;
   border-top: solid 1px #ccc;
 }
 
-.group-search-table-cell.group-search-table-td {
-  padding-left: 25px;
-}
-
-.group-search-table-cell > p {
+.search-table-cell > p {
   font-size: 16px;
   margin-bottom: unset;
   margin-top: 5px;
 }
 
-.group-search-table {
+.search-table {
   display: table;
   width: 100%;
 }
 
-.group-search-table-row,
-.group-search-table-cell-row {
+/* Interaction state */
+.search-table-row,
+.search-table-cell-row {
   display: table-row;
   transform: scale(1);
 }
 
-.group-search-table-cell {
-  display: table-cell;
-}
-
-.group-search-table-tbody {
-  display: table-row-group;
-}
-
-.group-search-table-cell-row:hover {
+.search-table-cell-row:hover {
   background-color: #f2f2f2;
 }
 
-.group-search-table-cell-row:hover .ministry-heading,
-.group-search-table-cell-row:hover .group-search-heading {
+.search-table-cell-row:hover .ministry-heading,
+.search-table-cell-row:hover .search-heading {
   text-decoration: underline;
 }
 
-.group-search-table-cell-row:hover span {
+.search-table-cell-row:hover span {
   font-weight: 700;
-}
-
-.group-search-table-thead-th.ontario-table-cell--numeric {
-  padding: 2.75rem 1.5rem 2.75rem 1rem;
-  text-align: right;
-}
-
-@media screen and (max-width: 40em) {
-  .group-search-table-thead-th.ontario-table-cell--numeric {
-    padding: 1.53125rem 1rem 1.53125rem .5rem
-  }
-
-  .group-search-table-thead-th {
-    padding: 1.53125rem .5rem 1.53125rem .5rem;
-  }
-
-  .group-search-table-cell {
-    padding: 1.1875rem .5rem 1.1875rem .5rem;
-  }
 }
 
 .anchor-div-group {
@@ -3190,13 +3155,30 @@ label::after {
   left: 0;
   width: 100%;
   height: 100%;
-}
-
-a.anchor-div-group {
   text-decoration: none;
 }
 
-.group-search-table-cell.group-search-table-td.ontario-table-cell--numeric {
+/* Numeric column */
+.search-table-thead-th.ontario-table-cell--numeric {
+  padding: 2.75rem 1.5rem 2.75rem 1rem;
+  text-align: right;
+}
+
+@media screen and (max-width: 40em) {
+  .search-table-thead-th.ontario-table-cell--numeric {
+    padding: 1.53125rem 1rem 1.53125rem .5rem
+  }
+
+  .search-table-thead-th {
+    padding: 1.53125rem .5rem 1.53125rem .5rem;
+  }
+
+  .search-table-cell {
+    padding: 1.1875rem .5rem 1.1875rem .5rem;
+  }
+}
+
+.search-table-cell.search-table-td.ontario-table-cell--numeric {
   padding: 1.1875rem 1.5rem 1.1875rem 1rem;
   text-align: right;
   font-family: "Courier Prime", Courier, "Courier New", monospace;

--- a/ckanext/ontario_theme/fanstatic/common.css
+++ b/ckanext/ontario_theme/fanstatic/common.css
@@ -765,14 +765,10 @@ a:focus {
 /* ========================================================================
    Custom overrides - ministry page
    ======================================================================== */
-.ministry-heading {
+.ministry-heading,
+.group-search-heading {
   font-weight: 700;
   font-size: 18px;
-  line-height: 45px;
-}
-
-a.ministry-heading {
-  text-decoration: none;
 }
 
 .ministry-item.media-item:first-child {
@@ -3064,8 +3060,7 @@ label::after {
   display: table-cell;
   font-weight: 700;
   text-align: left;
-  padding: 1.75rem 1rem 1.75rem 1.5rem;
-  margin: 0;
+  padding: 1.75rem 1rem 1.75rem 1rem;
   font-size: 22px;
   line-height: 1.5rem;
 }
@@ -3074,19 +3069,24 @@ label::after {
   display: table-header-group;
 }
 
-.group-search-table-row,
-.group-search-heading {
+.group-search-table-row {
   font-size: 18px;
 }
 
-.group-search-heading {
-  font-size: 18px;
-  font-weight: 700;
-  line-height: 45px;
+a.group-search-table-cell-row {
+  text-decoration: none;
+}
+
+a.group-search-table-cell-row .group-search-count {
+  color: #000;
+}
+
+a.group-search-table-cell-row p {
+  color: #000;
 }
 
 .group-search-table-cell {
-  padding: 1.1875rem 1rem 1.1875rem 1.5rem;
+  padding: 2.1875rem 1rem 2.1875rem 1rem;
   text-align: left;
   letter-spacing: .025rem;
   border-top: solid 1px #ccc;
@@ -3097,8 +3097,9 @@ label::after {
 }
 
 .group-search-table-cell > p {
-  font-size: 19px;
+  font-size: 16px;
   margin-bottom: unset;
+  margin-top: 5px;
 }
 
 .group-search-table {
@@ -3123,9 +3124,9 @@ label::after {
   background-color: #f2f2f2;
 }
 
-.group-search-table-cell-row:hover a {
+.group-search-table-cell-row:hover .ministry-heading,
+.group-search-table-cell-row:hover .group-search-heading {
   text-decoration: underline;
-  color: #00478f;
 }
 
 .group-search-table-cell-row:hover span {
@@ -3133,8 +3134,29 @@ label::after {
 }
 
 .group-search-table-thead-th.ontario-table-cell--numeric {
-  padding: 1.75rem 1.5rem 1.75rem 1rem;
+  padding: 2.75rem 1.5rem 2.75rem 1rem;
   text-align: right;
+}
+
+@media screen and (max-width: 40em) {
+  .group-search-table-thead-th.ontario-table-cell--numeric {
+    padding: 1.53125rem 1rem 1.53125rem .5rem
+  }
+
+  .group-search-table-thead-th {
+    padding: 1.53125rem .5rem 1.53125rem .5rem;
+  }
+
+  .group-search-table-cell {
+    padding: 1.1875rem .5rem 1.1875rem .5rem;
+  }
+}
+
+.anchor-div-group {
+  position: absolute;
+  top: 0;
+  left: 0;
+  z-index: 999;
 }
 
 .group-search-table-cell.group-search-table-td.ontario-table-cell--numeric {

--- a/ckanext/ontario_theme/fanstatic/common.css
+++ b/ckanext/ontario_theme/fanstatic/common.css
@@ -771,6 +771,26 @@ a:focus {
   font-size: 18px;
 }
 
+.ministry-heading,
+.group-search-heading {
+  color: #0066cc;
+}
+
+.ministry-heading:visited,
+.group-search-heading:visited {
+  color: #551a8b;
+}
+
+.ministry-heading:hover,
+.group-search-heading:hover {
+  color: #00478f;
+}
+
+.ministry-heading:active,
+.group-search-heading:active {
+  color: #002142;
+}
+
 .ministry-item.media-item:first-child {
   border-top: 1px solid #dddddd;
 }
@@ -3069,6 +3089,7 @@ label::after {
 /* ========================================================================
    Group Search Page - Table view
    ======================================================================== */
+
 .group-search-table-thead-th {
   display: table-cell;
   font-weight: 700;
@@ -3086,15 +3107,12 @@ label::after {
   font-size: 18px;
 }
 
-a.group-search-table-cell-row {
+.group-search-table-cell-row {
   text-decoration: none;
 }
 
-a.group-search-table-cell-row .group-search-count {
-  color: #000;
-}
-
-a.group-search-table-cell-row p {
+.group-search-table-cell-row .group-search-count,
+.group-search-table-cell-row p {
   color: #000;
 }
 
@@ -3123,6 +3141,7 @@ a.group-search-table-cell-row p {
 .group-search-table-row,
 .group-search-table-cell-row {
   display: table-row;
+  transform: scale(1);
 }
 
 .group-search-table-cell {
@@ -3169,7 +3188,12 @@ a.group-search-table-cell-row p {
   position: absolute;
   top: 0;
   left: 0;
-  z-index: 999;
+  width: 100%;
+  height: 100%;
+}
+
+a.anchor-div-group {
+  text-decoration: none;
 }
 
 .group-search-table-cell.group-search-table-td.ontario-table-cell--numeric {

--- a/ckanext/ontario_theme/templates/internal/group/snippets/group_item.html
+++ b/ckanext/ontario_theme/templates/internal/group/snippets/group_item.html
@@ -7,24 +7,30 @@
       <div class="group-search-table-cell">
         {% block title %}
           {% block link %}
-            <span class="group-search-heading">{{ h.get_translated(group,"title") }}</span>
+            <span aria-hidden="true"
+                  id="group-title-{{ position }}"
+                  class="group-search-heading">{{ h.get_translated(group,"title") }}</span>
           {% endblock link %}
         {% endblock title %}
         {% block description %}
           {% if h.get_translated(group,"description") %}
-            <p>{{ h.markdown_extract(h.get_translated(group,"description"), extract_length=80) }}</p>
+            <p aria-hidden="true" id="description-{{ position }}">
+              {{ h.markdown_extract(h.get_translated(group,"description"), extract_length=80) }}
+            </p>
           {% endif %}
         {% endblock description %}
       </div>
       <div class="group-search-table-cell group-search-table-td ontario-table-cell--numeric">
         {% block datasets %}
           {% set group_datasets = ungettext('{number} <span class="ontario-show-for-sr">dataset</span>', '{number} <span class="ontario-show-for-sr">datasets</span>', group.package_count) %}
-          <span class="group-search-count">{{ group_datasets.format(number=group.package_count)|safe }}</span>
+          <span aria-hidden="true"
+                id="count-{{ position }}"
+                class="group-search-count">{{ group_datasets.format(number=group.package_count)|safe }}</span>
         {% endblock datasets %}
       </div>
     {% endblock item_inner %}
     <a href="{{ url }}"
-       aria-label="{{ h.get_translated(group,'title') }}"
+       aria-labelledby="group-title-{{ position }} description-{{ position }} count-{{ position }}"
        class="anchor-div-group"></a>
   </li>
 {% endblock item %}

--- a/ckanext/ontario_theme/templates/internal/group/snippets/group_item.html
+++ b/ckanext/ontario_theme/templates/internal/group/snippets/group_item.html
@@ -14,7 +14,7 @@
         {% endblock title %}
         {% block description %}
           {% if h.get_translated(group,"description") %}
-            <p aria-hidden="true" id="description-{{ position }}">
+            <p id="description-{{ position }}">
               {{ h.markdown_extract(h.get_translated(group,"description"), extract_length=80) }}
             </p>
           {% endif %}
@@ -30,8 +30,8 @@
       </div>
     {% endblock item_inner %}
     <a href="{{ url }}"
-       aria-labelledby="group-title-{{ position }}"
-       aria-describedby="description-{{ position }} count-{{ position }}"
+       aria-labelledby="group-title-{{ position }} count-{{ position }}"
+       aria-describedby="description-{{ position }}"
        class="anchor-div-group"></a>
   </li>
 {% endblock item %}

--- a/ckanext/ontario_theme/templates/internal/group/snippets/group_item.html
+++ b/ckanext/ontario_theme/templates/internal/group/snippets/group_item.html
@@ -2,12 +2,12 @@
 {% set url = h.url_for(type ~ '.read', id=group.name) %}
 
 {% block item %}
-  <div class="group-search-table-row">
+  <a href="{{ url }}" class="group-search-table-cell-row">
     {% block item_inner %}
       <div class="group-search-table-cell">
         {% block title %}
           {% block link %}
-            <a href="{{ url }}" class="group-search-heading">{{ h.get_translated(group,"title") }}</a>
+            <span class="group-search-heading">{{ h.get_translated(group,"title") }}</span>
           {% endblock link %}
         {% endblock title %}
         {% block description %}
@@ -16,12 +16,12 @@
           {% endif %}
         {% endblock description %}
       </div>
-      <div class="group-search-table-cell group-search-table-td ">
+      <div class="group-search-table-cell group-search-table-td ontario-table-cell--numeric">
         {% block datasets %}
           {% set group_datasets = ungettext('{number} <span class="ontario-show-for-sr">dataset</span>', '{number} <span class="ontario-show-for-sr">datasets</span>', group.package_count) %}
           <span class="group-search-count">{{ group_datasets.format(number=group.package_count)|safe }}</span>
         {% endblock datasets %}
       </div>
     {% endblock item_inner %}
-  </div>
+  </a>
 {% endblock item %}

--- a/ckanext/ontario_theme/templates/internal/group/snippets/group_item.html
+++ b/ckanext/ontario_theme/templates/internal/group/snippets/group_item.html
@@ -30,7 +30,8 @@
       </div>
     {% endblock item_inner %}
     <a href="{{ url }}"
-       aria-labelledby="group-title-{{ position }} description-{{ position }} count-{{ position }}"
+       aria-labelledby="group-title-{{ position }}"
+       aria-describedby="description-{{ position }} count-{{ position }}"
        class="anchor-div-group"></a>
   </li>
 {% endblock item %}

--- a/ckanext/ontario_theme/templates/internal/group/snippets/group_item.html
+++ b/ckanext/ontario_theme/templates/internal/group/snippets/group_item.html
@@ -2,7 +2,7 @@
 {% set url = h.url_for(type ~ '.read', id=group.name) %}
 
 {% block item %}
-  <a href="{{ url }}" class="group-search-table-cell-row" aria-describedby="group-description">
+  <li class="group-search-table-cell-row">
     {% block item_inner %}
       <div class="group-search-table-cell">
         {% block title %}
@@ -12,7 +12,7 @@
         {% endblock title %}
         {% block description %}
           {% if h.get_translated(group,"description") %}
-            <p id="group-description" aria-hidden="true">{{ h.markdown_extract(h.get_translated(group,"description"), extract_length=80) }}</p>
+            <p>{{ h.markdown_extract(h.get_translated(group,"description"), extract_length=80) }}</p>
           {% endif %}
         {% endblock description %}
       </div>
@@ -23,5 +23,8 @@
         {% endblock datasets %}
       </div>
     {% endblock item_inner %}
-  </a>
+    <a href="{{ url }}"
+       aria-label="{{ h.get_translated(group,'title') }}"
+       class="anchor-div-group"></a>
+  </li>
 {% endblock item %}

--- a/ckanext/ontario_theme/templates/internal/group/snippets/group_item.html
+++ b/ckanext/ontario_theme/templates/internal/group/snippets/group_item.html
@@ -2,7 +2,7 @@
 {% set url = h.url_for(type ~ '.read', id=group.name) %}
 
 {% block item %}
-  <a href="{{ url }}" class="group-search-table-cell-row">
+  <a href="{{ url }}" class="group-search-table-cell-row" aria-describedby="group-description">
     {% block item_inner %}
       <div class="group-search-table-cell">
         {% block title %}
@@ -12,7 +12,7 @@
         {% endblock title %}
         {% block description %}
           {% if h.get_translated(group,"description") %}
-            <p>{{ h.markdown_extract(h.get_translated(group,"description"), extract_length=80) }}</p>
+            <p id="group-description" aria-hidden="true">{{ h.markdown_extract(h.get_translated(group,"description"), extract_length=80) }}</p>
           {% endif %}
         {% endblock description %}
       </div>

--- a/ckanext/ontario_theme/templates/internal/group/snippets/group_item.html
+++ b/ckanext/ontario_theme/templates/internal/group/snippets/group_item.html
@@ -2,9 +2,9 @@
 {% set url = h.url_for(type ~ '.read', id=group.name) %}
 
 {% block item %}
-  <li class="group-search-table-cell-row">
+  <li class="search-table-cell-row">
     {% block item_inner %}
-      <div class="group-search-table-cell">
+      <div class="search-table-cell">
         {% block title %}
           {% block link %}
             <span aria-hidden="true"
@@ -20,12 +20,12 @@
           {% endif %}
         {% endblock description %}
       </div>
-      <div class="group-search-table-cell group-search-table-td ontario-table-cell--numeric">
+      <div class="search-table-cell search-table-td ontario-table-cell--numeric">
         {% block datasets %}
           {% set group_datasets = ungettext('{number} <span class="ontario-show-for-sr">dataset</span>', '{number} <span class="ontario-show-for-sr">datasets</span>', group.package_count) %}
           <span aria-hidden="true"
                 id="count-{{ position }}"
-                class="group-search-count">{{ group_datasets.format(number=group.package_count)|safe }}</span>
+                class="search-count">{{ group_datasets.format(number=group.package_count)|safe }}</span>
         {% endblock datasets %}
       </div>
     {% endblock item_inner %}

--- a/ckanext/ontario_theme/templates/internal/group/snippets/group_list.html
+++ b/ckanext/ontario_theme/templates/internal/group/snippets/group_list.html
@@ -27,10 +27,11 @@
       <div class="group-search-table-thead">
         <div class="group-search-table-row">
           <div class="group-search-table-thead-th" aria-hidden="true">{{ _("Groups") }}</div>
-          <div class="group-search-table-thead-th ontario-table-cell--numeric" aria-hidden="true">{{ _("Datasets") }}</div>
+          <div class="group-search-table-thead-th ontario-table-cell--numeric"
+               aria-hidden="true">{{ _("Datasets") }}</div>
         </div>
       </div>
-      <div class="group-search-table-tbody">
+      <ul class="group-search-table-tbody">
         {% for group in groups %}
           {% if group['title_translated'] %}
             {% if group['title_translated'][current_lang] %}
@@ -43,7 +44,7 @@
           {% endif %}
           {% snippet "group/snippets/group_item.html", group=group, position=loop.index %}
         {% endfor %}
-      </div>
+      </ul>
     {% endblock group_list_inner %}
   </div>
 {% endblock group_list %}

--- a/ckanext/ontario_theme/templates/internal/group/snippets/group_list.html
+++ b/ckanext/ontario_theme/templates/internal/group/snippets/group_list.html
@@ -9,7 +9,7 @@
     
 #}
 {% block group_list %}
-  <div class="group-search-table ontario-small-12">
+  <div class="search-table ontario-small-12">
     {% block group_list_inner %}
       {# Sort array of Group objects according to title_translated.
                 Not necessary when accessing Groups from the groups tab on 
@@ -24,14 +24,14 @@
                   lang=current_lang,
                 reverse=reverse) %}
       {% endif %}
-      <div class="group-search-table-thead">
-        <div class="group-search-table-row">
-          <div class="group-search-table-thead-th" aria-hidden="true">{{ _("Groups") }}</div>
-          <div class="group-search-table-thead-th ontario-table-cell--numeric"
+      <div class="search-table-thead">
+        <div class="search-table-row">
+          <div class="search-table-thead-th" aria-hidden="true">{{ _("Groups") }}</div>
+          <div class="search-table-thead-th ontario-table-cell--numeric"
                aria-hidden="true">{{ _("Datasets") }}</div>
         </div>
       </div>
-      <ul class="group-search-table-tbody">
+      <ul class="search-table-tbody">
         {% for group in groups %}
           {% if group['title_translated'] %}
             {% if group['title_translated'][current_lang] %}

--- a/ckanext/ontario_theme/templates/internal/group/snippets/group_list.html
+++ b/ckanext/ontario_theme/templates/internal/group/snippets/group_list.html
@@ -27,10 +27,10 @@
       <div class="group-search-table-thead">
         <div class="group-search-table-row">
           <div class="group-search-table-thead-th" aria-hidden="true">{{ _("Groups") }}</div>
-          <div class="group-search-table-thead-th" aria-hidden="true">{{ _("Datasets") }}</div>
+          <div class="group-search-table-thead-th ontario-table-cell--numeric" aria-hidden="true">{{ _("Datasets") }}</div>
         </div>
       </div>
-      <div class="group-search-table-tbody">
+      <ul class="group-search-table-tbody">
         {% for group in groups %}
           {% if group['title_translated'] %}
             {% if group['title_translated'][current_lang] %}
@@ -43,7 +43,7 @@
           {% endif %}
           {% snippet "group/snippets/group_item.html", group=group, position=loop.index %}
         {% endfor %}
-      </div>
+      </ul>
     {% endblock group_list_inner %}
   </div>
 {% endblock group_list %}

--- a/ckanext/ontario_theme/templates/internal/group/snippets/group_list.html
+++ b/ckanext/ontario_theme/templates/internal/group/snippets/group_list.html
@@ -30,7 +30,7 @@
           <div class="group-search-table-thead-th ontario-table-cell--numeric" aria-hidden="true">{{ _("Datasets") }}</div>
         </div>
       </div>
-      <ul class="group-search-table-tbody">
+      <div class="group-search-table-tbody">
         {% for group in groups %}
           {% if group['title_translated'] %}
             {% if group['title_translated'][current_lang] %}
@@ -43,7 +43,7 @@
           {% endif %}
           {% snippet "group/snippets/group_item.html", group=group, position=loop.index %}
         {% endfor %}
-      </ul>
+      </div>
     {% endblock group_list_inner %}
   </div>
 {% endblock group_list %}

--- a/ckanext/ontario_theme/templates/internal/organization/index.html
+++ b/ckanext/ontario_theme/templates/internal/organization/index.html
@@ -66,7 +66,7 @@
 {% endblock pre_primary %}
 
 {% block primary %}
-  <div class="ontario-small-12 ontario-medium-9">
+  <div class="ontario-column ontario-small-12 ontario-medium-9">
     {% block primary_content_inner %}
       {% block organizations_list %}
         {% if c.page.items or request.params %}

--- a/ckanext/ontario_theme/templates/internal/organization/snippets/organization_item.html
+++ b/ckanext/ontario_theme/templates/internal/organization/snippets/organization_item.html
@@ -1,19 +1,23 @@
 {% set url = h.url_for(organization.type ~ '.read', id=organization.name) %}
 {% block item %}
-  <li class="media-item ministry-item">
+  <div class="group-search-table-row">
     {% block item_inner %}
-      {% block title %}
-        {% set organization_name = (h.get_translated(organization, "title") or organization.name) %}
-        <a href="{{ url }}"
-           title="{{ _('View {organization_name}').format(organization_name=organization_name) }}"
-           class="ministry-heading">{{ h.get_translated(organization, "title") or organization.name }}</a>
-      {% endblock title %}
-
-      {% block datasets %}
-        <p>
-          {{ ungettext( _('Datasets: {num}'), _('Datasets: {num}'), organization.package_count).format(num=organization.package_count) }}
-        </p>
-      {% endblock datasets %}
+      <div class="group-search-table-cell">
+        {% block title %}
+          {% block link %}
+            {% set organization_name = (h.get_translated(organization, "title") or organization.name) %}
+            <a href="{{ url }}"
+               title="{{ _('View {organization_name}').format(organization_name=organization_name) }}"
+               class="ministry-heading">{{ h.get_translated(organization, "title") or organization.name }}</a>
+          {% endblock link %}
+        {% endblock title %}
+      </div>
+      <div class="group-search-table-cell group-search-table-td">
+        {% block datasets %}
+          {% set organization_datasets = ungettext('{number} <span class="ontario-show-for-sr">dataset</span>', '{number} <span class="ontario-show-for-sr">datasets</span>', organization.package_count) %}
+          <span class="group-search-count">{{ organization_datasets.format(number=organization.package_count)|safe }}</span>
+        {% endblock datasets %}
+      </div>
     {% endblock item_inner %}
-  </li>
+  </div>
 {% endblock item %}

--- a/ckanext/ontario_theme/templates/internal/organization/snippets/organization_item.html
+++ b/ckanext/ontario_theme/templates/internal/organization/snippets/organization_item.html
@@ -1,21 +1,21 @@
 {% set url = h.url_for(organization.type ~ '.read', id=organization.name) %}
 {% set organization_name = (h.get_translated(organization, "title") or organization.name) %}
 {% block item %}
-  <li class="group-search-table-cell-row">
+  <li class="search-table-cell-row">
     {% block item_inner %}
-      <div class="group-search-table-cell">
+      <div class="search-table-cell">
         {% block title %}
           <span aria-hidden="true"
                 id="ministry-title-{{ position }}"
                 class="ministry-heading">{{ organization_name }}</span>
         {% endblock title %}
       </div>
-      <div class="group-search-table-cell group-search-table-td ontario-table-cell--numeric">
+      <div class="search-table-cell search-table-td ontario-table-cell--numeric">
         {% block datasets %}
           {% set organization_datasets = ungettext('{number} <span class="ontario-show-for-sr">dataset</span>', '{number} <span class="ontario-show-for-sr">datasets</span>', organization.package_count) %}
           <span aria-hidden="true"
                 id="count-{{ position }}"
-                class="group-search-count">{{ organization_datasets.format(number=organization.package_count)|safe }}</span>
+                class="search-count">{{ organization_datasets.format(number=organization.package_count)|safe }}</span>
         {% endblock datasets %}
       </div>
     {% endblock item_inner %}

--- a/ckanext/ontario_theme/templates/internal/organization/snippets/organization_item.html
+++ b/ckanext/ontario_theme/templates/internal/organization/snippets/organization_item.html
@@ -1,13 +1,11 @@
 {% set url = h.url_for(organization.type ~ '.read', id=organization.name) %}
 {% block item %}
-  <div class="group-search-table-cell-row">
+  <a href="{{ url }}" class="group-search-table-cell-row">
     {% block item_inner %}
       <div class="group-search-table-cell">
         {% block title %}
-          {% block link %}
-            {% set organization_name = (h.get_translated(organization, "title") or organization.name) %}
-            <a href="{{ url }}" class="ministry-heading">{{ organization_name }}</a>
-          {% endblock link %}
+          {% set organization_name = (h.get_translated(organization, "title") or organization.name) %}
+          <span href="{{ url }}" class="ministry-heading">{{ organization_name }}</span>
         {% endblock title %}
       </div>
       <div class="group-search-table-cell group-search-table-td ontario-table-cell--numeric">
@@ -17,5 +15,5 @@
         {% endblock datasets %}
       </div>
     {% endblock item_inner %}
-  </div>
+  </a>
 {% endblock item %}

--- a/ckanext/ontario_theme/templates/internal/organization/snippets/organization_item.html
+++ b/ckanext/ontario_theme/templates/internal/organization/snippets/organization_item.html
@@ -5,13 +5,17 @@
     {% block item_inner %}
       <div class="group-search-table-cell">
         {% block title %}
-          <span aria-hidden="true" id="ministry-title-{{ position }}" class="ministry-heading">{{ organization_name }}</span>
+          <span aria-hidden="true"
+                id="ministry-title-{{ position }}"
+                class="ministry-heading">{{ organization_name }}</span>
         {% endblock title %}
       </div>
       <div class="group-search-table-cell group-search-table-td ontario-table-cell--numeric">
         {% block datasets %}
           {% set organization_datasets = ungettext('{number} <span class="ontario-show-for-sr">dataset</span>', '{number} <span class="ontario-show-for-sr">datasets</span>', organization.package_count) %}
-          <span aria-hidden="true" id="count-{{ position }}" class="group-search-count">{{ organization_datasets.format(number=organization.package_count)|safe }}</span>
+          <span aria-hidden="true"
+                id="count-{{ position }}"
+                class="group-search-count">{{ organization_datasets.format(number=organization.package_count)|safe }}</span>
         {% endblock datasets %}
       </div>
     {% endblock item_inner %}

--- a/ckanext/ontario_theme/templates/internal/organization/snippets/organization_item.html
+++ b/ckanext/ontario_theme/templates/internal/organization/snippets/organization_item.html
@@ -5,18 +5,18 @@
     {% block item_inner %}
       <div class="group-search-table-cell">
         {% block title %}
-          <span id="ministry-title" class="ministry-heading">{{ organization_name }}</span>
+          <span aria-hidden="true" id="ministry-title-{{ position }}" class="ministry-heading">{{ organization_name }}</span>
         {% endblock title %}
       </div>
       <div class="group-search-table-cell group-search-table-td ontario-table-cell--numeric">
         {% block datasets %}
           {% set organization_datasets = ungettext('{number} <span class="ontario-show-for-sr">dataset</span>', '{number} <span class="ontario-show-for-sr">datasets</span>', organization.package_count) %}
-          <span class="group-search-count">{{ organization_datasets.format(number=organization.package_count)|safe }}</span>
+          <span aria-hidden="true" id="count-{{ position }}" class="group-search-count">{{ organization_datasets.format(number=organization.package_count)|safe }}</span>
         {% endblock datasets %}
       </div>
     {% endblock item_inner %}
     <a href="{{ url }}"
-       aria-labelledby="ministry-title"
+       aria-labelledby="ministry-title-{{ position }} count-{{ position }}"
        class="anchor-div-group"></a>
   </li>
 {% endblock item %}

--- a/ckanext/ontario_theme/templates/internal/organization/snippets/organization_item.html
+++ b/ckanext/ontario_theme/templates/internal/organization/snippets/organization_item.html
@@ -1,18 +1,16 @@
 {% set url = h.url_for(organization.type ~ '.read', id=organization.name) %}
 {% block item %}
-  <div class="group-search-table-row">
+  <div class="group-search-table-cell-row">
     {% block item_inner %}
       <div class="group-search-table-cell">
         {% block title %}
           {% block link %}
             {% set organization_name = (h.get_translated(organization, "title") or organization.name) %}
-            <a href="{{ url }}"
-               title="{{ _('View {organization_name}').format(organization_name=organization_name) }}"
-               class="ministry-heading">{{ h.get_translated(organization, "title") or organization.name }}</a>
+            <a href="{{ url }}" class="ministry-heading">{{ organization_name }}</a>
           {% endblock link %}
         {% endblock title %}
       </div>
-      <div class="group-search-table-cell group-search-table-td">
+      <div class="group-search-table-cell group-search-table-td ontario-table-cell--numeric">
         {% block datasets %}
           {% set organization_datasets = ungettext('{number} <span class="ontario-show-for-sr">dataset</span>', '{number} <span class="ontario-show-for-sr">datasets</span>', organization.package_count) %}
           <span class="group-search-count">{{ organization_datasets.format(number=organization.package_count)|safe }}</span>

--- a/ckanext/ontario_theme/templates/internal/organization/snippets/organization_item.html
+++ b/ckanext/ontario_theme/templates/internal/organization/snippets/organization_item.html
@@ -20,7 +20,8 @@
       </div>
     {% endblock item_inner %}
     <a href="{{ url }}"
-       aria-labelledby="ministry-title-{{ position }} count-{{ position }}"
+       aria-labelledby="ministry-title-{{ position }}"
+       aria-describedby="count-{{ position }}"
        class="anchor-div-group"></a>
   </li>
 {% endblock item %}

--- a/ckanext/ontario_theme/templates/internal/organization/snippets/organization_item.html
+++ b/ckanext/ontario_theme/templates/internal/organization/snippets/organization_item.html
@@ -20,8 +20,7 @@
       </div>
     {% endblock item_inner %}
     <a href="{{ url }}"
-       aria-labelledby="ministry-title-{{ position }}"
-       aria-describedby="count-{{ position }}"
+       aria-labelledby="ministry-title-{{ position }} count-{{ position }}"
        class="anchor-div-group"></a>
   </li>
 {% endblock item %}

--- a/ckanext/ontario_theme/templates/internal/organization/snippets/organization_item.html
+++ b/ckanext/ontario_theme/templates/internal/organization/snippets/organization_item.html
@@ -1,11 +1,11 @@
 {% set url = h.url_for(organization.type ~ '.read', id=organization.name) %}
+{% set organization_name = (h.get_translated(organization, "title") or organization.name) %}
 {% block item %}
-  <a href="{{ url }}" class="group-search-table-cell-row">
+  <li class="group-search-table-cell-row">
     {% block item_inner %}
       <div class="group-search-table-cell">
         {% block title %}
-          {% set organization_name = (h.get_translated(organization, "title") or organization.name) %}
-          <span href="{{ url }}" class="ministry-heading">{{ organization_name }}</span>
+          <span id="ministry-title" class="ministry-heading">{{ organization_name }}</span>
         {% endblock title %}
       </div>
       <div class="group-search-table-cell group-search-table-td ontario-table-cell--numeric">
@@ -15,5 +15,8 @@
         {% endblock datasets %}
       </div>
     {% endblock item_inner %}
-  </a>
+    <a href="{{ url }}"
+       aria-labelledby="ministry-title"
+       class="anchor-div-group"></a>
+  </li>
 {% endblock item %}

--- a/ckanext/ontario_theme/templates/internal/organization/snippets/organization_list.html
+++ b/ckanext/ontario_theme/templates/internal/organization/snippets/organization_list.html
@@ -1,14 +1,14 @@
 {% block organization_list %}
-  <div class="group-search-table ontario-small-12">
+  <div class="search-table ontario-small-12">
     {% block organization_list_inner %}
-      <div class="group-search-table-thead">
-        <div class="group-search-table-row">
-          <div class="group-search-table-thead-th" aria-hidden="true">{{ _("Ministries") }}</div>
-          <div class="group-search-table-thead-th ontario-table-cell--numeric"
+      <div class="search-table-thead">
+        <div class="search-table-row">
+          <div class="search-table-thead-th" aria-hidden="true">{{ _("Ministries") }}</div>
+          <div class="search-table-thead-th ontario-table-cell--numeric"
                aria-hidden="true">{{ _("Datasets") }}</div>
         </div>
       </div>
-      <ul class="group-search-table-tbody">
+      <ul class="search-table-tbody">
         {% for organization in organizations %}
           {% snippet "organization/snippets/organization_item.html", organization=organization, position=loop.index, show_capacity=show_capacity %}
         {% endfor %}

--- a/ckanext/ontario_theme/templates/internal/organization/snippets/organization_list.html
+++ b/ckanext/ontario_theme/templates/internal/organization/snippets/organization_list.html
@@ -1,0 +1,17 @@
+{% block organization_list %}
+  <div class="group-search-table ontario-small-12">
+    {% block organization_list_inner %}
+      <div class="group-search-table-thead">
+        <div class="group-search-table-row">
+          <div class="group-search-table-thead-th" aria-hidden="true">{{ _("Ministries") }}</div>
+          <div class="group-search-table-thead-th" aria-hidden="true">{{ _("Datasets") }}</div>
+        </div>
+      </div>
+      <div class="group-search-table-tbody">
+        {% for organization in organizations %}
+          {% snippet "organization/snippets/organization_item.html", organization=organization, position=loop.index, show_capacity=show_capacity %}
+        {% endfor %}
+      </div>
+    {% endblock organization_list_inner %}
+  </div>
+{% endblock organization_list %}

--- a/ckanext/ontario_theme/templates/internal/organization/snippets/organization_list.html
+++ b/ckanext/ontario_theme/templates/internal/organization/snippets/organization_list.html
@@ -8,11 +8,11 @@
                aria-hidden="true">{{ _("Datasets") }}</div>
         </div>
       </div>
-      <div class="group-search-table-tbody">
+      <ul class="group-search-table-tbody">
         {% for organization in organizations %}
           {% snippet "organization/snippets/organization_item.html", organization=organization, position=loop.index, show_capacity=show_capacity %}
         {% endfor %}
-      </div>
+      </ul>
     {% endblock organization_list_inner %}
   </div>
 {% endblock organization_list %}

--- a/ckanext/ontario_theme/templates/internal/organization/snippets/organization_list.html
+++ b/ckanext/ontario_theme/templates/internal/organization/snippets/organization_list.html
@@ -4,7 +4,8 @@
       <div class="group-search-table-thead">
         <div class="group-search-table-row">
           <div class="group-search-table-thead-th" aria-hidden="true">{{ _("Ministries") }}</div>
-          <div class="group-search-table-thead-th" aria-hidden="true">{{ _("Datasets") }}</div>
+          <div class="group-search-table-thead-th ontario-table-cell--numeric"
+               aria-hidden="true">{{ _("Datasets") }}</div>
         </div>
       </div>
       <div class="group-search-table-tbody">


### PR DESCRIPTION
## What this PR accomplishes

- Matches Ministries list items design to the table in the Groups page
- Switches Groups page design from div to list
- Makes entire list item row clickable as link
- Gives accessible name and description (if needed) to link 

## Issue(s) addressed

- When a user places their mouse cursor over the row - the whole row changes the look to mouse-hover and acts as a hyperlink.
- Mirrors the design from the Groups page (a table) on the Ministries page (a list)

## What needs review

- The design of the groups list on the Groups page and Ministries page look identical with the exception of Groups page having a short group description underneath the group name. 
- The interaction of the groups table: on mouse hover on both pages whole row is getting highlighted and acts as a hyperlink.