### PR TITLE
[Task]: Adds suggested datasets feedback to the right-hand side of page

### DIFF
--- a/ckanext/ontario_theme/fanstatic/common.css
+++ b/ckanext/ontario_theme/fanstatic/common.css
@@ -1722,7 +1722,7 @@ via submission form. Copied from DS.*/
   }
 
   .dataset-aside {
-    order: 2;
+    order: 3;
   }
 
   .resource-aside {
@@ -3427,7 +3427,7 @@ label::after {
    Radio buttons - Design System
    ======================================================================== */
 
-* .ontario-radios {
+.ontario-radios {
   -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
   -moz-tap-highlight-color: rgba(0, 0, 0, 0)
 }
@@ -3654,4 +3654,12 @@ legend {
 
 .related-datasets-container ul {
   margin-bottom: 2.5rem;
+}
+
+.related-feedback-default {
+  display: none;
+}
+
+#feedback-input-right, #feedback-input-bottom{
+  display: none;
 }

--- a/ckanext/ontario_theme/fanstatic/scripts/odc-related-datasets-links-feedback.js
+++ b/ckanext/ontario_theme/fanstatic/scripts/odc-related-datasets-links-feedback.js
@@ -1,33 +1,19 @@
 //Shows the input field in the Related datasets section at the bottom and right-hand side of the page when user clicks on no as a radio button option
 
 (function () {
-  var noRadioButton = document.getElementById("radio-button-option-no");
-  var yesRadioButton = document.getElementById("radio-button-option-yes");
-  var noRadioButtonRight = document.getElementById("radio-button-option-no-right");
-  var yesRadioButtonRight = document.getElementById("radio-button-option-yes-right");
 
-  var explanationInput = document.getElementById("feedback-input-bottom");
-  var explanationInputRight = document.getElementById("feedback-input-right");
+  const yesNoRadioButtons = document.querySelectorAll('[id^="radio-button-option-"');
 
-  noRadioButton.addEventListener('change', handleRadioButton);
-  yesRadioButton.addEventListener('change', handleRadioButton);
-  noRadioButtonRight.addEventListener('change', handleRadioButtonRight);
-  yesRadioButtonRight.addEventListener('change', handleRadioButtonRight);
+  yesNoRadioButtons.forEach(element => {
+    element.addEventListener('change', handleRadioButton)
+  })
 
   function handleRadioButton() {
-    if (noRadioButton.checked) {
+    let explanationInput = document.getElementById(`feedback-input-${this.dataset.feedback}`)
+    if (this.value === 'option-no' && this.checked) {
       explanationInput.style.display = "block";
     } else {
       explanationInput.style.display = "none";
     }
   }
-
-  function handleRadioButtonRight() {
-    if (noRadioButtonRight.checked) {
-      explanationInputRight.style.display = "block";
-    } else {
-      explanationInputRight.style.display = "none";
-    }
-  }
-
 })();

--- a/ckanext/ontario_theme/fanstatic/scripts/odc-related-datasets-links-feedback.js
+++ b/ckanext/ontario_theme/fanstatic/scripts/odc-related-datasets-links-feedback.js
@@ -1,0 +1,33 @@
+//Shows the input field in the Related datasets section at the bottom and right-hand side of the page when user clicks on no as a radio button option
+
+(function () {
+  var noRadioButton = document.getElementById("radio-button-option-no");
+  var yesRadioButton = document.getElementById("radio-button-option-yes");
+  var noRadioButtonRight = document.getElementById("radio-button-option-no-right");
+  var yesRadioButtonRight = document.getElementById("radio-button-option-yes-right");
+
+  var explanationInput = document.getElementById("feedback-input-bottom");
+  var explanationInputRight = document.getElementById("feedback-input-right");
+
+  noRadioButton.addEventListener('change', handleRadioButton);
+  yesRadioButton.addEventListener('change', handleRadioButton);
+  noRadioButtonRight.addEventListener('change', handleRadioButtonRight);
+  yesRadioButtonRight.addEventListener('change', handleRadioButtonRight);
+
+  function handleRadioButton() {
+    if (noRadioButton.checked) {
+      explanationInput.style.display = "block";
+    } else {
+      explanationInput.style.display = "none";
+    }
+  }
+
+  function handleRadioButtonRight() {
+    if (noRadioButtonRight.checked) {
+      explanationInputRight.style.display = "block";
+    } else {
+      explanationInputRight.style.display = "none";
+    }
+  }
+
+})();

--- a/ckanext/ontario_theme/fanstatic/scripts/odc-relevant-datasets-form.js
+++ b/ckanext/ontario_theme/fanstatic/scripts/odc-relevant-datasets-form.js
@@ -1,0 +1,10 @@
+//Shows the feedback module once a related dataset link is clicked on from the previous page
+
+var feedbackForm = document.getElementById('related-dataset-feedback-form');
+var relatedDatasetLinks = document.querySelectorAll('#related-datasets-right-module a');
+
+relatedDatasetLinks.forEach(function(link) {
+  link.addEventListener('click', function(event) {
+    feedbackForm.style.display = 'block'; 
+  });
+});

--- a/ckanext/ontario_theme/fanstatic/scripts/webassets.yml
+++ b/ckanext/ontario_theme/fanstatic/scripts/webassets.yml
@@ -6,6 +6,8 @@ ontario_theme_js:
     - ontario-back-to-top.js
     - odc-show-more.js
     - odc-active-page.js
+    - odc-related-datasets-links-feedback.js
+    - odc-relevant-datasets-form.js
 
 ontario_theme_form_validators_js:
   filters: rjsmin

--- a/ckanext/ontario_theme/templates/internal/package/read_base.html
+++ b/ckanext/ontario_theme/templates/internal/package/read_base.html
@@ -24,5 +24,10 @@
     {% block package_license %}
       {% snippet "snippets/license.html", pkg_dict=pkg %}
     {% endblock package_license %}
+<div id="related-dataset-feedback-form" class="related-feedback-default">
+  {% block package_related %}
+    {% snippet "snippets/related_dataset_page.html" %}
+  {% endblock package_related %}
+</div>
   </aside>
 {% endblock secondary %}

--- a/ckanext/ontario_theme/templates/internal/package/read_base.html
+++ b/ckanext/ontario_theme/templates/internal/package/read_base.html
@@ -24,10 +24,10 @@
     {% block package_license %}
       {% snippet "snippets/license.html", pkg_dict=pkg %}
     {% endblock package_license %}
-<div id="related-dataset-feedback-form" class="related-feedback-default">
-  {% block package_related %}
-    {% snippet "snippets/related_dataset_page.html" %}
-  {% endblock package_related %}
-</div>
+    <div id="related-dataset-feedback-form" class="related-feedback-default">
+    {% block package_related %}
+      {% snippet "snippets/related_dataset_page.html" %}
+    {% endblock package_related %}
+    </div>
   </aside>
 {% endblock secondary %}

--- a/ckanext/ontario_theme/templates/internal/package/snippets/related_datasets.html
+++ b/ckanext/ontario_theme/templates/internal/package/snippets/related_datasets.html
@@ -23,7 +23,8 @@
                id="radio-button-option-yes"
                name="radio-buttons"
                type="radio"
-               value="option-no">
+               value="option-yes"
+               data-feedback="bottom">
         <label class="ontario-label ontario-radios__label"
                for="radio-button-option-yes">Yes</label>
       </div>
@@ -32,12 +33,13 @@
                id="radio-button-option-no"
                name="radio-buttons"
                type="radio"
-               value="option-no">
+               value="option-no"
+               data-feedback="bottom">
         <label class="ontario-label ontario-radios__label"
                for="radio-button-option-no">No</label>
       </div>
     </div>
-    <div class="ontario-form-group" id="feedback-input-bottom">     
+    <div class="ontario-form-group" id="feedback-input-bottom">
       <label class="ontario-label" for="explanation-input">
         Please explain <span class="ontario-label__flag">(optional)</span>
       </label>

--- a/ckanext/ontario_theme/templates/internal/package/snippets/related_datasets.html
+++ b/ckanext/ontario_theme/templates/internal/package/snippets/related_datasets.html
@@ -7,7 +7,7 @@
     Browse similar datasets grouped by artificial intelligence (<abbr>AI</abbr>).
   </p>
   {# list of related datasets as links #}
-  <ul class="related-datasets-list">
+  <ul class="related-datasets-list" id="related-datasets-right-module">
     {# For loop for displaying AI generated list #}
     <li>
       <a href="#">Test link</a>
@@ -17,7 +17,7 @@
     <legend class="ontario-fieldset__legend">
       Are these suggestions accurate? <span class="ontario-label__flag">(required)</span>
     </legend>
-    <div class="ontario-radios">
+    <div class="ontario-radios" id="related-dataset-feedback-bottom">
       <div class="ontario-radios__item">
         <input class="ontario-radios__input"
                id="radio-button-option-yes"
@@ -37,8 +37,8 @@
                for="radio-button-option-no">No</label>
       </div>
     </div>
-    <div class="ontario-form-group">
-      <label class="ontario-label" for="texplanation-input">
+    <div class="ontario-form-group" id="feedback-input-bottom">     
+      <label class="ontario-label" for="explanation-input">
         Please explain <span class="ontario-label__flag">(optional)</span>
       </label>
       <input class="ontario-input" type="text" id="explanation-input">

--- a/ckanext/ontario_theme/templates/internal/snippets/related_dataset_page.html
+++ b/ckanext/ontario_theme/templates/internal/snippets/related_dataset_page.html
@@ -1,0 +1,39 @@
+<div class="module module-narrow module-shallow context-info">
+
+{% block related_title %}
+  <h2 class="ontario-h4">Is this page relevant?</h2>
+{% endblock related_title %}
+
+{% block relevant_content %}
+<fieldset class="ontario-fieldset">
+       <h5> Do you think this dataset is related to the one you just came from? <span class="ontario-label__flag">(required)</span> </h5>
+       <div class="ontario-radios" id="related-dataset-feedback-right">
+        <div class="ontario-radios__item">
+          <input class="ontario-radios__input"
+                 id="radio-button-option-yes-right"
+                 name="radio-buttons"
+                 type="radio"
+                 value="option-no">
+          <label class="ontario-label ontario-radios__label"
+                 for="radio-button-option-yes-right">Yes</label>
+        </div>
+        <div class="ontario-radios__item">
+          <input class="ontario-radios__input"
+                 id="radio-button-option-no-right"
+                 name="radio-buttons"
+                 type="radio"
+                 value="option-no">
+          <label class="ontario-label ontario-radios__label"
+                 for="radio-button-option-no-right">No</label>
+        </div>
+      </div>
+       <div class="ontario-form-group" id="feedback-input-right">
+        <label class="ontario-label" for="explanation-input">
+          Please explain <span class="ontario-label__flag">(optional)</span>
+        </label>
+        <input class="ontario-input" type="text" id="explanation-input">
+      </div>
+      <button class="ontario-button ontario-button--primary">{{ _('Submit') }}</button>
+</fieldset>
+{% endblock relevant_content %}
+</div>

--- a/ckanext/ontario_theme/templates/internal/snippets/related_dataset_page.html
+++ b/ckanext/ontario_theme/templates/internal/snippets/related_dataset_page.html
@@ -1,19 +1,22 @@
 <div class="module module-narrow module-shallow context-info">
 
-{% block related_title %}
-  <h2 class="ontario-h4">Is this page relevant?</h2>
-{% endblock related_title %}
+  {% block related_title %}
+    <h2 class="ontario-h4">Is this page relevant?</h2>
+  {% endblock related_title %}
 
-{% block relevant_content %}
-<fieldset class="ontario-fieldset">
-       <h5> Do you think this dataset is related to the one you just came from? <span class="ontario-label__flag">(required)</span> </h5>
-       <div class="ontario-radios" id="related-dataset-feedback-right">
+  {% block relevant_content %}
+    <fieldset class="ontario-fieldset">
+      <legend class="ontario-fieldset__legend">
+        Do you think this dataset is related to the one you just came from? <span class="ontario-label__flag">(required)</span>
+      </legend>
+      <div class="ontario-radios" id="related-dataset-feedback-right">
         <div class="ontario-radios__item">
           <input class="ontario-radios__input"
                  id="radio-button-option-yes-right"
                  name="radio-buttons"
                  type="radio"
-                 value="option-no">
+                 value="option-yes"
+                 data-feedback="right">
           <label class="ontario-label ontario-radios__label"
                  for="radio-button-option-yes-right">Yes</label>
         </div>
@@ -22,18 +25,19 @@
                  id="radio-button-option-no-right"
                  name="radio-buttons"
                  type="radio"
-                 value="option-no">
+                 value="option-no"
+                 data-feedback="right">
           <label class="ontario-label ontario-radios__label"
                  for="radio-button-option-no-right">No</label>
         </div>
       </div>
-       <div class="ontario-form-group" id="feedback-input-right">
+      <div class="ontario-form-group" id="feedback-input-right">
         <label class="ontario-label" for="explanation-input">
           Please explain <span class="ontario-label__flag">(optional)</span>
         </label>
         <input class="ontario-input" type="text" id="explanation-input">
       </div>
       <button class="ontario-button ontario-button--primary">{{ _('Submit') }}</button>
-</fieldset>
-{% endblock relevant_content %}
+    </fieldset>
+  {% endblock relevant_content %}
 </div>


### PR DESCRIPTION
### What this PR accomplishes

- Adds suggested datasets feedback section to the right-hand side of the page when a related dataset link is clicked
- Input fields are available when radio button is selected as "no"

### Issue(s) addressed
- DATA-1432

### What needs review
- Section looks like figma
- Content is identical to figma content
- Input field is available only when "no" is selected as a radio button