### PR TITLE
[Bug]: Right side boxes are displayed incorrectly on large screens

### DIFF
--- a/ckanext/ontario_theme/templates/internal/package/read.html
+++ b/ckanext/ontario_theme/templates/internal/package/read.html
@@ -6,7 +6,7 @@
 
 {% block primary %}
   <article class="module package-z-index">
-    <header class="page-header col-xs-12 col-lg-8">
+    <header class="page-header ontario-columns ontario-small-12 ontario-large-8">
       <div class="content_action">
         {% block content_action %}
           {% if h.check_access('package_update', {'id':pkg.id }) %}
@@ -25,7 +25,7 @@
       </ul>
     </header>
     {% block primary_content_inner %}
-      <div class="col-lg-8 col-xs-12">
+      <div class="ontario-columns ontario-small-12 ontario-large-8">
         {% if pkg.get("asset_type") == "ai" %}
           <div class="odc-alert odc-alert-algorithm">
             <p class="ontario-h5">
@@ -91,9 +91,7 @@
         {% if pkg.resources and pkg['access_level'] == 'open' %}
           {% snippet "package/snippets/report_an_error.html" %}
         {% endif %}
-        <div class="row">
-          <div class="col-md-12">{% snippet "home/snippets/ontario_theme_contact_us.html" %}</div>
-        </div>
+        <div class="ontario-small-12">{% snippet "home/snippets/ontario_theme_contact_us.html" %}</div>
       </div>
     {% endblock primary_content_inner %}
   </article>

--- a/ckanext/ontario_theme/templates/internal/package/read_base.html
+++ b/ckanext/ontario_theme/templates/internal/package/read_base.html
@@ -13,7 +13,7 @@
 {% endblock meta_description -%}
 
 {% block secondary %}
-  <aside class="dataset-aside secondary col-xs-12 col-lg-4 right-col dataset-font">
+  <aside class="dataset-aside secondary ontario-small-12 ontario-large-4 right-col dataset-font">
     {% block package_organization %}
       {% if pkg.organization %}
         {% set org = h.get_organization(pkg.organization.id) %}

--- a/ckanext/ontario_theme/templates/internal/scheming/package/resource_read.html
+++ b/ckanext/ontario_theme/templates/internal/scheming/package/resource_read.html
@@ -35,7 +35,7 @@
             {% block resource_actions %}
               {% block resource_actions_inner %}
                 {% if is_admin %}
-                  <header class="col-xs-12 page-header">
+                  <header class="ontario-small-12 page-header">
                     <div class="content_action">
                       {% link_for _('Edit'), named_route=pkg.type + '_resource.edit', id=pkg.name, resource_id=res.id, class_='btn btn-default content_action', icon='wrench' %}
                     </div>
@@ -47,7 +47,7 @@
         {% endblock resource_inner %}
       </section>
       {% block resource_content %}
-        <div class="col-lg-8 col-xs-12">
+        <div class="ontario-columns ontario-small-12 ontario-large-8">
           {% block resource_read_title %}
             <h1>{{ h.resource_display_name(res) }}</h1>
           {% endblock resource_read_title %}
@@ -67,7 +67,9 @@
             {% endblock resource_read_url %}
 
             {% if res.description %}
-              <div>{{ h.render_markdown(h.get_translated(res, "description")) }}</div>
+              <div>
+                {{ h.render_markdown(h.get_translated(res, "description")) }}
+              </div>
             {% endif %}
             {% if not res.description and c.package.notes %}
               {% if res.datastore_active %}
@@ -89,7 +91,7 @@
       {% endblock resource_content %}
 
       {% asset "ontario_theme/ontario_theme_download_tracker_js" %}
-      <div class="secondary col-xs-12 col-lg-4 right-col dataset-font resource-aside">
+      <div class="secondary ontario-small-12 ontario-large-4 right-col dataset-font resource-aside">
         {% if res.url and h.is_url(res.url) %}
           {% set this_org = h.get_translated(pkg.organization, 'title') or pkg.organization.name %}
           {% if pkg.groups %}
@@ -167,7 +169,7 @@
           </div>
         {% endif %}
       </div>
-      <div class="col-xs-12">
+      <div class="ontario-column ontario-small-12">
         {% block data_preview %}
           {% if res.format == "CSV" %}
             {% block resource_view_nav %}
@@ -190,7 +192,7 @@
       </div>
       {# if dataset is not open and user is not admin, show msg #}
     {% else %}
-      <h1 class="col-xs-12">{{ _('Data Not Available') }}</h1>
+      <h1 class="ontario-column ontario-small-12">{{ _('Data Not Available') }}</h1>
     {% endif %}
   {% endblock resource %}
 {% endblock pre_primary %}
@@ -220,13 +222,17 @@
                   {%- block resource_created -%}
                     <div class="res-additional-info-tr">
                       <dt class="res-additional-info-th">{{ _('Created') }}</dt>
-                      <dd class="res-additional-info-td">{{ h.render_datetime(res.created) or _('unknown') }}</dd>
+                      <dd class="res-additional-info-td">
+                        {{ h.render_datetime(res.created) or _('unknown') }}
+                      </dd>
                     </div>
                   {%- endblock resource_created -%}
                   {%- block resource_format -%}
                     <div class="res-additional-info-tr">
                       <dt class="res-additional-info-th">{{ _('Format') }}</dt>
-                      <dd class="res-additional-info-td">{{ res.mimetype_inner or res.mimetype or res.format or _('unknown') }}</dd>
+                      <dd class="res-additional-info-td">
+                        {{ res.mimetype_inner or res.mimetype or res.format or _('unknown') }}
+                      </dd>
                     </div>
                     {# Add resource size if known. This extends scheming's template. #}
                     {% if not res.mimetype and not res.size %}
@@ -244,7 +250,9 @@
                     {% set license = h.ontario_theme_get_license(pkg.license_id) %}
                     <div class="res-additional-info-tr">
                       <dt class="res-additional-info-th">{{ _('Licence') }}</dt>
-                      <dd class="res-additional-info-td">{{ h.get_translated(license._data, 'title') }}</dd>
+                      <dd class="res-additional-info-td">
+                        {{ h.get_translated(license._data, 'title') }}
+                      </dd>
                     </div>
                   {%- endblock resource_license -%}
                   {%- block resource_fields -%}


### PR DESCRIPTION
## What this PR accomplishes

- Removes ckan grid system and replaces is with DS grid system on dataset and resource page
- Fixes right hand side boxes error on large screens between 1170px-1199px wide

## Issue(s) addressed

- DATA-1435

## What needs review

- On screens 1170px-1199px wide, the grey boxes are on the right side of the main content of the dataset and resource pages.
- All content on both types of pages are responsive.