### PR TITLE
[Task]: Additional info table headers removed and added description lists

### DIFF
--- a/ckanext/ontario_theme/fanstatic/common.css
+++ b/ckanext/ontario_theme/fanstatic/common.css
@@ -3278,6 +3278,7 @@ label::after {
   background-color: #f9f9f9;
   border: none;
   display: table;
+  width: 100%;
 }
 
 .dataset-details.package-additional-info-td {

--- a/ckanext/ontario_theme/templates/external/scheming/package/snippets/additional_info.html
+++ b/ckanext/ontario_theme/templates/external/scheming/package/snippets/additional_info.html
@@ -26,22 +26,22 @@
       and pkg_dict[field.field_name]
       and (pkg_dict[field.field_name] != {'fr': '', 'en': ''}) -%}
       <div class="package-additional-info-tr">
-        <div class="dataset-label package-additional-info-th">{{ h.scheming_language_text(field.label) }}</div>
-        <div class="dataset-details package-additional-info-td"
+        <dt class="dataset-label package-additional-info-th">{{ h.scheming_language_text(field.label) }}</dt>
+        <dd class="dataset-details package-additional-info-td"
             {% if field.display_property -%}property="{{ field.display_property }}"{%- endif %}>
           {% if field.preset == "date" %}
             {{ h.render_datetime(pkg_dict[field.field_name]) }}
           {% else %}
             {%- snippet 'scheming/snippets/display_field.html', field=field, data=pkg_dict, schema=schema -%}
           {% endif %}
-        </div>
+        </dd>
       </div>
     {%- endif -%}
   {%- endfor -%}
   {% if h.check_access('package_update',{'id':pkg_dict.id}) %}
     <div class="package-additional-info-tr">
-      <div class="dataset-label package-additional-info-th">{{ _("State") }}</div>
-      <div class="dataset-details package-additional-info-td">{{ _(pkg_dict.state) }}</div>
+      <dt class="dataset-label package-additional-info-th">{{ _("State") }}</dt>
+      <dd class="dataset-details package-additional-info-td">{{ _(pkg_dict.state) }}</dd>
     </div>
   {% endif %}
 {% endblock package_additional_info %}

--- a/ckanext/ontario_theme/templates/internal/package/snippets/additional_info.html
+++ b/ckanext/ontario_theme/templates/internal/package/snippets/additional_info.html
@@ -1,90 +1,84 @@
 <section class="additional-info">
   <h2>{{ _('Additional information') }}</h2>
   <div class="package-additional-info-table table-condensed">
-    <div class="package-additional-info-thead">
-      <div class="package-additional-info-tr">
-        <div class="package-additional-info-th">{{ _('Field') }}</div>
-        <div class="package-additional-info-th">{{ _('Value') }}</div>
-      </div>
-    </div>
-    <div class="package-additional-info-tbody">
+    <dl class="package-additional-info-tbody">
       {% block package_additional_info %}
         {% if pkg_dict.url %}
           <div class="package-additional-info-tr">
-            <div class="dataset-label package-additional-info-th">{{ _('Source') }}</div>
+            <dt class="dataset-label package-additional-info-th">{{ _('Source') }}</dt>
             {% if h.is_url(pkg_dict.url) %}
-              <div class="dataset-details package-additional-info-td" property="foaf:homepage">
+              <dd class="dataset-details package-additional-info-td" property="foaf:homepage">
                 {{ h.link_to(pkg_dict.url, pkg_dict.url, rel='foaf:homepage', target='_blank') }}
-              </div>
+              </dd>
             {% else %}
-              <div class="dataset-details package-additional-info-td" property="foaf:homepage">{{ pkg_dict.url }}</div>
+              <dd class="dataset-details package-additional-info-td" property="foaf:homepage">{{ pkg_dict.url }}</dd>
             {% endif %}
           </div>
         {% endif %}
         {% if pkg_dict.author_email %}
           <div class="package-additional-info-tr">
-            <div class="dataset-label package-additional-info-th">{{ _("Author") }}</div>
-            <div class="dataset-details package-additional-info-td" property="dc:creator">
+            <dt class="dataset-label package-additional-info-th">{{ _("Author") }}</dt>
+            <dd class="dataset-details package-additional-info-td" property="dc:creator">
               {{ h.mail_to(email_address=pkg_dict.author_email, name=pkg_dict.author) }}
-            </div>
+            </dd>
           </div>
         {% elif pkg_dict.author %}
           <div class="package-additional-info-tr">
-            <div class="dataset-label package-additional-info-th">{{ _("Author") }}</div>
-            <div class="dataset-details package-additional-info-td" property="dc:creator">{{ pkg_dict.author }}</div>
+            <dt class="dataset-label package-additional-info-th">{{ _("Author") }}</dt>
+            <dd class="dataset-details package-additional-info-td" property="dc:creator">{{ pkg_dict.author }}</dd>
           </div>
         {% endif %}
         {% if pkg_dict.maintainer_email %}
           <div class="package-additional-info-tr">
