### PR TITLE
[Task]: Change catalogue footer to auto-update the end date for King's Printer applicable date range

### DIFF
--- a/ckanext/ontario_theme/plugin.py
+++ b/ckanext/ontario_theme/plugin.py
@@ -22,6 +22,8 @@ import ckan.lib.helpers as helpers
 import ckan.lib.formatters as formatters
 from ckan.lib.helpers import core_helper
 
+from datetime import datetime
+
 from ckan.model import Package
 import ckan.model as model
 import locale
@@ -663,6 +665,11 @@ def order_package_facets(orig_ordered_dict):
 
     return OrderedDict(facet_titles_reorg)
 
+
+def get_current_year():
+    return datetime.today().strftime('%Y')
+
+
 def extract_package_name(url):
     ''' Returns the package name or gets resource name if url is for
         a dataset or resource page
@@ -1068,7 +1075,8 @@ type data_last_updated
                 'ontario_theme_sort_accented_characters': sort_accented_characters,
                 'ontario_theme_abbr_localised_filesize': abbr_localised_filesize,
                 'ontario_theme_get_facet_options': get_facet_options,
-                'ontario_theme_site_title': site_title
+                'ontario_theme_site_title': site_title,
+                'ontario_theme_get_current_year': get_current_year
                 }
 
     # IBlueprint

--- a/ckanext/ontario_theme/templates/internal/footer.html
+++ b/ckanext/ontario_theme/templates/internal/footer.html
@@ -34,7 +34,7 @@
           <div class="ontario-footer__copyright">
             <a class="ontario-footer__link"
                href="{%- trans -%}https://www.ontario.ca/page/copyright-information{%- endtrans -%}">
-            {{ _('&copy; King&#8217;s Printer for Ontario,') }} 2012&ndash;23</a>
+            {{ _('&copy; King&#8217;s Printer for Ontario,') }} 2012&ndash;{{ h.ontario_theme_get_current_year()[-2:] }}</a>
           </div>
         {% endblock footer_nav %}
       </div>


### PR DESCRIPTION
## What this PR accomplishes

- Changes catalogue footer to auto-update the end date for King's Printer

## Issue(s) addressed

- DATA-236

## What needs review

- Footer end date is updated to current date
- code looks fine