### PR TITLE
[Task]: Add a ckan validator to trim whitespace from EN and FR titles

### DIFF
--- a/ckanext/ontario_theme/plugin.py
+++ b/ckanext/ontario_theme/plugin.py
@@ -1210,5 +1210,6 @@ type data_last_updated
        return {
             'lock_if_odc': validators.lock_if_odc,
             'ontario_theme_copy_fluent_keywords_to_tags': validators.ontario_theme_copy_fluent_keywords_to_tags,
-            'ontario_tag_name_validator': validators.tag_name_validator
+            'ontario_tag_name_validator': validators.tag_name_validator,
+            'ontario_strip_fluent_value': validators.strip_fluent_value
        }

--- a/ckanext/ontario_theme/schemas/external/ontario_theme_dataset.json
+++ b/ckanext/ontario_theme/schemas/external/ontario_theme_dataset.json
@@ -21,7 +21,8 @@
       "required": "true",
       "fieldset": 1,
       "fieldset_name": "Describing the resource",
-      "form_snippet": "extrafields_fluent_title.html"
+      "form_snippet": "extrafields_fluent_title.html",
+      "validators": "fluent_text ontario_strip_fluent_value"
     },
     {
       "field_name": "name",
@@ -668,7 +669,8 @@
       },
       "fieldset": 2,
       "fieldset_name": "Describe the file",
-      "classes": ["form-group","col-md-12"] 
+      "classes": ["form-group","col-md-12"],
+      "validators": "fluent_text ontario_strip_fluent_value"
     },
     {
       "field_name": "description_translated",

--- a/ckanext/ontario_theme/validators.py
+++ b/ckanext/ontario_theme/validators.py
@@ -165,3 +165,13 @@ def lock_if_odc(key, data, errors, context):
     if __is_public_record(context) and not is_sysadmin(context['user']):
         errors = __if_change_submitted(key, data, context, errors, _(u'This is a public catalogue field and can\'t be changed.')) or errors
     return
+
+
+def strip_fluent_value(key, data, errors, context):
+    '''Trims the Whitespace of fluent field'''
+    value = json.loads(data[key])
+    for lang, text in value.items():
+        if isinstance(text, str):
+            value[lang] = text.strip()
+    data[key] = json.dumps(value)
+    return


### PR DESCRIPTION
## What this PR accomplishes

- Creates validator to strip whitespace from fluent fields.
- Adds validator to dataset and resource schemas for titles and names

## Issue(s) addressed

- DATA-1392

## What needs review

- When creating/updating a dataset and/or resources with EN and FR titles that start or end with a space, the whitespaces get trimmed.
- When sorting `Name Ascending`, these datasets don't appear out of sort order at the beginning of the list.