### PR TITLE
[Task]: Update ckan.ini to reflect organization item page limit

### DIFF
--- a/config/ckan/ckan.ini
+++ b/config/ckan/ckan.ini
@@ -223,6 +223,10 @@ ckan.hide_activity_from_users = %(ckan.site_id)s
 ## Background Job Settings
 ckan.jobs.timeout = 180
 
+## Group and Organization search settings
+# ckan.group_and_organization_list_max = 1000
+ckan.group_and_organization_list_all_fields_max = 100
+
 ## Logging configuration
 [loggers]
 keys = root, ckan, ckanext, werkzeug


### PR DESCRIPTION
## What this PR accomplishes

- updates ckan.ini to set `ckan.group_and_organization_list_all_fields_max = 100`

## Issue(s) addressed

- DATA-1389

## What needs review

- `config/ckan/ckan.ini` is updated