### PR TITLE
[Fix]: ld+json script causing 500 error on dataset's pages

### DIFF
--- a/ckanext/ontario_theme/templates/internal/package/activity.html
+++ b/ckanext/ontario_theme/templates/internal/package/activity.html
@@ -1,5 +1,8 @@
 {% extends "package/read.html" %}
 
+{% block schema_tag_attr %}
+{% endblock schema_tag_attr %}
+
 {% block subtitle %}
   {{ _('History') }} {{ g.template_title_delimiter }} {{ super() }}
 {% endblock subtitle %}

--- a/ckanext/ontario_theme/templates/internal/package/group_list.html
+++ b/ckanext/ontario_theme/templates/internal/package/group_list.html
@@ -1,6 +1,10 @@
 {% extends "package/read.html" %}
 
 {% import "macros/form.html" as form %}
+
+{% block schema_tag_attr %}
+{% endblock schema_tag_attr %}
+
 {% block primary_content_inner %}
   <h2 class="hide-heading">{{ _('Groups') }}</h2>
   <div class="col-sm-8 col-xs-12">


### PR DESCRIPTION
## What this PR accomplishes

- Ld+json script was causing a 500 error on the dataset's groups and activity stream pages, due to not being able to find `schema`

## Issue(s) addressed

- DATA-1369 
- PR #455 

## What needs review

- ld+json script appears on dataset 'asset' page.
- navigating to the groups and history pages do not cause an error