### PR TITLE
[Bug]: French sorting for datasets does not lead to correct results

### DIFF
--- a/ckanext/ontario_theme/plugin.py
+++ b/ckanext/ontario_theme/plugin.py
@@ -1145,6 +1145,11 @@ type data_last_updated
         u'''Extensions will receive a dictionary with the query parameters,
         and should return a modified (or not) version of it.
         '''
+        sort = search_params.get('sort')
+        if sort and 'titles' in sort:
+            title_sorted = 'fr' if h.lang() == 'fr' else 'string'
+            new_sort = sort.replace('titles', 'title_{}'.format(title_sorted))
+            search_params.update({"sort": new_sort})
         return num_resources_filter_scrub(search_params)
 
     def after_search(self, search_results, search_params):
@@ -1154,6 +1159,9 @@ type data_last_updated
         kw = json.loads(pkg_dict.get('extras_keywords', '{}'))
         pkg_dict['keywords_en'] = kw.get('en', [])
         pkg_dict['keywords_fr'] = kw.get('fr', [])
+
+        title = json.loads(pkg_dict.get('title_translated', '{}'))
+        pkg_dict['title_fr'] = title.get('fr', '')
 
         # Index some organization extras fields from fluent/scheming.
         organization_dict = toolkit.get_action('organization_show')(data_dict={'id': pkg_dict['organization']})

--- a/ckanext/ontario_theme/templates/internal/group/read.html
+++ b/ckanext/ontario_theme/templates/internal/group/read.html
@@ -17,8 +17,8 @@ block. super() will end up calling the facets twice.
     'remove_field': remove_field } %}
   {% set sorting = [
       (_('Relevance'), 'score desc, metadata_modified desc'),
-      (_('Name Ascending'), 'name asc'),
-      (_('Name Descending'), 'name desc'),
+      (_('Name Ascending'), 'titles asc'),
+      (_('Name Descending'), 'titles desc'),
       (_('Last Modified'), 'metadata_modified desc'),
     (_('Popular'), 'views_recent desc') if g.tracking_enabled else (false, false) ] %}
   {# Make 'Relevance' the default selection when first landing on page #}

--- a/ckanext/ontario_theme/templates/internal/organization/read.html
+++ b/ckanext/ontario_theme/templates/internal/organization/read.html
@@ -16,8 +16,8 @@ Override CKAN's read.html to add some new facets.
         'remove_field': remove_field } %}
     {% set sorting = [
           (_('Relevance'), 'score desc, metadata_modified desc'),
-          (_('Name Ascending'), 'name asc'),
-          (_('Name Descending'), 'tname desc'),
+          (_('Name Ascending'), 'titles asc'),
+          (_('Name Descending'), 'titles desc'),
           (_('Last Modified'), 'metadata_modified desc'),
         (_('Popular'), 'views_recent desc') if g.tracking_enabled else (false, false) ] %}
     {# Make 'Relevance' the default selection when first landing on page #}

--- a/ckanext/ontario_theme/templates/internal/package/search.html
+++ b/ckanext/ontario_theme/templates/internal/package/search.html
@@ -31,8 +31,8 @@ in the core template for search.html.
             'remove_field': c.remove_field } %}
       {% set sorting = [
               (_('Relevance'), 'score desc, metadata_modified desc'),
-              (_('Name Ascending'), 'name asc'),
-              (_('Name Descending'), 'name desc'),
+              (_('Name Ascending'), 'titles asc'),
+              (_('Name Descending'), 'titles desc'),
               (_('Last Modified'), 'metadata_modified desc'),
               (_('Recently Created'), 'dataset_published_date desc'),
             (_('Popular'), 'views_recent desc') if g.tracking_enabled else (false, false) ] %}

--- a/ckanext/ontario_theme/templates/internal/snippets/package_list.html
+++ b/ckanext/ontario_theme/templates/internal/snippets/package_list.html
@@ -16,25 +16,6 @@
   {% if packages %}
     <ul class="{{ list_class or 'dataset-list list-unstyled' }}">
       {% block package_list_inner %}
