### PR TITLE
Data Validation MVP 1: placeholder page for Step 4 publish

### DIFF
--- a/ckanext/ontario_theme/datastore.py
+++ b/ckanext/ontario_theme/datastore.py
@@ -125,4 +125,6 @@ class DictionaryView(MethodView):
                 None,
                 {"resource_id": resource_id, "ignore_hash": True}
             )
-        return h.redirect_to("datastore.dictionary", id=id, resource_id=resource_id)
+            return h.redirect_to("ontario_theme.new_resource_publish", id=id, resource_id=resource_id)
+        else:
+            return h.redirect_to("datastore.dictionary", id=id, resource_id=resource_id)

--- a/ckanext/ontario_theme/plugin.py
+++ b/ckanext/ontario_theme/plugin.py
@@ -937,6 +937,11 @@ ckanext.ontario_theme:schemas/ontario_theme_organization.json
 ckanext.ontario_theme:schemas/ontario_theme_group.json
 """
 
+def new_resource_publish(id, resource_id):
+    '''New page for submitting new resource for publication.
+    '''
+    pkg_dict = toolkit.get_action(u'package_show')(None, {u'id': id})
+    return render_template('/package/new_resource_publish.html', id=id, resource_id=resource_id, pkg_dict=pkg_dict)
 
 class OntarioThemePlugin(plugins.SingletonPlugin, DefaultTranslation):
     plugins.implements(plugins.ITranslation)
@@ -1094,6 +1099,7 @@ type data_last_updated
 
     # IBlueprint
 
+
     def get_blueprint(self):
         '''Return a Flask Blueprint object to be registered by the app.
         '''
@@ -1118,15 +1124,16 @@ type data_last_updated
         # Add url rules to Blueprint object.
         rules = [
             (u'/help', u'help', help),
-            (u'/dataset/inventory', u'inventory', csv_dump)
+            (u'/dataset/inventory', u'inventory', csv_dump),
+            (u'/dataset/<id>/<resource_id>/new_resource_publish/', u'new_resource_publish', new_resource_publish)
         ]
 
         for rule in rules:
             blueprint.add_url_rule(*rule)
         blueprint.add_url_rule('/dataset/new', view_func=OntarioThemeCreateView.as_view(str(u'new')), defaults={u'package_type': u'dataset'})
         blueprint.add_url_rule(u'/organization', view_func=organization_index, strict_slashes=False)
-        blueprint.add_url_rule(u'/dataset/<id>/dictionary/<resource_id>',view_func=DictionaryView.as_view(str(u'dictionary'))
-)
+        blueprint.add_url_rule(u'/dataset/<id>/dictionary/<resource_id>',view_func=DictionaryView.as_view(str(u'dictionary')))
+
         return blueprint
 
     # IUploader

--- a/ckanext/ontario_theme/plugin.py
+++ b/ckanext/ontario_theme/plugin.py
@@ -200,6 +200,12 @@ def help():
     '''
     return render_template('home/help.html')
 
+def new_resource_publish(id, resource_id):
+    '''New page for submitting new resource for publication.
+    '''
+    pkg_dict = toolkit.get_action(u'package_show')(None, {u'id': id})
+    return render_template('/package/new_resource_publish.html', id=id, resource_id=resource_id, pkg_dict=pkg_dict)
+
 
 def csv_dump():
     '''
@@ -937,11 +943,6 @@ ckanext.ontario_theme:schemas/ontario_theme_organization.json
 ckanext.ontario_theme:schemas/ontario_theme_group.json
 """
 
-def new_resource_publish(id, resource_id):
-    '''New page for submitting new resource for publication.
-    '''
-    pkg_dict = toolkit.get_action(u'package_show')(None, {u'id': id})
-    return render_template('/package/new_resource_publish.html', id=id, resource_id=resource_id, pkg_dict=pkg_dict)
 
 class OntarioThemePlugin(plugins.SingletonPlugin, DefaultTranslation):
     plugins.implements(plugins.ITranslation)

--- a/ckanext/ontario_theme/templates/internal/package/new_resource_publish.html
+++ b/ckanext/ontario_theme/templates/internal/package/new_resource_publish.html
@@ -1,0 +1,16 @@
+{% extends "package/base.html" %}
+
+
+
+{% block primary_content_inner %}
+
+
+    <p>Click to Submit {{pkg}}</p>
+
+
+
+{% endblock %}
+
+{% block secondary %}
+
+{% endblock secondary %}


### PR DESCRIPTION
## What this PR accomplishes
Connects the "Run validator to continue" button in the Data Dictionary page to a new page which will contain a review of the metadata and data dictionary fields. At the moment, this page is just a placeholder for the future content. 

This placeholder page will only be rendered when the data dictionary validation completes successfully. If the data dictionary validation fails, the page stays on the Data Dictionary page and the validation error report is shown, as before.

## What needs review
- Test that the workflow from the Data Dictionary page works as expected for 2 cases:
    - a csv file with valid data types
    - a csv file with a data type error (e.g. string in integer column)
 - Make sure that `pkg` variable is passed to the placeholder page (the content of `pkg` should display on the page)