-            <div class="dataset-label package-additional-info-th">{{ _('Maintainer') }}</div>
-            <div class="dataset-details package-additional-info-td" property="dc:contributor">
+            <dt class="dataset-label package-additional-info-th">{{ _('Maintainer') }}</dt>
+            <dd class="dataset-details package-additional-info-td" property="dc:contributor">
               {{ h.mail_to(email_address=pkg_dict.maintainer_email, name=pkg_dict.maintainer) }}
-            </div>
+            </dd>
           </div>
         {% elif pkg_dict.maintainer %}
           <div class="package-additional-info-tr">
-            <div class="dataset-label package-additional-info-th">{{ _('Maintainer') }}</div>
-            <div class="dataset-details package-additional-info-td" property="dc:contributor">{{ pkg_dict.maintainer }}</div>
+            <dt class="dataset-label package-additional-info-th">{{ _('Maintainer') }}</dt>
+            <dd class="dataset-details package-additional-info-td" property="dc:contributor">{{ pkg_dict.maintainer }}</dd>
           </div>
         {% endif %}
         {% if pkg_dict.version %}
           <div class="package-additional-info-tr">
-            <div class="dataset-label package-additional-info-th">{{ _("Version") }}</div>
-            <div class="dataset-details package-additional-info-td">{{ pkg_dict.version }}</div>
+            <dt class="dataset-label package-additional-info-th">{{ _("Version") }}</dt>
+            <dd class="dataset-details package-additional-info-td">{{ pkg_dict.version }}</dd>
           </div>
         {% endif %}
         {% if h.check_access('package_update',{'id':pkg_dict.id}) %}
           <div class="package-additional-info-tr">
-            <div class="dataset-label package-additional-info-th">{{ _("State") }}</div>
-            <div class="dataset-details package-additional-info-td">{{ _(pkg_dict.state) }}</div>
+            <dt class="dataset-label package-additional-info-th">{{ _("State") }}</dt>
+            <dd class="dataset-details package-additional-info-td">{{ _(pkg_dict.state) }}</dd>
           </div>
         {% endif %}
         {% if pkg_dict.metadata_modified %}
           <div class="package-additional-info-tr">
-            <div class="dataset-label package-additional-info-th">{{ _("Last Updated") }}</div>
-            <div class="dataset-details package-additional-info-td">
+            <dt class="dataset-label package-additional-info-th">{{ _("Last Updated") }}</dt>
+            <dd class="dataset-details package-additional-info-td">
               {% snippet "snippets/local_friendly_datetime.html", datetime_obj=pkg_dict.metadata_modified %}
-            </div>
+            </dd>
           </div>
         {% endif %}
         {% if pkg_dict.metadata_created %}
           <div class="package-additional-info-tr">
-            <div class="dataset-label package-additional-info-th">{{ _("Created") }}</div>
-            <div class="dataset-details package-additional-info-td">
+            <dt class="dataset-label package-additional-info-th">{{ _("Created") }}</dt>
+            <dd class="dataset-details package-additional-info-td">
               {% snippet "snippets/local_friendly_datetime.html", datetime_obj=pkg_dict.metadata_created %}
-            </div>
+            </dd>
           </div>
         {% endif %}
         {% block extras scoped %}
           {% for extra in h.sorted_extras(pkg_dict.extras) %}
             {% set key, value = extra %}
             <div class="package-additional-info-tr" rel="dc:relation" resource="_:extra{{ i }}">
-              <div class="dataset-label package-additional-info-th" property="rdfs:label">{{ _(key|e) }}</div>
-              <div class="dataset-details package-additional-info-td" property="rdf:value">{{ value }}</div>
+              <dt class="dataset-label package-additional-info-th" property="rdfs:label">{{ _(key|e) }}</dt>
+              <dd class="dataset-details package-additional-info-td" property="rdf:value">{{ value }}</dd>
             </div>
           {% endfor %}
         {% endblock extras %}
       {% endblock package_additional_info %}
-    </div>
+    </dl>
   </div>
 </section>

--- a/ckanext/ontario_theme/templates/internal/scheming/package/resource_read.html
+++ b/ckanext/ontario_theme/templates/internal/scheming/package/resource_read.html
@@ -210,68 +210,62 @@
               <h2>{{ _('Additional information') }}</h2>
               <div class="ontario-margin-top-40 res-additional-info-table table table-striped table-bordered table-condensed"
                    data-module="table-toggle-more">
