### PR TITLE
Condition to prevent Nonetype concatenate error

### DIFF
--- a/ckanext/ontario_theme/templates/internal/snippets/search_form.html
+++ b/ckanext/ontario_theme/templates/internal/snippets/search_form.html
@@ -68,7 +68,7 @@
             {% set search_facets_items = facets.search.get(field)['items'] %}
             <span class="facet">
               {% if (not query and not loop.index0==0) or query %}<span class="sr-only">and</span>{% endif %}
-              {{ facets.titles.get(field) + _(':') }}
+              {{ facets.titles.get(field) + _(':') if facets.titles.get(field) is not none }}
             </span>
             {% for field_value in facets.fields[field] %}
               {% set dict = h.get_facet_items_dict(field)|selectattr("name", "equalto", field_value)|list if h.get_facet_items_dict(field) %}


### PR DESCRIPTION
## What this PR accomplishes & Issue(s) addressed

- Adds condition to facet search to prevent `TypeError: unsupported operand type(s) for +: 'NoneType' and 'Markup'` this error being thrown intermittently.

## What needs review

- `TypeError: unsupported operand type(s) for +: 'NoneType' and 'Markup'` error is no longer thrown.