### PR TITLE
[Bug]: Sorting on Ministries is not implemented 

### DIFF
--- a/ckanext/ontario_theme/fanstatic/common.css
+++ b/ckanext/ontario_theme/fanstatic/common.css
@@ -3057,6 +3057,7 @@ label::after {
   padding: 1.75rem 1rem 1.75rem 1rem;
   font-size: 22px;
   line-height: 1.5rem;
+  border-bottom: solid 1px #ccc;
 }
 
 .search-table-thead {
@@ -3084,7 +3085,7 @@ label::after {
   padding: 2.1875rem 1rem 2.1875rem 1rem;
   text-align: left;
   letter-spacing: .025rem;
-  border-top: solid 1px #ccc;
+  border-bottom: solid 1px #ccc;
 }
 
 .search-table-cell > p {

--- a/ckanext/ontario_theme/organization.py
+++ b/ckanext/ontario_theme/organization.py
@@ -1,0 +1,82 @@
+
+from ckan.logic import NotAuthorized, ValidationError
+import ckan.lib.base as base
+import ckan.lib.helpers as h
+import ckan.model as model
+from ckan.common import g, request, _
+from ckan.views.group import _check_access, _action, _get_group_template, set_org
+
+
+def index(group_type='organization', is_organization=True):
+    extra_vars = {}
+    set_org(is_organization)
+    page = h.get_page_number(request.params) or 1
+
+    context = {
+        u'model': model,
+        u'session': model.Session,
+        u'user': g.user,
+        u'for_view': True,
+        u'with_private': False
+    }
+
+    try:
+        _check_access(u'site_read', context)
+        _check_access(u'group_list', context)
+    except NotAuthorized:
+        base.abort(403, _(u'Not authorized to see this page'))
+
+    q = request.params.get(u'q', u'')
+    sort_by = request.params.get(u'sort')
+
+    # TODO: Remove
+    # ckan 2.9: Adding variables that were removed from c object for
+    # compatibility with templates in existing extensions
+    g.q = q
+    g.sort_by_selected = sort_by
+
+    extra_vars["q"] = q
+    extra_vars["sort_by_selected"] = sort_by
+
+    # pass user info to context as needed to view private datasets of
+    # orgs correctly
+    if g.userobj:
+        context['user_id'] = g.userobj.id
+        context['user_is_admin'] = g.userobj.sysadmin
+
+    try:
+        data_dict_global_results = {
+            u'all_fields': True,
+            u'q': q,
+            u'sort': sort_by,
+            u'type': group_type or u'group',
+            u'include_extras': True,
+        }
+        global_results = _action(u'group_list')(context,
+                                                data_dict_global_results)
+    except ValidationError as e:
+        if e.error_dict and e.error_dict.get(u'message'):
+            msg = e.error_dict['message']
+        else:
+            msg = str(e)
+        h.flash_error(msg)
+        extra_vars["page"] = h.Page([], 0)
+        extra_vars["group_type"] = group_type
+        return base.render(
+            _get_group_template(u'index_template', group_type), extra_vars)
+
+    extra_vars["page"] = h.Page(
+        collection=global_results,
+        page=page,
+        url=h.pager_url,
+        items_per_page=len(global_results))
+
+    extra_vars["page"].items = global_results
+    extra_vars["group_type"] = group_type
+
+    # TODO: Remove
+    # ckan 2.9: Adding variables that were removed from c object for
+    # compatibility with templates in existing extensions
+    g.page = extra_vars["page"]
+    return base.render(
+        _get_group_template(u'index_template', group_type), extra_vars)

--- a/ckanext/ontario_theme/organization.py
+++ b/ckanext/ontario_theme/organization.py
@@ -1,4 +1,3 @@
-
 from ckan.logic import NotAuthorized, ValidationError
 import ckan.lib.base as base
 import ckan.lib.helpers as h
@@ -8,6 +7,10 @@ from ckan.views.group import _check_access, _action, _get_group_template, set_or
 
 
 def index(group_type='organization', is_organization=True):
+    '''Function from ckan.views.group modified to remove pagination
+    and return all fields of organizations for easier multilingual sorting
+    Specifically for organizations but can be reworked for both
+    groups and organizations.'''
     extra_vars = {}
     set_org(is_organization)
     page = h.get_page_number(request.params) or 1

--- a/ckanext/ontario_theme/plugin.py
+++ b/ckanext/ontario_theme/plugin.py
@@ -544,48 +544,6 @@ def get_all_packages(**kwargs):
 
     return package_search['results']
 
-def get_all_organizations(**kwargs):
-    '''Helper function to returns the full list of organizations 
-    output from a keyword search (or all organizations in the 
-    case of no search). In the search page, only the paginated 
-    number of organizations for the current page is available, 
-    which prohibits application of any custom sorting since that 
-    needs the full list.
-
-    collection_names
-        An array of short-hand (hyphenated) organization names 
-        (e.g. 'attorney-general') for all items returned from the 
-        search. If no search performed, includes all items.
-        Passed from c.page.collection.
-
-    '''
-    collection_names=kwargs['collection_names']    
-
-    # Get the id of all organizations in the catalogue.
-    all_organization_names = toolkit.get_action('organization_list')(data_dict={})
-    
-    # When there are no organizations in the catalogue (e.g. when application is 
-    # first installed and database not yet indexed), the below try will fail and
-    # and empty array will be returned, preventing the template from calling 
-    # the sort method on organizations.
-    try:
-        this_name = all_organization_names[0]
-        if toolkit.get_action('organization_show')(data_dict={'id':this_name}):
-            # Filter only those organizations whose names matching those in 
-            # collection_names. Then use helper function h.get_organization() 
-            # to extract the full details for each organization, matching on 'id'.
-            org_array = []
-            for name in collection_names:
-                for idx in range(len(all_organization_names)):
-                    if name == all_organization_names[idx]:
-                        organization_obj = toolkit.get_action('organization_show')(data_dict={'id':name})
-                        organization_id = organization_obj['id']
-                        org_array.append(h.get_organization(organization_id))
-    except:
-        org_array = []
-
-    return org_array
-
 
 def sort_by_title_translated(item_list, **kwargs):
     '''Helper function to sort an array of items by the
@@ -1082,7 +1040,6 @@ type data_last_updated
                 'ontario_theme_get_group_datasets': get_group_datasets,
                 'ontario_theme_get_keyword_count': get_keyword_count,
                 'ontario_theme_get_all_packages': get_all_packages,
-                'ontario_theme_get_all_organizations': get_all_organizations,
                 'ontario_theme_sort_by_title_translated': sort_by_title_translated,
                 'ontario_theme_sort_accented_characters': sort_accented_characters,
                 'ontario_theme_abbr_localised_filesize': abbr_localised_filesize,

--- a/ckanext/ontario_theme/plugin.py
+++ b/ckanext/ontario_theme/plugin.py
@@ -31,7 +31,7 @@ import functools
 
 from ckanext.ontario_theme.resource_upload import ResourceUpload
 from ckanext.ontario_theme.create_view import CreateView as OntarioThemeCreateView
-from ckanext.ontario_theme.organization import index
+from ckanext.ontario_theme.organization import index as organization_index
 
 # For Image Uploader
 #from ckan.controllers.home import CACHE_PARAMETERS
@@ -1074,13 +1074,13 @@ type data_last_updated
         # Add url rules to Blueprint object.
         rules = [
             (u'/help', u'help', help),
-            (u'/dataset/inventory', u'inventory', csv_dump),
+            (u'/dataset/inventory', u'inventory', csv_dump)
         ]
 
         for rule in rules:
             blueprint.add_url_rule(*rule)
         blueprint.add_url_rule('/dataset/new', view_func=OntarioThemeCreateView.as_view(str(u'new')), defaults={u'package_type': u'dataset'})
-        blueprint.add_url_rule(u'/organization', view_func=index, strict_slashes=False)
+        blueprint.add_url_rule(u'/organization', view_func=organization_index, strict_slashes=False)
         return blueprint
 
     # IUploader

--- a/ckanext/ontario_theme/plugin.py
+++ b/ckanext/ontario_theme/plugin.py
@@ -788,8 +788,33 @@ def default_locale():
     return value
 
 
-def sort_accented_characters(french_list, primary_key, secondary_key=None,
+def sort_accented_characters(french_dict, primary_key, secondary_key=None,
                              tertiary_option=None, reverse=False):
+    '''Sorts a dict containing accented and different cased letters
+
+    french_dict
+        Dict in French containing accented characters and different
+        cased letters.
+    primary_key
+        Key of key:value pair, where the string containing accented
+        characters is the value.
+        (E.g. {"label_fr": "Justice et sécurité publique"})
+    secondary_key
+        Key of nested dictionary key:value pair, where
+        the string containing accented characters is the value.
+        (E.g. {'title_translated': {'en': 'Justice and Public Safety',
+                                    'fr': 'Justice et sécurité publique'}})
+    tertiary_option
+        Optional key for cases where a secondary key value is missing
+        from the nested dictionary. The optional key should be used
+        in place of primary_key and secondary_key.
+        (E.g. {'title': 'Justice and Public Safety',
+               'title_translated': {'en': 'Justice and Public Safety',
+                                    'fr': ''}})
+    reverse
+        Direction of sort, ascending or descending. Set to False (asc)
+        by default.
+    '''
     locale.setlocale(locale.LC_ALL, "")
 
     def get_key(item):
@@ -799,7 +824,7 @@ def sort_accented_characters(french_list, primary_key, secondary_key=None,
             return item[primary_key][secondary_key]
         else:
             return item[primary_key]
-    sorted_list = humansorted(french_list, key=get_key, reverse=reverse)
+    sorted_list = humansorted(french_dict, key=get_key, reverse=reverse)
     return sorted_list
 
 

--- a/ckanext/ontario_theme/templates/internal/organization/index.html
+++ b/ckanext/ontario_theme/templates/internal/organization/index.html
@@ -71,21 +71,14 @@
       {% block organizations_list %}
         {% if c.page.items or request.params %}
           {% if c.page.items %}
-            {# Custom sort by language for name ascending and descending #}
-            {# Get all organization returned by query #}
-            {% set org_list = h.ontario_theme_get_all_organizations(collection_names=c.page.collection) %}
-            {# Prevent any organization sorting when there are no organizations #}
-            {% if org_list | length > 0 %}
-              {# Sort org_list by title_translated as per current language #}
-              {% set current_lang = request.environ.CKAN_LANG %}
-              {% set reverse = True if 'desc' in request.params['sort'] else False %}
-              {% set sorted_org = h.ontario_theme_sort_by_title_translated(org_list,
+            {% set current_lang = request.environ.CKAN_LANG %}
+            {% set reverse = True if 'desc' in request.params['sort'] else False %}
+            {% set sorted_org = h.ontario_theme_sort_by_title_translated(c.page.items,
                               current_page=c.page.page,
                               items_per_page=c.page.items_per_page,
                               lang=current_lang,
                             reverse=reverse) %}
-              {% snippet "organization/snippets/organization_list.html", organizations=sorted_org %}
-            {% endif %}
+            {% snippet "organization/snippets/organization_list.html", organizations=sorted_org %}
           {% endif %}
         {% else %}
           <p class="empty">

--- a/ckanext/ontario_theme/templates/internal/organization/index.html
+++ b/ckanext/ontario_theme/templates/internal/organization/index.html
@@ -89,10 +89,6 @@
           </p>
         {% endif %}
       {% endblock organizations_list %}
-
-      {% block page_pagination %}
-        {{ c.page.pager(q=c.q or '', sort=c.sort_by_selected or '') }}
-      {% endblock page_pagination %}
     {% endblock primary_content_inner %}
   </div>
   <div class="ontario-columns ontario-small-12">{% snippet 'home/snippets/ontario_theme_contact_us.html' %}</div>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 dominate==2.6.0
+natsort==8.4.0


### PR DESCRIPTION
## What this PR accomplishes

- Removes pagination from Ministries' page
- Displays all Ministries on one page
- Implements natsort for sorting Ministry titles
- Reduces Ministries' page loading time
- Reworks Ministries' index view function to return all fields for faster and more efficient sorting

## Issue(s) addressed

- DATA-1389

## What needs review

- For testing:
   - set `ckan.group_and_organization_list_all_fields_max = 100` in the ckan.ini
   - run `pip install -r requirements.txt` (in virtual environment) for the `natsort` library
- Ministries' page should have all ministries on one page and no pagination
- Ministries in English and French should be sorted correctly.