-                <div class="res-additional-info-thead">
-                  <div class="res-additional-info-tr">
-                    <div class="res-additional-info-th">{{ _('Field') }}</div>
-                    <div class="res-additional-info-th">{{ _('Value') }}</div>
-                  </div>
-                </div>
-                <div class="res-additional-info-tbody">
+                <dl class="res-additional-info-tbody">
                   {%- block resource_last_updated -%}
                     <div class="res-additional-info-tr">
-                      <div class="res-additional-info-th">{{ _('Last updated') }}</div>
-                      <div class="res-additional-info-td">
+                      <dt class="res-additional-info-th">{{ _('Last updated') }}</dt>
+                      <dd class="res-additional-info-td">
                         {{ h.render_datetime(res.data_last_updated) or h.render_datetime(res.last_modified) or h.render_datetime(res.revision_timestamp) or h.render_datetime(res.created) or _('unknown') }}
-                      </div>
+                      </dd>
                     </div>
                   {%- endblock resource_last_updated -%}
                   {%- block resource_created -%}
                     <div class="res-additional-info-tr">
-                      <div class="res-additional-info-th">{{ _('Created') }}</div>
-                      <div class="res-additional-info-td">{{ h.render_datetime(res.created) or _('unknown') }}</div>
+                      <dt class="res-additional-info-th">{{ _('Created') }}</dt>
+                      <dd class="res-additional-info-td">{{ h.render_datetime(res.created) or _('unknown') }}</dd>
                     </div>
                   {%- endblock resource_created -%}
                   {%- block resource_format -%}
                     <div class="res-additional-info-tr">
-                      <div class="res-additional-info-th">{{ _('Format') }}</div>
-                      <div class="res-additional-info-td">{{ res.mimetype_inner or res.mimetype or res.format or _('unknown') }}</div>
+                      <dt class="res-additional-info-th">{{ _('Format') }}</dt>
+                      <dd class="res-additional-info-td">{{ res.mimetype_inner or res.mimetype or res.format or _('unknown') }}</dd>
                     </div>
                     {# Add resource size if known. This extends scheming's template. #}
                     {% if not res.mimetype and not res.size %}
                       {% set exclude_fields = exclude_fields.append('size') %}
                     {% else %}
                       <div class="res-additional-info-tr">
-                        <div class="res-additional-info-th">{{ _('File size') }}</div>
-                        <div class="res-additional-info-td">
+                        <dt class="res-additional-info-th">{{ _('File size') }}</dt>
+                        <dd class="res-additional-info-td">
                           {{ h.ontario_theme_abbr_localised_filesize(res.size)|safe if res.size else _('unknown size') }}
-                        </div>
+                        </dd>
                       </div>
                     {% endif %}
                   {%- endblock resource_format -%}
                   {%- block resource_license -%}
                     {% set license = h.ontario_theme_get_license(pkg.license_id) %}
                     <div class="res-additional-info-tr">
-                      <div class="res-additional-info-th">{{ _('Licence') }}</div>
-                      <div class="res-additional-info-td">{{ h.get_translated(license._data, 'title') }}</div>
+                      <dt class="res-additional-info-th">{{ _('Licence') }}</dt>
+                      <dd class="res-additional-info-td">{{ h.get_translated(license._data, 'title') }}</dd>
                     </div>
                   {%- endblock resource_license -%}
                   {%- block resource_fields -%}
                     {%- for field in schema.resource_fields -%}
                       {%- if field.field_name not in exclude_fields and res[field.field_name] and (res[field.field_name] != {'fr': '', 'en': ''}) -%}
                         <div class="res-additional-info-tr">
-                          <div class="res-additional-info-th">{{- h.scheming_language_text(field.label) -}}</div>
-                          <div class="res-additional-info-td">
+                          <dt class="res-additional-info-th">{{- h.scheming_language_text(field.label) -}}</dt>
+                          <dd class="res-additional-info-td">
                             {%- if field.preset == "date" -%}
                               {{- h.render_datetime(res[field.field_name]) -}}
                             {%- else -%}
                               {%- snippet "scheming/snippets/display_field.html", field=field, data=res, entity_type='dataset', object_type=dataset_type -%}
                             {%- endif -%}
-                          </div>
+                          </dd>
                         </div>
                       {%- endif -%}
                     {%- endfor -%}
                   {%- endblock resource_fields -%}
-                </div>
+                </dl>
               </div>
             </div>
           {% endblock resource_additional_information_inner %}


### PR DESCRIPTION
## What this PR accomplishes

- Removes additional info table headers
- Adds description list, terms and definitions for additional information tables

## Issue(s) addressed

- DATA-1396

## What needs review

- No hidden or visible table headers on additional information tables on dataset and resource page
- Key-value pairs are in `<dt>` and `<dd>` respectively in the additional information table