-        {# Custom sort by language for name ascending and descending #}
-        {% if 'name' in request.params['sort'] %}
-          {% set current_org = '' if not this_org_name else this_org_name %}
-          {% set current_group = '' if not this_group_name else this_group_name %}
-          {# Get all packages returned by query #}
-          {% set package_list = h.ontario_theme_get_all_packages(q=c.q,
-                      request_params_items=request.params,
-                      current_org=current_org,
-                      current_group=current_group,
-                    item_count=c.page.item_count) %}
-          {# Sort package_list by title_translated as per current language #}
-          {% set current_lang = request.environ.CKAN_LANG %}
-          {% set reverse = True if 'desc' in request.params['sort'] else False %}
-          {% set packages = h.ontario_theme_sort_by_title_translated(package_list,
-                      current_page=c.page.page,
-                      items_per_page=c.page.items_per_page,
-                      lang=current_lang,
-                    reverse=reverse) %}
-        {% endif %}
         {% for package in packages %}
           {% snippet 'snippets/package_item.html',
           package=package,

--- a/config/solr/managed-schema
+++ b/config/solr/managed-schema
@@ -1,207 +1,150 @@
-<?xml version="1.0" encoding="UTF-8" ?>
-<!--
- Licensed to the Apache Software Foundation (ASF) under one or more
- contributor license agreements.  See the NOTICE file distributed with
- this work for additional information regarding copyright ownership.
- The ASF licenses this file to You under the Apache License, Version 2.0
- (the "License"); you may not use this file except in compliance with
- the License.  You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
--->
-
-<!--
-     NB Please copy changes to this file into the multilingual schema:
-        ckanext/multilingual/solr/schema.xml
--->
-
-<!-- We update the version when there is a backward-incompatible change to this
-schema. We used to use the `version` attribute for this but this is an internal
-attribute that should not be used so starting from CKAN 2.10 we use the `name`
-attribute with the form `ckan-X.Y` -->
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Solr managed schema - automatically generated - DO NOT EDIT -->
 <schema name="ckan-2.10" version="1.6">
-
-<types>
-    <fieldType name="string" class="solr.StrField" sortMissingLast="true" omitNorms="true"/>
-    <fieldType name="boolean" class="solr.BoolField" sortMissingLast="true" omitNorms="true"/>
-    <fieldtype name="binary" class="solr.BinaryField"/>
-    <fieldType name="int" class="solr.IntPointField" omitNorms="true" positionIncrementGap="0"/>
-    <fieldType name="float" class="solr.FloatPointField" omitNorms="true" positionIncrementGap="0"/>
-    <fieldType name="long" class="solr.LongPointField" omitNorms="true" positionIncrementGap="0"/>
-    <fieldType name="double" class="solr.DoublePointField" omitNorms="true" positionIncrementGap="0"/>
-    <fieldType name="pint" class="solr.IntPointField" omitNorms="true" positionIncrementGap="0"/>
-    <fieldType name="pfloat" class="solr.FloatPointField" omitNorms="true" positionIncrementGap="0"/>
-    <fieldType name="plong" class="solr.LongPointField" omitNorms="true" positionIncrementGap="0"/>
-    <fieldType name="pdouble" class="solr.DoublePointField" omitNorms="true" positionIncrementGap="0"/>
-    <fieldType name="date" class="solr.DatePointField" omitNorms="true" positionIncrementGap="0"/>
-    <fieldType name="pdate" class="solr.DatePointField" omitNorms="true" positionIncrementGap="0"/>
-
-    <fieldType name="pdates" class="solr.DatePointField" positionIncrementGap="0" multiValued="true"/>
-    <fieldType name="booleans" class="solr.BoolField" sortMissingLast="true" multiValued="true"/>
-    <fieldType name="pints" class="solr.IntPointField" positionIncrementGap="0" multiValued="true"/>
-    <fieldType name="pfloats" class="solr.FloatPointField" positionIncrementGap="0" multiValued="true"/>
-    <fieldType name="plongs" class="solr.LongPointField" positionIncrementGap="0" multiValued="true"/>
-    <fieldType name="pdoubles" class="solr.DoublePointField" positionIncrementGap="0" multiValued="true"/>
-
-    <fieldType name="text" class="solr.TextField" positionIncrementGap="100">
-        <analyzer type="index">
-            <tokenizer class="solr.WhitespaceTokenizerFactory"/>
-            <filter class="solr.WordDelimiterGraphFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="1" catenateNumbers="1" catenateAll="0" splitOnCaseChange="1"/>
-            <filter class="solr.FlattenGraphFilterFactory"/> <!-- required on index analyzers after graph filters -->
-            <filter class="solr.LowerCaseFilterFactory"/>
-            <filter class="solr.SnowballPorterFilterFactory" language="English" protected="protwords.txt"/>
-            <filter class="solr.ASCIIFoldingFilterFactory"/>
-        </analyzer>
-        <analyzer type="query">
-            <tokenizer class="solr.WhitespaceTokenizerFactory"/>
-            <filter class="solr.SynonymGraphFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="true"/>
-            <filter class="solr.WordDelimiterGraphFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="0" catenateNumbers="0" catenateAll="0" splitOnCaseChange="1"/>
-            <filter class="solr.LowerCaseFilterFactory"/>
-            <filter class="solr.SnowballPorterFilterFactory" language="English" protected="protwords.txt"/>
-            <filter class="solr.ASCIIFoldingFilterFactory"/>
-        </analyzer>
-    </fieldType>
-
-
-    <!-- A general unstemmed text field - good if one does not know the language of the field -->
-    <fieldType name="text_general" class="solr.TextField" positionIncrementGap="100">
-        <analyzer type="index">
-            <tokenizer class="solr.WhitespaceTokenizerFactory"/>
-            <filter class="solr.WordDelimiterGraphFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="1" catenateNumbers="1" catenateAll="0" splitOnCaseChange="0"/>
-            <filter class="solr.FlattenGraphFilterFactory"/> <!-- required on index analyzers after graph filters -->
-            <filter class="solr.LowerCaseFilterFactory"/>
-        </analyzer>
-        <analyzer type="query">
-            <tokenizer class="solr.WhitespaceTokenizerFactory"/>
-            <filter class="solr.SynonymGraphFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="true"/>
-            <filter class="solr.WordDelimiterGraphFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="0" catenateNumbers="0" catenateAll="0" splitOnCaseChange="0"/>
-            <filter class="solr.LowerCaseFilterFactory"/>
-        </analyzer>
-    </fieldType>
-
-    <fieldType name="text_ngram" class="solr.TextField" positionIncrementGap="100">
-      <analyzer type="index">
-        <tokenizer class="solr.NGramTokenizerFactory" minGramSize="2" maxGramSize="10"/>
-        <filter class="solr.LowerCaseFilterFactory"/>
-      </analyzer>
-      <analyzer type="query">
-        <tokenizer class="solr.WhitespaceTokenizerFactory"/>
-        <filter class="solr.LowerCaseFilterFactory"/>
-      </analyzer>
-    </fieldType>
-
-</types>
-
-
-<fields>
-    <field name="index_id" type="string" indexed="true" stored="true" required="true" />
-    <field name="id" type="string" indexed="true" stored="true" required="true" />
-    <field name="site_id" type="string" indexed="true" stored="true" required="true" />
-    <field name="title" type="text" indexed="true" stored="true" />
-    <field name="title_ngram" type="text_ngram" indexed="true" stored="true" />
-    <field name="entity_type" type="string" indexed="true" stored="true" omitNorms="true" />
-    <field name="dataset_type" type="string" indexed="true" stored="true" />
-    <field name="state" type="string" indexed="true" stored="true" omitNorms="true" />
-    <field name="name" type="string" indexed="true" stored="true" omitNorms="true" />
-    <field name="name_ngram" type="text_ngram" indexed="true" stored="true" />
-    <field name="revision_id" type="string" indexed="true" stored="true" omitNorms="true" />
-    <field name="version" type="string" indexed="true" stored="true" />
-    <field name="url" type="string" indexed="true" stored="true" omitNorms="true" />
-    <field name="ckan_url" type="string" indexed="true" stored="true" omitNorms="true" />
-    <field name="download_url" type="string" indexed="true" stored="true" omitNorms="true" />
-    <field name="notes" type="text" indexed="true" stored="true"/>
-    <field name="author" type="text_general" indexed="true" stored="true" />
-    <field name="author_email" type="text_general" indexed="true" stored="true" />
-    <field name="maintainer" type="text_general" indexed="true" stored="true" />
-    <field name="maintainer_email" type="text_general" indexed="true" stored="true" />
-    <field name="license" type="string" indexed="true" stored="true" />
-    <field name="license_id" type="string" indexed="true" stored="true" />
-    <field name="tags" type="string" indexed="true" stored="true" multiValued="true"/>
-    <field name="groups" type="string" indexed="true" stored="true" multiValued="true"/>
-    <field name="organization" type="string" indexed="true" stored="true" multiValued="false"/>
-
-    <field name="capacity" type="string" indexed="true" stored="true" multiValued="false"/>
-    <field name="permission_labels" type="string" indexed="true" stored="false" multiValued="true"/>
-
-    <field name="res_name" type="text_general" indexed="true" stored="true" multiValued="true" />
-    <field name="res_description" type="text_general" indexed="true" stored="true" multiValued="true"/>
-    <field name="res_format" type="string" indexed="true" stored="true" multiValued="true"/>
-    <field name="res_url" type="string" indexed="true" stored="true" multiValued="true"/>
-    <field name="res_type" type="string" indexed="true" stored="true" multiValued="true"/>
-
-    <!-- catchall field, containing all other searchable text fields (implemented
-         via copyField further on in this schema  -->
-    <field name="text" type="text" indexed="true" stored="false" multiValued="true"/>
-    <field name="urls" type="text" indexed="true" stored="false" multiValued="true"/>
-
-    <field name="depends_on" type="text" indexed="true" stored="false" multiValued="true"/>
-    <field name="dependency_of" type="text" indexed="true" stored="false" multiValued="true"/>
-    <field name="derives_from" type="text" indexed="true" stored="false" multiValued="true"/>
-    <field name="has_derivation" type="text" indexed="true" stored="false" multiValued="true"/>
-    <field name="links_to" type="text" indexed="true" stored="false" multiValued="true"/>
-    <field name="linked_from" type="text" indexed="true" stored="false" multiValued="true"/>
-    <field name="child_of" type="text" indexed="true" stored="false" multiValued="true"/>
-    <field name="parent_of" type="text" indexed="true" stored="false" multiValued="true"/>
-    <field name="views_total" type="int" indexed="true" stored="false"/>
-    <field name="views_recent" type="int" indexed="true" stored="false"/>
-    <field name="resources_accessed_total" type="int" indexed="true" stored="false"/>
-    <field name="resources_accessed_recent" type="int" indexed="true" stored="false"/>
-
-    <field name="metadata_created" type="date" indexed="true" stored="true" multiValued="false"/>
-    <field name="metadata_modified" type="date" indexed="true" stored="true" multiValued="false"/>
-
-    <field name="indexed_ts" type="date" indexed="true" stored="true" default="NOW" multiValued="false"/>
-
-    <!-- Copy the title field into titleString, and treat as a string
-         (rather than text type).  This allows us to sort on the titleString -->
-    <field name="title_string" type="string" indexed="true" stored="false" />
-
-    <field name="data_dict" type="string" indexed="false" stored="true" />
-    <field name="validated_data_dict" type="string" indexed="false" stored="true" />
-
-    <field name="_version_" type="string" indexed="true" stored="true"/>
-
-    <dynamicField name="*_date" type="date" indexed="true" stored="true" multiValued="false"/>
-
-    <dynamicField name="extras_*" type="text" indexed="true" stored="true" multiValued="false"/>
-    <dynamicField name="res_extras_*" type="text" indexed="true" stored="true" multiValued="true"/>
-    <dynamicField name="vocab_*" type="string" indexed="true" stored="true" multiValued="true"/>
-    <dynamicField name="*" type="string" indexed="true"  stored="false"/>
-
-    <!-- Extra Ontario fields -->
-    <field name="keywords_en" type="string" indexed="true" stored="true" multiValued="true"/>
-    <field name="keywords_fr" type="string" indexed="true" stored="true" multiValued="true"/>
-</fields>
-
-<uniqueKey>index_id</uniqueKey>
-
-<copyField source="url" dest="urls"/>
-<copyField source="title" dest="title_ngram"/>
-<copyField source="name" dest="name_ngram"/>
-<copyField source="ckan_url" dest="urls"/>
-<copyField source="download_url" dest="urls"/>
-<copyField source="res_url" dest="urls"/>
-<copyField source="extras_*" dest="text"/>
-<copyField source="res_extras_*" dest="text"/>
-<copyField source="vocab_*" dest="text"/>
-<copyField source="urls" dest="text"/>
-<copyField source="name" dest="text"/>
-<copyField source="title" dest="text"/>
-<copyField source="text" dest="text"/>
-<copyField source="license" dest="text"/>
-<copyField source="notes" dest="text"/>
-<copyField source="tags" dest="text"/>
-<copyField source="groups" dest="text"/>
-<copyField source="organization" dest="text"/>
-<copyField source="res_name" dest="text"/>
-<copyField source="res_description" dest="text"/>
-<copyField source="maintainer" dest="text"/>
-<copyField source="author" dest="text"/>
-
+  <uniqueKey>index_id</uniqueKey>
+  <fieldType name="binary" class="solr.BinaryField"/>
+  <fieldType name="boolean" class="solr.BoolField" omitNorms="true" sortMissingLast="true"/>
+  <fieldType name="booleans" class="solr.BoolField" sortMissingLast="true" multiValued="true"/>
+  <fieldType name="date" class="solr.DatePointField" omitNorms="true" positionIncrementGap="0"/>
+  <fieldType name="double" class="solr.DoublePointField" omitNorms="true" positionIncrementGap="0"/>
+  <fieldType name="float" class="solr.FloatPointField" omitNorms="true" positionIncrementGap="0"/>
+  <fieldType name="icu_sort_fr" class="solr.ICUCollationField" strength="primary" locale="fr_CA"/>
+  <fieldType name="int" class="solr.IntPointField" omitNorms="true" positionIncrementGap="0"/>
+  <fieldType name="long" class="solr.LongPointField" omitNorms="true" positionIncrementGap="0"/>
+  <fieldType name="pdate" class="solr.DatePointField" omitNorms="true" positionIncrementGap="0"/>
+  <fieldType name="pdates" class="solr.DatePointField" positionIncrementGap="0" multiValued="true"/>
+  <fieldType name="pdouble" class="solr.DoublePointField" omitNorms="true" positionIncrementGap="0"/>
+  <fieldType name="pdoubles" class="solr.DoublePointField" positionIncrementGap="0" multiValued="true"/>
+  <fieldType name="pfloat" class="solr.FloatPointField" omitNorms="true" positionIncrementGap="0"/>
+  <fieldType name="pfloats" class="solr.FloatPointField" positionIncrementGap="0" multiValued="true"/>
+  <fieldType name="pint" class="solr.IntPointField" omitNorms="true" positionIncrementGap="0"/>
+  <fieldType name="pints" class="solr.IntPointField" positionIncrementGap="0" multiValued="true"/>
+  <fieldType name="plong" class="solr.LongPointField" omitNorms="true" positionIncrementGap="0"/>
+  <fieldType name="plongs" class="solr.LongPointField" positionIncrementGap="0" multiValued="true"/>
+  <fieldType name="string" class="solr.StrField" omitNorms="true" sortMissingLast="true"/>
+  <fieldType name="text" class="solr.TextField" positionIncrementGap="100">
+    <analyzer type="index">
+      <tokenizer class="solr.WhitespaceTokenizerFactory"/>
+      <filter class="solr.WordDelimiterGraphFilterFactory" catenateNumbers="1" generateNumberParts="1" splitOnCaseChange="1" generateWordParts="1" catenateAll="0" catenateWords="1"/>
+      <filter class="solr.FlattenGraphFilterFactory"/>
+      <filter class="solr.LowerCaseFilterFactory"/>
+      <filter class="solr.SnowballPorterFilterFactory" language="English" protected="protwords.txt"/>
+      <filter class="solr.ASCIIFoldingFilterFactory"/>
+    </analyzer>
+    <analyzer type="query">
+      <tokenizer class="solr.WhitespaceTokenizerFactory"/>
+      <filter class="solr.SynonymGraphFilterFactory" expand="true" ignoreCase="true" synonyms="synonyms.txt"/>
+      <filter class="solr.WordDelimiterGraphFilterFactory" catenateNumbers="0" generateNumberParts="1" splitOnCaseChange="1" generateWordParts="1" catenateAll="0" catenateWords="0"/>
+      <filter class="solr.LowerCaseFilterFactory"/>
+      <filter class="solr.SnowballPorterFilterFactory" language="English" protected="protwords.txt"/>
+      <filter class="solr.ASCIIFoldingFilterFactory"/>
+    </analyzer>
+  </fieldType>
+  <fieldType name="text_general" class="solr.TextField" positionIncrementGap="100">
+    <analyzer type="index">
+      <tokenizer class="solr.WhitespaceTokenizerFactory"/>
+      <filter class="solr.WordDelimiterGraphFilterFactory" catenateNumbers="1" generateNumberParts="1" splitOnCaseChange="0" generateWordParts="1" catenateAll="0" catenateWords="1"/>
+      <filter class="solr.FlattenGraphFilterFactory"/>
+      <filter class="solr.LowerCaseFilterFactory"/>
+    </analyzer>
+    <analyzer type="query">
+      <tokenizer class="solr.WhitespaceTokenizerFactory"/>
+      <filter class="solr.SynonymGraphFilterFactory" expand="true" ignoreCase="true" synonyms="synonyms.txt"/>
+      <filter class="solr.WordDelimiterGraphFilterFactory" catenateNumbers="0" generateNumberParts="1" splitOnCaseChange="0" generateWordParts="1" catenateAll="0" catenateWords="0"/>
+      <filter class="solr.LowerCaseFilterFactory"/>
+    </analyzer>
+  </fieldType>
+  <fieldType name="text_ngram" class="solr.TextField" positionIncrementGap="100">
+    <analyzer type="index">
+      <tokenizer class="solr.NGramTokenizerFactory" maxGramSize="10" minGramSize="2"/>
+      <filter class="solr.LowerCaseFilterFactory"/>
+    </analyzer>
+    <analyzer type="query">
+      <tokenizer class="solr.WhitespaceTokenizerFactory"/>
+      <filter class="solr.LowerCaseFilterFactory"/>
+    </analyzer>
+  </fieldType>
+  <field name="_version_" type="string" indexed="true" stored="true"/>
+  <field name="author" type="text_general" indexed="true" stored="true"/>
+  <field name="author_email" type="text_general" indexed="true" stored="true"/>
+  <field name="capacity" type="string" multiValued="false" indexed="true" stored="true"/>
+  <field name="child_of" type="text" multiValued="true" indexed="true" stored="false"/>
+  <field name="ckan_url" type="string" omitNorms="true" indexed="true" stored="true"/>
+  <field name="data_dict" type="string" indexed="false" stored="true"/>
+  <field name="dataset_type" type="string" indexed="true" stored="true"/>
+  <field name="dependency_of" type="text" multiValued="true" indexed="true" stored="false"/>
+  <field name="depends_on" type="text" multiValued="true" indexed="true" stored="false"/>
+  <field name="derives_from" type="text" multiValued="true" indexed="true" stored="false"/>
+  <field name="download_url" type="string" omitNorms="true" indexed="true" stored="true"/>
+  <field name="entity_type" type="string" omitNorms="true" indexed="true" stored="true"/>
+  <field name="groups" type="string" multiValued="true" indexed="true" stored="true"/>
+  <field name="has_derivation" type="text" multiValued="true" indexed="true" stored="false"/>
+  <field name="id" type="string" indexed="true" required="true" stored="true"/>
+  <field name="index_id" type="string" indexed="true" required="true" stored="true"/>
+  <field name="indexed_ts" type="date" default="NOW" multiValued="false" indexed="true" stored="true"/>
+  <field name="keywords_en" type="string" multiValued="true" indexed="true" stored="true"/>
+  <field name="keywords_fr" type="string" multiValued="true" indexed="true" stored="true"/>
+  <field name="license" type="string" indexed="true" stored="true"/>
+  <field name="license_id" type="string" indexed="true" stored="true"/>
+  <field name="linked_from" type="text" multiValued="true" indexed="true" stored="false"/>
+  <field name="links_to" type="text" multiValued="true" indexed="true" stored="false"/>
+  <field name="maintainer" type="text_general" indexed="true" stored="true"/>
+  <field name="maintainer_email" type="text_general" indexed="true" stored="true"/>
+  <field name="metadata_created" type="date" multiValued="false" indexed="true" stored="true"/>
+  <field name="metadata_modified" type="date" multiValued="false" indexed="true" stored="true"/>
+  <field name="name" type="string" omitNorms="true" indexed="true" stored="true"/>
+  <field name="name_ngram" type="text_ngram" indexed="true" stored="true"/>
+  <field name="notes" type="text" indexed="true" stored="true"/>
+  <field name="organization" type="string" multiValued="false" indexed="true" stored="true"/>
+  <field name="parent_of" type="text" multiValued="true" indexed="true" stored="false"/>
+  <field name="permission_labels" type="string" multiValued="true" indexed="true" stored="false"/>
+  <field name="res_description" type="text_general" multiValued="true" indexed="true" stored="true"/>
+  <field name="res_format" type="string" multiValued="true" indexed="true" stored="true"/>
+  <field name="res_name" type="text_general" multiValued="true" indexed="true" stored="true"/>
+  <field name="res_type" type="string" multiValued="true" indexed="true" stored="true"/>
+  <field name="res_url" type="string" multiValued="true" indexed="true" stored="true"/>
+  <field name="resources_accessed_recent" type="int" indexed="true" stored="false"/>
+  <field name="resources_accessed_total" type="int" indexed="true" stored="false"/>
+  <field name="revision_id" type="string" omitNorms="true" indexed="true" stored="true"/>
+  <field name="site_id" type="string" indexed="true" required="true" stored="true"/>
+  <field name="state" type="string" omitNorms="true" indexed="true" stored="true"/>
+  <field name="tags" type="string" multiValued="true" indexed="true" stored="true"/>
+  <field name="text" type="text" multiValued="true" indexed="true" stored="false"/>
+  <field name="title" type="text" indexed="true" stored="true"/>
+  <field name="title_fr" type="icu_sort_fr" stored="false"/>
+  <field name="title_ngram" type="text_ngram" indexed="true" stored="true"/>
+  <field name="title_string" type="string" indexed="true" stored="false"/>
+  <field name="url" type="string" omitNorms="true" indexed="true" stored="true"/>
+  <field name="urls" type="text" multiValued="true" indexed="true" stored="false"/>
+  <field name="validated_data_dict" type="string" indexed="false" stored="true"/>
+  <field name="version" type="string" indexed="true" stored="true"/>
+  <field name="views_recent" type="int" indexed="true" stored="false"/>
+  <field name="views_total" type="int" indexed="true" stored="false"/>
+  <dynamicField name="res_extras_*" type="text" multiValued="true" indexed="true" stored="true"/>
+  <dynamicField name="extras_*" type="text" multiValued="false" indexed="true" stored="true"/>
+  <dynamicField name="vocab_*" type="string" multiValued="true" indexed="true" stored="true"/>
+  <dynamicField name="*_date" type="date" multiValued="false" indexed="true" stored="true"/>
+  <dynamicField name="*" type="string" indexed="true" stored="false"/>
+  <copyField source="author" dest="text"/>
+  <copyField source="ckan_url" dest="urls"/>
+  <copyField source="download_url" dest="urls"/>
+  <copyField source="groups" dest="text"/>
+  <copyField source="license" dest="text"/>
+  <copyField source="maintainer" dest="text"/>
+  <copyField source="name" dest="name_ngram"/>
+  <copyField source="name" dest="text"/>
+  <copyField source="notes" dest="text"/>
+  <copyField source="organization" dest="text"/>
+  <copyField source="res_description" dest="text"/>
+  <copyField source="res_name" dest="text"/>
+  <copyField source="res_url" dest="urls"/>
+  <copyField source="tags" dest="text"/>
+  <copyField source="text" dest="text"/>
+  <copyField source="title" dest="text"/>
+  <copyField source="title" dest="title_ngram"/>
+  <copyField source="url" dest="urls"/>
+  <copyField source="urls" dest="text"/>
+  <copyField source="extras_*" dest="text"/>
+  <copyField source="res_extras_*" dest="text"/>
+  <copyField source="vocab_*" dest="text"/>
 </schema>

--- a/config/solr/solrconfig.xml
+++ b/config/solr/solrconfig.xml
@@ -73,7 +73,9 @@
        with their external dependencies.
     -->
     <!-- <lib dir="${solr.install.dir:../../../..}/dist/" regex="solr-ltr-\d.*\.jar" /> -->
-
+     <lib dir="${solr.install.dir:../../../..}/contrib/analysis-extras/lib/" regex="icu4j-\d.*\.jar" />
+     <lib dir="${solr.install.dir:../../../..}/contrib/analysis-extras/lucene-libs/" regex="lucene-analyzers-icu-\d.*\.jar" />
+     <lib dir="${solr.install.dir:../../../..}/dist/" regex="solr-analysis-extras-\d.*\.jar" />
   <!-- an exact 'path' can be used instead of a 'dir' to specify a
        specific jar file.  This will cause a serious error to be logged
        if it can't be loaded.
@@ -257,7 +259,7 @@
 
        For more details see http://wiki.apache.org/solr/SolrJmx
     -->
-  <jmx />
+  <!-- <jmx /> -->
   <!-- If you want to connect to a particular server, specify the
        agentId
     -->


### PR DESCRIPTION
## What this PR accomplishes

- Uses solr to sort French package/dataset titles on search pages in correct order, including accents and lowercase letters
- Improves performance of French name ascending/descending sort on search pages

## Issue(s) addressed

- DATA-1162

## What needs review

- Consult ticket for directions on how to implement changes
- Check that the datasets on all search pages are sorted correctly in French when `Name Ascending` and `Name Descending` are chosen.