### PR TITLE
[Bug]: Object Identification using data attributes

### DIFF
--- a/ckanext/ontario_theme/templates/internal/group/snippets/group_item.html
+++ b/ckanext/ontario_theme/templates/internal/group/snippets/group_item.html
@@ -25,13 +25,15 @@
           {% set group_datasets = ungettext('{number} <span class="ontario-show-for-sr">dataset</span>', '{number} <span class="ontario-show-for-sr">datasets</span>', group.package_count) %}
           <span aria-hidden="true"
                 id="count-{{ position }}"
-                class="search-count">{{ group_datasets.format(number=group.package_count)|safe }}</span>
+                class="search-count"
+                data-nw="{{ group.name }}-count">{{ group_datasets.format(number=group.package_count)|safe }}</span>
         {% endblock datasets %}
       </div>
     {% endblock item_inner %}
     <a href="{{ url }}"
        aria-labelledby="group-title-{{ position }} count-{{ position }}"
        aria-describedby="description-{{ position }}"
-       class="anchor-div-group"></a>
+       class="anchor-div-group"
+       data-nw="{{ group.name }}"></a>
   </li>
 {% endblock item %}

--- a/ckanext/ontario_theme/templates/internal/organization/snippets/organization_item.html
+++ b/ckanext/ontario_theme/templates/internal/organization/snippets/organization_item.html
@@ -15,12 +15,14 @@
           {% set organization_datasets = ungettext('{number} <span class="ontario-show-for-sr">dataset</span>', '{number} <span class="ontario-show-for-sr">datasets</span>', organization.package_count) %}
           <span aria-hidden="true"
                 id="count-{{ position }}"
-                class="search-count">{{ organization_datasets.format(number=organization.package_count)|safe }}</span>
+                class="search-count"
+                data-nw="{{ organization.name }}-count">{{ organization_datasets.format(number=organization.package_count)|safe }}</span>
         {% endblock datasets %}
       </div>
     {% endblock item_inner %}
     <a href="{{ url }}"
        aria-labelledby="ministry-title-{{ position }} count-{{ position }}"
-       class="anchor-div-group"></a>
+       class="anchor-div-group"
+       data-nw="{{ organization.name }}"></a>
   </li>
 {% endblock item %}


### PR DESCRIPTION
## What this PR accomplishes

- Adds data attributes for QA on Ministries page and Groups page.
- Attributes are of the links to click onto a Ministry/Group and on the count

## Issue(s) addressed

- DATA-1387

## What needs review

- `data-nw` attributes are on Ministry/Group page links and on count