### PR TITLE
[Task]: change Addtional Information table from <table> to <div>s

### DIFF
--- a/ckanext/ontario_theme/fanstatic/common.css
+++ b/ckanext/ontario_theme/fanstatic/common.css
@@ -1752,7 +1752,7 @@ section#dataset-resources > h2 {
 }
 
 .tag-list {
-  padding: 10px 10px 5px 0;
+  padding: 10px 0 5px 0;
 }
 
 .resource-item-div:hover .resource-item-title {
@@ -3261,19 +3261,8 @@ label::after {
   font-weight: 700;
   line-height: 32.6px;
   color: #4d4d4d;
-  width: 50%;
-  padding: 5px 15px 5px 15px;
-}
-
-@media screen and (min-width: 40em) {
-  .dataset-label.package-additional-info-th {
-    padding: 5px 15px 5px 30px;
-    width: 40%;
-  }
-
-  .dataset-details.package-additional-info-td {
-    padding: 5px 30px 5px 0;
-  }
+  width: 40%;
+  padding: 5px 15px 5px 30px;
 }
 
 .package-additional-info-tr {
@@ -3291,8 +3280,19 @@ label::after {
 }
 
 .dataset-details.package-additional-info-td {
-  padding: 5px 0;
+  padding: 5px 15px 5px 0;
   font-weight: 400;
   line-height: 32.6px;
   color: #4d4d4d;
+}
+
+@media screen and (max-width: 40em) {
+  .dataset-details.package-additional-info-td {
+    padding: 5px 0;
+  }
+
+  .dataset-label.package-additional-info-th {
+    padding: 5px 15px 5px 15px;
+    width: 50%;
+  }
 }

--- a/ckanext/ontario_theme/fanstatic/common.css
+++ b/ckanext/ontario_theme/fanstatic/common.css
@@ -3268,6 +3268,25 @@ label::after {
   display: table-cell;
 }
 
+.dataset-label.package-additional-info-th {
+  font-weight: 700;
+  line-height: 32.6px;
+  color: #4d4d4d;
+  width: 50%;
+  padding: 5px 15px 5px 15px;
+}
+
+@media screen and (min-width: 40em) {
+  .dataset-label.package-additional-info-th {
+    padding: 5px 15px 5px 30px;
+    width: 40%;
+  }
+
+  .dataset-details.package-additional-info-td {
+    padding: 5px 30px 5px 0;
+  }
+}
+
 .package-additional-info-tr {
   display: table-row;
 }
@@ -3276,21 +3295,16 @@ label::after {
   display: table-row-group;
 }
 
-.table.package-additional-info-table {
+.package-additional-info-table {
   background-color: #f9f9f9;
   border: none;
+  display: table;
 }
 
-.dataset-label.package-additional-info-th {
-  padding: 5px 15px 5px 30px;
-  font-weight: 700;
-  line-height: 32.6px;
-  color: #4d4d4d;
-  width: 40%;
-}
+
 
 .dataset-details.package-additional-info-td {
-  padding: 5px 30px 5px 0;
+  padding: 5px 0;
   font-weight: 400;
   line-height: 32.6px;
   color: #4d4d4d;

--- a/ckanext/ontario_theme/fanstatic/common.css
+++ b/ckanext/ontario_theme/fanstatic/common.css
@@ -3254,3 +3254,44 @@ label::after {
   font-size: 16px;
   line-height: 26px;
 }
+
+/* ========================================================================
+   Resource Page - Additional info table
+   ======================================================================== */
+
+.package-additional-info-thead {
+  display: none;
+}
+
+.package-additional-info-td,
+.package-additional-info-th {
+  display: table-cell;
+}
+
+.package-additional-info-tr {
+  display: table-row;
+}
+
+.package-additional-info-tbody {
+  display: table-row-group;
+}
+
+.table.package-additional-info-table {
+  background-color: #f9f9f9;
+  border: none;
+}
+
+.dataset-label.package-additional-info-th {
+  padding: 5px 15px 5px 30px;
+  font-weight: 700;
+  line-height: 32.6px;
+  color: #4d4d4d;
+  width: 40%;
+}
+
+.dataset-details.package-additional-info-td {
+  padding: 5px 30px 5px 0;
+  font-weight: 400;
+  line-height: 32.6px;
+  color: #4d4d4d;
+}

--- a/ckanext/ontario_theme/fanstatic/common.css
+++ b/ckanext/ontario_theme/fanstatic/common.css
@@ -1734,52 +1734,6 @@ via submission form. Copied from DS.*/
   position: relative;
 }
 
-section.additional-info table.table {
-  border: none;
-}
-
-section.additional-info table.table thead {
-  display: none;
-}
-
-section.additional-info table.table td {
-  border: none;
-}
-
-section.additional-info table.table tbody tr:nth-child(even) th,
-section.additional-info table.table tbody tr:nth-child(even) td {
-  background-color: #f9f9f9;
-}
-
-section.additional-info table.table tbody tr:first-child th,
-section.additional-info table.table tbody tr:first-child td {
-  padding-top: 10px;
-}
-
-section.additional-info table.table tbody tr:last-child th,
-section.additional-info table.table tbody tr:last-child td {
-  padding-bottom: 10px;
-}
-
-section.additional-info table.table tbody tr th {
-  padding: 5px 15px 5px 30px;
-  font-weight: 700;
-  line-height: 32.6px;
-  color: #4d4d4d;
-}
-
-section.additional-info table.table tbody tr td {
-  padding: 5px 30px 5px 0;
-  font-weight: 400;
-  line-height: 32.6px;
-  color: #4d4d4d;
-}
-
-section.additional-info table.table tbody tr th,
-section.additional-info table.table tbody tr td {
-  border: none;
-}
-
 section#dataset-resources > h2 {
   margin-top: 35px;
   margin-bottom: 20px;
@@ -1909,31 +1863,66 @@ a.ontario-button.ontario-button--tertiary:hover {
 
 
 /* ========================================================================
-   Custom overrides - datafile pages
+   Custom overrides - resource pages
    ======================================================================== */
 .ontario-margin-top-40 {
   margin-top: 40px;
 }
 
-.additional-info-table.table-bordered > tbody > tr > th,
-.additional-info-table.table-bordered > thead > tr > th {
-  border-right: unset;
+.res-additional-info-thead {
+  display: table-header-group;
 }
 
-.additional-info-table.table-bordered > tbody > tr > td,
-.additional-info-table.table-bordered > thead > tr > th {
-  border-left: unset;
-}
-
-.module-resource {
+.res-additional-info-table {
+  display: table;
+  line-height: 22.85px;
+  font-size: 16px;
   border-bottom: unset;
-  z-index: 1;
+}
+
+.res-additional-info-thead .res-additional-info-th,
+.res-additional-info-thead .res-additional-info-td {
+  border-bottom-width: 2px;
+  font-weight: 700;
+}
+
+.res-additional-info-th {
+  font-weight: 700;
+}
+
+.res-additional-info-tr {
+  display: table-row;
+}
+
+.res-additional-info-tbody {
+  display: table-row-group;
+}
+
+.res-additional-info-tbody .res-additional-info-tr:nth-of-type(2n+1) {
+  background-color: #f9f9f9;
+}
+
+.res-additional-info-tbody .res-additional-info-tr:nth-of-type(2n) {
+  background-color: #f2f2f2;
+}
+
+.res-additional-info-th,
+.res-additional-info-td {
+  display: table-cell;
+  padding: 12px;
+  border-bottom: 1px solid #ddd;
+  width: 50%;
 }
 
 .table-condensed > tbody > tr > th,
 .table-condensed > thead > tr > th,
 .table-condensed > tbody > tr > td {
   padding: 12px;
+}
+
+.module-resource {
+  border-bottom: unset;
+  z-index: 1;
 }
 
 .action-group {
@@ -3256,7 +3245,7 @@ label::after {
 }
 
 /* ========================================================================
-   Resource Page - Additional info table
+   Dataset Page - Additional info table
    ======================================================================== */
 
 .package-additional-info-thead {
@@ -3300,8 +3289,6 @@ label::after {
   border: none;
   display: table;
 }
-
-
 
 .dataset-details.package-additional-info-td {
   padding: 5px 0;

--- a/ckanext/ontario_theme/templates/external/scheming/package/snippets/additional_info.html
+++ b/ckanext/ontario_theme/templates/external/scheming/package/snippets/additional_info.html
@@ -26,7 +26,7 @@
       and pkg_dict[field.field_name]
       and (pkg_dict[field.field_name] != {'fr': '', 'en': ''}) -%}
       <div class="package-additional-info-tr">
-        <div scope="row" class="dataset-label package-additional-info-th">{{ h.scheming_language_text(field.label) }}</div>
+        <div class="dataset-label package-additional-info-th">{{ h.scheming_language_text(field.label) }}</div>
         <div class="dataset-details package-additional-info-td"
             {% if field.display_property -%}property="{{ field.display_property }}"{%- endif %}>
           {% if field.preset == "date" %}
@@ -40,7 +40,7 @@
   {%- endfor -%}
   {% if h.check_access('package_update',{'id':pkg_dict.id}) %}
     <div class="package-additional-info-tr">
-      <div scope="row" class="dataset-label package-additional-info-th">{{ _("State") }}</div>
+      <div class="dataset-label package-additional-info-th">{{ _("State") }}</div>
       <div class="dataset-details package-additional-info-td">{{ _(pkg_dict.state) }}</div>
     </div>
   {% endif %}

--- a/ckanext/ontario_theme/templates/external/scheming/package/snippets/additional_info.html
+++ b/ckanext/ontario_theme/templates/external/scheming/package/snippets/additional_info.html
@@ -25,23 +25,23 @@
       and field.display_snippet is not none
       and pkg_dict[field.field_name]
       and (pkg_dict[field.field_name] != {'fr': '', 'en': ''}) -%}
-      <tr>
-        <th scope="row" class="dataset-label">{{ h.scheming_language_text(field.label) }}</th>
-        <td class="dataset-details"
+      <div class="package-additional-info-tr">
+        <div scope="row" class="dataset-label package-additional-info-th">{{ h.scheming_language_text(field.label) }}</div>
+        <div class="dataset-details package-additional-info-td"
             {% if field.display_property -%}property="{{ field.display_property }}"{%- endif %}>
           {% if field.preset == "date" %}
             {{ h.render_datetime(pkg_dict[field.field_name]) }}
           {% else %}
             {%- snippet 'scheming/snippets/display_field.html', field=field, data=pkg_dict, schema=schema -%}
           {% endif %}
-        </td>
-      </tr>
+        </div>
+      </div>
     {%- endif -%}
   {%- endfor -%}
   {% if h.check_access('package_update',{'id':pkg_dict.id}) %}
-    <tr>
-      <th scope="row" class="dataset-label">{{ _("State") }}</th>
-      <td class="dataset-details">{{ _(pkg_dict.state) }}</td>
-    </tr>
+    <div class="package-additional-info-tr">
+      <div scope="row" class="dataset-label package-additional-info-th">{{ _("State") }}</div>
+      <div class="dataset-details package-additional-info-td">{{ _(pkg_dict.state) }}</div>
+    </div>
   {% endif %}
 {% endblock package_additional_info %}

--- a/ckanext/ontario_theme/templates/internal/package/snippets/additional_info.html
+++ b/ckanext/ontario_theme/templates/internal/package/snippets/additional_info.html
@@ -1,90 +1,90 @@
 <section class="additional-info">
   <h2>{{ _('Additional information') }}</h2>
-  <table class="table table-striped table-bordered table-condensed">
-    <thead>
-      <tr>
-        <th scope="col">{{ _('Field') }}</th>
-        <th scope="col">{{ _('Value') }}</th>
-      </tr>
-    </thead>
-    <tbody>
+  <div class="table package-additional-info-table table-striped table-bordered table-condensed">
+    <div class="package-additional-info-thead">
+      <div class="package-additional-info-tr">
+        <div class="package-additional-info-th" scope="col">{{ _('Field') }}</div>
+        <div class="package-additional-info-th" scope="col">{{ _('Value') }}</div>
+      </div>
+    </div>
+    <div class="package-additional-info-tbody">
       {% block package_additional_info %}
         {% if pkg_dict.url %}
-          <tr>
-            <th scope="row" class="dataset-label">{{ _('Source') }}</th>
+          <div class="package-additional-info-tr">
+            <div scope="row" class="dataset-label package-additional-info-th">{{ _('Source') }}</div>
             {% if h.is_url(pkg_dict.url) %}
-              <td class="dataset-details" property="foaf:homepage">
+              <div class="dataset-details package-additional-info-td" property="foaf:homepage">
                 {{ h.link_to(pkg_dict.url, pkg_dict.url, rel='foaf:homepage', target='_blank') }}
-              </td>
+              </div>
             {% else %}
-              <td class="dataset-details" property="foaf:homepage">{{ pkg_dict.url }}</td>
+              <div class="dataset-details package-additional-info-td" property="foaf:homepage">{{ pkg_dict.url }}</div>
             {% endif %}
-          </tr>
+          </div>
         {% endif %}
         {% if pkg_dict.author_email %}
-          <tr>
-            <th scope="row" class="dataset-label">{{ _("Author") }}</th>
-            <td class="dataset-details" property="dc:creator">
+          <div class="package-additional-info-tr">
+            <div scope="row" class="dataset-label package-additional-info-th">{{ _("Author") }}</div>
+            <div class="dataset-details package-additional-info-td" property="dc:creator">
               {{ h.mail_to(email_address=pkg_dict.author_email, name=pkg_dict.author) }}
-            </td>
-          </tr>
+            </div>
+          </div>
         {% elif pkg_dict.author %}
-          <tr>
-            <th scope="row" class="dataset-label">{{ _("Author") }}</th>
-            <td class="dataset-details" property="dc:creator">{{ pkg_dict.author }}</td>
-          </tr>
+          <div class="package-additional-info-tr">
+            <div scope="row" class="dataset-label package-additional-info-th">{{ _("Author") }}</div>
+            <div class="dataset-details package-additional-info-td" property="dc:creator">{{ pkg_dict.author }}</div>
+          </div>
         {% endif %}
         {% if pkg_dict.maintainer_email %}
-          <tr>
-            <th scope="row" class="dataset-label">{{ _('Maintainer') }}</th>
-            <td class="dataset-details" property="dc:contributor">
+          <div class="package-additional-info-tr">
+            <div scope="row" class="dataset-label package-additional-info-th">{{ _('Maintainer') }}</div>
+            <div class="dataset-details package-additional-info-td" property="dc:contributor">
               {{ h.mail_to(email_address=pkg_dict.maintainer_email, name=pkg_dict.maintainer) }}
-            </td>
-          </tr>
+            </div>
+          </div>
         {% elif pkg_dict.maintainer %}
-          <tr>
-            <th scope="row" class="dataset-label">{{ _('Maintainer') }}</th>
-            <td class="dataset-details" property="dc:contributor">{{ pkg_dict.maintainer }}</td>
-          </tr>
+          <div class="package-additional-info-tr">
+            <div scope="row" class="dataset-label package-additional-info-th">{{ _('Maintainer') }}</div>
+            <div class="dataset-details package-additional-info-td" property="dc:contributor">{{ pkg_dict.maintainer }}</div>
+          </div>
         {% endif %}
         {% if pkg_dict.version %}
-          <tr>
-            <th scope="row" class="dataset-label">{{ _("Version") }}</th>
-            <td class="dataset-details">{{ pkg_dict.version }}</td>
-          </tr>
+          <div class="package-additional-info-tr">
+            <div scope="row" class="dataset-label package-additional-info-th">{{ _("Version") }}</div>
+            <div class="dataset-details package-additional-info-td">{{ pkg_dict.version }}</div>
+          </div>
         {% endif %}
         {% if h.check_access('package_update',{'id':pkg_dict.id}) %}
-          <tr>
-            <th scope="row" class="dataset-label">{{ _("State") }}</th>
-            <td class="dataset-details">{{ _(pkg_dict.state) }}</td>
-          </tr>
+          <div class="package-additional-info-tr">
+            <div scope="row" class="dataset-label package-additional-info-th">{{ _("State") }}</div>
+            <div class="dataset-details package-additional-info-td">{{ _(pkg_dict.state) }}</div>
+          </div>
         {% endif %}
         {% if pkg_dict.metadata_modified %}
-          <tr>
-            <th scope="row" class="dataset-label">{{ _("Last Updated") }}</th>
-            <td class="dataset-details">
+          <div class="package-additional-info-tr">
+            <div scope="row" class="dataset-label package-additional-info-th">{{ _("Last Updated") }}</div>
+            <div class="dataset-details package-additional-info-td">
               {% snippet "snippets/local_friendly_datetime.html", datetime_obj=pkg_dict.metadata_modified %}
-            </td>
-          </tr>
+            </div>
+          </div>
         {% endif %}
         {% if pkg_dict.metadata_created %}
-          <tr>
-            <th scope="row" class="dataset-label">{{ _("Created") }}</th>
-            <td class="dataset-details">
+          <div class="package-additional-info-tr">
+            <div scope="row" class="dataset-label package-additional-info-th">{{ _("Created") }}</div>
+            <div class="dataset-details package-additional-info-td">
               {% snippet "snippets/local_friendly_datetime.html", datetime_obj=pkg_dict.metadata_created %}
-            </td>
-          </tr>
+            </div>
+          </div>
         {% endif %}
         {% block extras scoped %}
           {% for extra in h.sorted_extras(pkg_dict.extras) %}
             {% set key, value = extra %}
-            <tr rel="dc:relation" resource="_:extra{{ i }}">
-              <th scope="row" class="dataset-label" property="rdfs:label">{{ _(key|e) }}</th>
-              <td class="dataset-details" property="rdf:value">{{ value }}</td>
-            </tr>
+            <div class="package-additional-info-tr" rel="dc:relation" resource="_:extra{{ i }}">
+              <div scope="row" class="dataset-label package-additional-info-th" property="rdfs:label">{{ _(key|e) }}</div>
+              <div class="dataset-details package-additional-info-td" property="rdf:value">{{ value }}</div>
+            </div>
           {% endfor %}
         {% endblock extras %}
       {% endblock package_additional_info %}
-    </tbody>
-  </table>
+    </div>
+  </div>
 </section>

--- a/ckanext/ontario_theme/templates/internal/package/snippets/additional_info.html
+++ b/ckanext/ontario_theme/templates/internal/package/snippets/additional_info.html
@@ -1,6 +1,6 @@
 <section class="additional-info">
   <h2>{{ _('Additional information') }}</h2>
-  <div class="table package-additional-info-table table-striped table-bordered table-condensed">
+  <div class="package-additional-info-table table-condensed">
     <div class="package-additional-info-thead">
       <div class="package-additional-info-tr">
         <div class="package-additional-info-th" scope="col">{{ _('Field') }}</div>

--- a/ckanext/ontario_theme/templates/internal/package/snippets/additional_info.html
+++ b/ckanext/ontario_theme/templates/internal/package/snippets/additional_info.html
@@ -3,15 +3,15 @@
   <div class="package-additional-info-table table-condensed">
     <div class="package-additional-info-thead">
       <div class="package-additional-info-tr">
-        <div class="package-additional-info-th" scope="col">{{ _('Field') }}</div>
-        <div class="package-additional-info-th" scope="col">{{ _('Value') }}</div>
+        <div class="package-additional-info-th">{{ _('Field') }}</div>
+        <div class="package-additional-info-th">{{ _('Value') }}</div>
       </div>
     </div>
     <div class="package-additional-info-tbody">
       {% block package_additional_info %}
         {% if pkg_dict.url %}
           <div class="package-additional-info-tr">
-            <div scope="row" class="dataset-label package-additional-info-th">{{ _('Source') }}</div>
+            <div class="dataset-label package-additional-info-th">{{ _('Source') }}</div>
             {% if h.is_url(pkg_dict.url) %}
               <div class="dataset-details package-additional-info-td" property="foaf:homepage">
                 {{ h.link_to(pkg_dict.url, pkg_dict.url, rel='foaf:homepage', target='_blank') }}
@@ -23,45 +23,45 @@
         {% endif %}
         {% if pkg_dict.author_email %}
           <div class="package-additional-info-tr">
-            <div scope="row" class="dataset-label package-additional-info-th">{{ _("Author") }}</div>
+            <div class="dataset-label package-additional-info-th">{{ _("Author") }}</div>
             <div class="dataset-details package-additional-info-td" property="dc:creator">
               {{ h.mail_to(email_address=pkg_dict.author_email, name=pkg_dict.author) }}
             </div>
           </div>
         {% elif pkg_dict.author %}
           <div class="package-additional-info-tr">
-            <div scope="row" class="dataset-label package-additional-info-th">{{ _("Author") }}</div>
+            <div class="dataset-label package-additional-info-th">{{ _("Author") }}</div>
             <div class="dataset-details package-additional-info-td" property="dc:creator">{{ pkg_dict.author }}</div>
           </div>
         {% endif %}
         {% if pkg_dict.maintainer_email %}
           <div class="package-additional-info-tr">
-            <div scope="row" class="dataset-label package-additional-info-th">{{ _('Maintainer') }}</div>
+            <div class="dataset-label package-additional-info-th">{{ _('Maintainer') }}</div>
             <div class="dataset-details package-additional-info-td" property="dc:contributor">
               {{ h.mail_to(email_address=pkg_dict.maintainer_email, name=pkg_dict.maintainer) }}
             </div>
           </div>
         {% elif pkg_dict.maintainer %}
           <div class="package-additional-info-tr">
-            <div scope="row" class="dataset-label package-additional-info-th">{{ _('Maintainer') }}</div>
+            <div class="dataset-label package-additional-info-th">{{ _('Maintainer') }}</div>
             <div class="dataset-details package-additional-info-td" property="dc:contributor">{{ pkg_dict.maintainer }}</div>
           </div>
         {% endif %}
         {% if pkg_dict.version %}
           <div class="package-additional-info-tr">
-            <div scope="row" class="dataset-label package-additional-info-th">{{ _("Version") }}</div>
+            <div class="dataset-label package-additional-info-th">{{ _("Version") }}</div>
             <div class="dataset-details package-additional-info-td">{{ pkg_dict.version }}</div>
           </div>
         {% endif %}
         {% if h.check_access('package_update',{'id':pkg_dict.id}) %}
           <div class="package-additional-info-tr">
-            <div scope="row" class="dataset-label package-additional-info-th">{{ _("State") }}</div>
+            <div class="dataset-label package-additional-info-th">{{ _("State") }}</div>
             <div class="dataset-details package-additional-info-td">{{ _(pkg_dict.state) }}</div>
           </div>
         {% endif %}
         {% if pkg_dict.metadata_modified %}
           <div class="package-additional-info-tr">
-            <div scope="row" class="dataset-label package-additional-info-th">{{ _("Last Updated") }}</div>
+            <div class="dataset-label package-additional-info-th">{{ _("Last Updated") }}</div>
             <div class="dataset-details package-additional-info-td">
               {% snippet "snippets/local_friendly_datetime.html", datetime_obj=pkg_dict.metadata_modified %}
             </div>
@@ -69,7 +69,7 @@
         {% endif %}
         {% if pkg_dict.metadata_created %}
           <div class="package-additional-info-tr">
-            <div scope="row" class="dataset-label package-additional-info-th">{{ _("Created") }}</div>
+            <div class="dataset-label package-additional-info-th">{{ _("Created") }}</div>
             <div class="dataset-details package-additional-info-td">
               {% snippet "snippets/local_friendly_datetime.html", datetime_obj=pkg_dict.metadata_created %}
             </div>
@@ -79,7 +79,7 @@
           {% for extra in h.sorted_extras(pkg_dict.extras) %}
             {% set key, value = extra %}
             <div class="package-additional-info-tr" rel="dc:relation" resource="_:extra{{ i }}">
-              <div scope="row" class="dataset-label package-additional-info-th" property="rdfs:label">{{ _(key|e) }}</div>
+              <div class="dataset-label package-additional-info-th" property="rdfs:label">{{ _(key|e) }}</div>
               <div class="dataset-details package-additional-info-td" property="rdf:value">{{ value }}</div>
             </div>
           {% endfor %}

--- a/ckanext/ontario_theme/templates/internal/scheming/package/resource_read.html
+++ b/ckanext/ontario_theme/templates/internal/scheming/package/resource_read.html
@@ -212,14 +212,14 @@
                    data-module="table-toggle-more">
                 <div class="res-additional-info-thead">
                   <div class="res-additional-info-tr">
-                    <div class="res-additional-info-th" scope="col">{{ _('Field') }}</div>
-                    <div class="res-additional-info-th" scope="col">{{ _('Value') }}</div>
+                    <div class="res-additional-info-th">{{ _('Field') }}</div>
+                    <div class="res-additional-info-th">{{ _('Value') }}</div>
                   </div>
                 </div>
                 <div class="res-additional-info-tbody">
                   {%- block resource_last_updated -%}
                     <div class="res-additional-info-tr">
-                      <div class="res-additional-info-th" scope="row">{{ _('Last updated') }}</div>
+                      <div class="res-additional-info-th">{{ _('Last updated') }}</div>
                       <div class="res-additional-info-td">
                         {{ h.render_datetime(res.data_last_updated) or h.render_datetime(res.last_modified) or h.render_datetime(res.revision_timestamp) or h.render_datetime(res.created) or _('unknown') }}
                       </div>
@@ -227,13 +227,13 @@
                   {%- endblock resource_last_updated -%}
                   {%- block resource_created -%}
                     <div class="res-additional-info-tr">
-                      <div class="res-additional-info-th" scope="row">{{ _('Created') }}</div>
+                      <div class="res-additional-info-th">{{ _('Created') }}</div>
                       <div class="res-additional-info-td">{{ h.render_datetime(res.created) or _('unknown') }}</div>
                     </div>
                   {%- endblock resource_created -%}
                   {%- block resource_format -%}
                     <div class="res-additional-info-tr">
-                      <div class="res-additional-info-th" scope="row">{{ _('Format') }}</div>
+                      <div class="res-additional-info-th">{{ _('Format') }}</div>
                       <div class="res-additional-info-td">{{ res.mimetype_inner or res.mimetype or res.format or _('unknown') }}</div>
                     </div>
                     {# Add resource size if known. This extends scheming's template. #}
@@ -241,7 +241,7 @@
                       {% set exclude_fields = exclude_fields.append('size') %}
                     {% else %}
                       <div class="res-additional-info-tr">
-                        <div class="res-additional-info-th" scope="row">{{ _('File size') }}</div>
+                        <div class="res-additional-info-th">{{ _('File size') }}</div>
                         <div class="res-additional-info-td">
                           {{ h.ontario_theme_abbr_localised_filesize(res.size)|safe if res.size else _('unknown size') }}
                         </div>
@@ -251,7 +251,7 @@
                   {%- block resource_license -%}
                     {% set license = h.ontario_theme_get_license(pkg.license_id) %}
                     <div class="res-additional-info-tr">
-                      <div class="res-additional-info-th" scope="row">{{ _('Licence') }}</div>
+                      <div class="res-additional-info-th">{{ _('Licence') }}</div>
                       <div class="res-additional-info-td">{{ h.get_translated(license._data, 'title') }}</div>
                     </div>
                   {%- endblock resource_license -%}
@@ -259,7 +259,7 @@
                     {%- for field in schema.resource_fields -%}
                       {%- if field.field_name not in exclude_fields and res[field.field_name] and (res[field.field_name] != {'fr': '', 'en': ''}) -%}
                         <div class="res-additional-info-tr">
-                          <div class="res-additional-info-th" scope="row">{{- h.scheming_language_text(field.label) -}}</div>
+                          <div class="res-additional-info-th">{{- h.scheming_language_text(field.label) -}}</div>
                           <div class="res-additional-info-td">
                             {%- if field.preset == "date" -%}
                               {{- h.render_datetime(res[field.field_name]) -}}

--- a/ckanext/ontario_theme/templates/internal/scheming/package/resource_read.html
+++ b/ckanext/ontario_theme/templates/internal/scheming/package/resource_read.html
@@ -8,12 +8,14 @@
   resource-main
 {% endblock wrapper_class %}
 
-{% block head_extras %}{% endblock head_extras %}
+{%- block head_extras -%}
+{%- endblock head_extras -%}
 
 {% block meta -%}
   {{ super() }}
   {% set description = h.markdown_extract(h.get_translated(res, 'description'), extract_length=200) if res.description else h.markdown_extract(h.get_translated(package, 'notes'), extract_length=200) %}
-  <meta property="og:title" content="{{ h.dataset_display_name(package) }} - {{ h.resource_display_name(res) }} - {{ h.ontario_theme_site_title() }}">
+  <meta property="og:title"
+        content="{{ h.dataset_display_name(package) }} - {{ h.resource_display_name(res) }} - {{ h.ontario_theme_site_title() }}">
   <meta property="og:description" content="{{ description|forceescape }}">
 {% endblock meta -%}
 
@@ -68,9 +70,7 @@
               {% endif %}
             {% endblock resource_read_url %}
 
-            {% if res.description %}
-              <div>{{ h.render_markdown(h.get_translated(res, "description")) }}</div>
-            {% endif %}
+            {% if res.description %}<div>{{ h.render_markdown(h.get_translated(res, "description")) }}</div>{% endif %}
             {% if not res.description and c.package.notes %}
               {% if res.datastore_active %}
                 {{ h.render_markdown(h.get_translated(c.package, 'notes')) }}
@@ -201,83 +201,83 @@
   {# only display resource page content if open dataset or admin user #}
   {% set is_open = (pkg.access_level == 'open') %}
   {% if is_open or is_admin %}
-    <div class="col-xs-12">{% snippet 'package/snippets/report_an_error.html' %}</div>
+    <div class="ontario-column ontario-small-12">{% snippet 'package/snippets/report_an_error.html' %}</div>
     {% block primary_content %}
       {% block resource_additional_information %}
         {% if res %}
           {% block resource_additional_information_inner %}
-            <div class="col-sm-9 col-xs-12">
+            <div class="ontario-column ontario-small-12 ontario-medium-9">
               <h2>{{ _('Additional information') }}</h2>
-              <table class="ontario-margin-top-40 additional-info-table datafile-p table table-striped table-bordered table-condensed"
-                     data-module="table-toggle-more">
-                <thead>
-                  <tr>
-                    <th scope="col">{{ _('Field') }}</th>
-                    <th scope="col">{{ _('Value') }}</th>
-                  </tr>
-                </thead>
-                <tbody>
+              <div class="ontario-margin-top-40 res-additional-info-table table table-striped table-bordered table-condensed"
+                   data-module="table-toggle-more">
+                <div class="res-additional-info-thead">
+                  <div class="res-additional-info-tr">
+                    <div class="res-additional-info-th" scope="col">{{ _('Field') }}</div>
+                    <div class="res-additional-info-th" scope="col">{{ _('Value') }}</div>
+                  </div>
+                </div>
+                <div class="res-additional-info-tbody">
                   {%- block resource_last_updated -%}
-                    <tr>
-                      <th scope="row">{{ _('Last updated') }}</th>
-                      <td>
+                    <div class="res-additional-info-tr">
+                      <div class="res-additional-info-th" scope="row">{{ _('Last updated') }}</div>
+                      <div class="res-additional-info-td">
                         {{ h.render_datetime(res.data_last_updated) or h.render_datetime(res.last_modified) or h.render_datetime(res.revision_timestamp) or h.render_datetime(res.created) or _('unknown') }}
-                      </td>
-                    </tr>
+                      </div>
+                    </div>
                   {%- endblock resource_last_updated -%}
                   {%- block resource_created -%}
-                    <tr>
-                      <th scope="row">{{ _('Created') }}</th>
-                      <td>{{ h.render_datetime(res.created) or _('unknown') }}</td>
-                    </tr>
+                    <div class="res-additional-info-tr">
+                      <div class="res-additional-info-th" scope="row">{{ _('Created') }}</div>
+                      <div class="res-additional-info-td">{{ h.render_datetime(res.created) or _('unknown') }}</div>
+                    </div>
                   {%- endblock resource_created -%}
                   {%- block resource_format -%}
-                    <tr>
-                      <th scope="row">{{ _('Format') }}</th>
-                      <td>{{ res.mimetype_inner or res.mimetype or res.format or _('unknown') }}</td>
-                    </tr>
+                    <div class="res-additional-info-tr">
+                      <div class="res-additional-info-th" scope="row">{{ _('Format') }}</div>
+                      <div class="res-additional-info-td">{{ res.mimetype_inner or res.mimetype or res.format or _('unknown') }}</div>
+                    </div>
                     {# Add resource size if known. This extends scheming's template. #}
                     {% if not res.mimetype and not res.size %}
                       {% set exclude_fields = exclude_fields.append('size') %}
                     {% else %}
-                      <tr>
-                        <th scope="row">{{ _('File size') }}</th>
-                        <td>
+                      <div class="res-additional-info-tr">
+                        <div class="res-additional-info-th" scope="row">{{ _('File size') }}</div>
+                        <div class="res-additional-info-td">
                           {{ h.ontario_theme_abbr_localised_filesize(res.size)|safe if res.size else _('unknown size') }}
-                        </td>
-                      </tr>
+                        </div>
+                      </div>
                     {% endif %}
                   {%- endblock resource_format -%}
                   {%- block resource_license -%}
                     {% set license = h.ontario_theme_get_license(pkg.license_id) %}
-                    <tr>
-                      <th scope="row">{{ _('Licence') }}</th>
-                      <td>{{ h.get_translated(license._data, 'title') }}</td>
-                    </tr>
+                    <div class="res-additional-info-tr">
+                      <div class="res-additional-info-th" scope="row">{{ _('Licence') }}</div>
+                      <div class="res-additional-info-td">{{ h.get_translated(license._data, 'title') }}</div>
+                    </div>
                   {%- endblock resource_license -%}
                   {%- block resource_fields -%}
                     {%- for field in schema.resource_fields -%}
                       {%- if field.field_name not in exclude_fields and res[field.field_name] and (res[field.field_name] != {'fr': '', 'en': ''}) -%}
-                        <tr>
-                          <th scope="row">{{- h.scheming_language_text(field.label) -}}</th>
-                          <td>
+                        <div class="res-additional-info-tr">
+                          <div class="res-additional-info-th" scope="row">{{- h.scheming_language_text(field.label) -}}</div>
+                          <div class="res-additional-info-td">
                             {%- if field.preset == "date" -%}
                               {{- h.render_datetime(res[field.field_name]) -}}
                             {%- else -%}
                               {%- snippet "scheming/snippets/display_field.html", field=field, data=res, entity_type='dataset', object_type=dataset_type -%}
                             {%- endif -%}
-                          </td>
-                        </tr>
+                          </div>
+                        </div>
                       {%- endif -%}
                     {%- endfor -%}
                   {%- endblock resource_fields -%}
-                </tbody>
-              </table>
+                </div>
+              </div>
             </div>
           {% endblock resource_additional_information_inner %}
         {% endif %}
       {% endblock resource_additional_information %}
     {% endblock primary_content %}
-    <div class="col-xs-12">{% snippet 'home/snippets/ontario_theme_contact_us.html' %}</div>
+    <div class="ontario-column ontario-small-12">{% snippet 'home/snippets/ontario_theme_contact_us.html' %}</div>
   {% endif %}
 {% endblock primary %}


### PR DESCRIPTION
## What this PR accomplishes

- change Addtional Information table from `<table>` to `<div>`s

## Issue(s) addressed

- DATA-1043

## What needs review

- Tables look the same as prod in all screen sizes
- Tables are made up of divs and not inside of a `<table>`