### PR TITLE
[Task]: Search accuracy - Case insensitivity

### DIFF
--- a/config/solr/managed-schema
+++ b/config/solr/managed-schema
@@ -114,7 +114,7 @@
   <field name="revision_id" type="string" omitNorms="true" indexed="true" stored="true"/>
   <field name="site_id" type="string" indexed="true" required="true" stored="true"/>
   <field name="state" type="string" omitNorms="true" indexed="true" stored="true"/>
-  <field name="tags" type="string" multiValued="true" indexed="true" stored="true"/>
+  <field name="tags" type="text_sort_case_insensitive" multiValued="true" indexed="true" stored="true"/>
   <field name="text" type="text" multiValued="true" indexed="true" stored="false"/>
   <field name="title" type="text" indexed="true" stored="true"/>
   <field name="title_en" type="text_sort_case_insensitive" stored="false"/>


### PR DESCRIPTION
## What this PR accomplishes

- Tags were of type String in solr, this PR changes tags to be of type "text_case_insensitive", a custom Text field.
- String fields are stored exactly as they are and cannot be modified while Text fields can be modified and can go through lower-casing.

## Issue(s) addressed

- DATA-871

## What needs review

- Searching terms like "Health" and "health" produce the same results in the same order.
- Requires solr reconfiguring