### PR TITLE
[Task]: Add Step Indicators to workflow pages

### DIFF
--- a/ckanext/ontario_theme/fanstatic/common.css
+++ b/ckanext/ontario_theme/fanstatic/common.css
@@ -2577,12 +2577,11 @@ figure {
   padding-right: 10px;
 }
 
-#news hr,
-#resources_and_information hr {
+hr {
   border: 0;
   padding: 0;
-  margin: 0 0 2.5rem;
-  border-bottom: 2px solid #f2f2f2;
+  margin: 2.5rem 0;
+  border-bottom: 4px solid #ccc;
 }
 
 #news {
@@ -2597,6 +2596,10 @@ body {
   .resource-view .actions {
     display: contents;
   }
+}
+
+.resource-margin {
+  margin-top: 1rem;
 }
 
 .resource-view .actions {
@@ -3381,4 +3384,64 @@ label::after {
 .notes.embedded-content.dataset-font p a,
 .dataset-details.package-additional-info-td > a {
   word-break: break-word;
+}
+
+/* ========================================================================
+   Step Indicator - Design System
+   ======================================================================== */
+
+.ontario-step-indicator .ontario-step-indicator--without-back-button,
+.ontario-step-indicator .ontario-step-indicator--with-back-button {
+  display: flex;
+  align-items: center
+}
+
+.ontario-step-indicator .ontario-step-indicator--without-back-button {
+  justify-content: flex-end
+}
+
+.ontario-step-indicator .ontario-step-indicator--with-back-button {
+  justify-content: space-between
+}
+
+.ontario-step-indicator .ontario-h4 {
+  margin: 1.125rem 0
+}
+
+@media screen and (max-width: 40em) {
+  .ontario-step-indicator .ontario-h4 {
+    margin: 1rem 0;
+    text-align: right
+  }
+}
+
+.ontario-step-indicator .ontario-button.ontario-button--tertiary {
+  display: flex;
+  align-items: center;
+  margin: .75rem 0;
+  padding-left: .5rem;
+  padding-right: 1rem;
+  min-width: 3rem
+}
+
+@media screen and (max-width: 40em) {
+  .ontario-step-indicator .ontario-button.ontario-button--tertiary {
+    width: unset
+  }
+}
+
+.ontario-step-indicator .ontario-button.ontario-button--tertiary .ontario-icon {
+  margin: 0 .375rem 0 0;
+  padding: 0;
+  min-width: 24px;
+  min-height: 24px
+}
+
+.ontario-step-indicator hr {
+  padding: 0;
+  margin: 0
+}
+
+.ontario-step-indicator p {
+  max-width: 48rem
 }

--- a/ckanext/ontario_theme/fanstatic/scripts/odc-step-indicator.js
+++ b/ckanext/ontario_theme/fanstatic/scripts/odc-step-indicator.js
@@ -1,0 +1,23 @@
+// Enable JavaScript's strict mode. Strict mode catches some common
+// programming errors and throws exceptions, prevents some unsafe actions from
+// being taken, and disables some confusing and bad JavaScript features.
+
+/*
+ * CKAN module function to redirect to logical page in the admin panel step
+ * indicator
+ * 
+ * url
+ *  URL to be redirected to when clicking the back button
+ */
+"use strict";
+
+ckan.module('step-indicator', function ($) {
+  return {
+      initialize: function () {
+      this.el.on('click', jQuery.proxy(this._onClick, this));
+    },
+    _onClick: function (event) {
+        window.location.href = this.options.url;
+    }
+  }
+});

--- a/ckanext/ontario_theme/fanstatic/scripts/webassets.yml
+++ b/ckanext/ontario_theme/fanstatic/scripts/webassets.yml
@@ -15,3 +15,12 @@ ontario_theme_form_validators_js:
     preload:
       - vendor/jquery
       - base/main
+
+ontario_theme_step_indicator:
+  filters: rjsmin
+  contents: odc-step-indicator.js
+  output: ontario_theme_scripts/%(version)s_odc-step-indicator.js
+  extra:
+    preload:
+      - vendor/jquery
+      - base/main

--- a/ckanext/ontario_theme/templates/internal/datastore/dictionary.html
+++ b/ckanext/ontario_theme/templates/internal/datastore/dictionary.html
@@ -2,7 +2,39 @@
 
 {% import 'macros/form.html' as form %}
 
-{% block subtitle %}{{ h.dataset_display_name(pkg) }} - {{ h.resource_display_name(res) }}{% endblock subtitle %}
+{% block subtitle %}
+  {{ h.dataset_display_name(pkg) }} - {{ h.resource_display_name(res) }}
+{% endblock subtitle %}
+
+{% block pre_primary %}
+  <div class="ontario-step-indicator">
+    <div class="ontario-columns ontario-small-12">
+      <div class="ontario-step-indicator--with-back-button">
+        <button class="ontario-button ontario-button--tertiary">
+          <svg class="ontario-icon"
+               alt=""
+               aria-hidden="true"
+               focusable="false"
+               sol:category="primary"
+               viewBox="0 0 24 24"
+               preserveAspectRatio="xMidYMid meet">
+            <use href="#ontario-icon-chevron-left"></use>
+          </svg>
+          Back
+        </button>
+        <span class="ontario-h4">Step&nbsp;2 of&nbsp;3</span>
+      </div>
+      <hr />
+    </div>
+  </div>
+{% endblock pre_primary %}
+
+{% block page_header %}
+{% endblock page_header %}
+
+{% block form_title %}
+  {{ _('Add data dictionary') }}
+{% endblock form_title %}
 
 {% block primary_content_inner %}
 
@@ -11,38 +43,48 @@
   {% if res.validation_status and res.validation_status == 'failure' %}
     <div class="ontario-alert ontario-alert--error">
       <div class="ontario-alert__header">
-          <div class="ontario-alert__header-icon">
-              <svg class="ontario-icon" alt="" aria-hidden="true" focusable="false" sol:category="primary" viewBox="0 0 24 24" preserveAspectRatio="xMidYMid meet">
-                  <use href="#ontario-icon-alert-error"></use>
-              </svg>
-          </div>
-          <h2 class="ontario-alert__header-title ontario-h4">There is a problem</h2>
+        <div class="ontario-alert__header-icon">
+          <svg class="ontario-icon"
+               alt=""
+               aria-hidden="true"
+               focusable="false"
+               sol:category="primary"
+               viewBox="0 0 24 24"
+               preserveAspectRatio="xMidYMid meet">
+            <use href="#ontario-icon-alert-error"></use>
+          </svg>
+        </div>
+        <h2 class="ontario-alert__header-title ontario-h4">There is a problem</h2>
       </div>
       <div class="ontario-alert__body">
-          <p>Data dictionary didn’t match the uploaded resource file.
-          <a href="#validation-report" data-module="modal-dialog" data-module-div="validation-report-dialog">Show validation report modal </a></p>
-          <p>You can either:</p>
-          <ul>
-            <li>Edit the data dictionary information on this page or</li>
-            <li>Upload a corrected data resource file on Step 2</li>
-          </ul>
+        <p>
+          Data dictionary didn’t match the uploaded resource file.
+          <a href="#validation-report"
+             data-module="modal-dialog"
+             data-module-div="validation-report-dialog">Show validation report modal</a>
+        </p>
+        <p>You can either:</p>
+        <ul>
+          <li>Edit the data dictionary information on this page or</li>
+          <li>Upload a corrected data resource file on Step 2</li>
+        </ul>
       </div>
     </div>
     {% set validation_report = h.ontario_theme_get_validation_report(res.id) %}
     {% snippet 'validation/snippets/validation_report_dialog.html', validation_report=validation_report %}
   {% endif %}
 
-  <form method="post" action="{{ action }}" >
+  <form method="post" action="{{ action }}">
     {% block dictionary_form %}
       {% for field in fields %}
-          {% snippet "datastore/snippets/dictionary_form.html", 
-            field=field, 
-            position=loop.index 
-          %}
+        {% snippet "datastore/snippets/dictionary_form.html",
+        field=field,
+        position=loop.index
+        %}
       {% endfor %}
     {% endblock dictionary_form %}
-    <button class="ontario-button ontario-button--primary" name="save" type="submit">
-      {{ _('Run validator to continue') }}
-    </button>
+    <button class="ontario-button ontario-button--primary"
+            name="save"
+            type="submit">{{ _('Run validator to continue') }}</button>
   </form>
 {% endblock primary_content_inner %}

--- a/ckanext/ontario_theme/templates/internal/datastore/dictionary.html
+++ b/ckanext/ontario_theme/templates/internal/datastore/dictionary.html
@@ -7,26 +7,8 @@
 {% endblock subtitle %}
 
 {% block pre_primary %}
-  <div class="ontario-step-indicator">
-    <div class="ontario-columns ontario-small-12">
-      <div class="ontario-step-indicator--with-back-button">
-        <button class="ontario-button ontario-button--tertiary">
-          <svg class="ontario-icon"
-               alt=""
-               aria-hidden="true"
-               focusable="false"
-               sol:category="primary"
-               viewBox="0 0 24 24"
-               preserveAspectRatio="xMidYMid meet">
-            <use href="#ontario-icon-chevron-left"></use>
-          </svg>
-          Back
-        </button>
-        <span class="ontario-h4">Step&nbsp;2 of&nbsp;3</span>
-      </div>
-      <hr />
-    </div>
-  </div>
+  {% set back_url = h.url_for(pkg.type ~ '_resource.edit', id=pkg.name, resource_id=res.id) %}
+  {% snippet "package/snippets/step_indicator.html", step=2, back_url=back_url %}
 {% endblock pre_primary %}
 
 {% block page_header %}

--- a/ckanext/ontario_theme/templates/internal/package/new_resource_not_draft.html
+++ b/ckanext/ontario_theme/templates/internal/package/new_resource_not_draft.html
@@ -11,14 +11,7 @@
 {% endblock secondary %}
 
 {% block pre_primary %}
-  <div class="ontario-step-indicator">
-    <div class="ontario-columns ontario-small-12">
-      <div class="ontario-step-indicator--without-back-button">
-        <span class="ontario-h4">Step&nbsp;1 of&nbsp;3</span>
-      </div>
-      <hr />
-    </div>
-  </div>
+  {% snippet "package/snippets/step_indicator.html", step=1 %}
 {% endblock pre_primary %}
 
 {% block form_title %}

--- a/ckanext/ontario_theme/templates/internal/package/new_resource_not_draft.html
+++ b/ckanext/ontario_theme/templates/internal/package/new_resource_not_draft.html
@@ -7,11 +7,27 @@
   </li>
 {% endblock breadcrumb_content %}
 
-{% block secondary_content %}
-  {% snippet "package/snippets/disclaimer.html" %}
-  {{ super() }}
-{% endblock secondary_content %}
+{% block secondary %}
+{% endblock secondary %}
+
+{% block pre_primary %}
+  <div class="ontario-step-indicator">
+    <div class="ontario-columns ontario-small-12">
+      <div class="ontario-step-indicator--without-back-button">
+        <span class="ontario-h4">Step&nbsp;1 of&nbsp;3</span>
+      </div>
+      <hr />
+    </div>
+  </div>
+{% endblock pre_primary %}
+
+{% block form_title %}
+  {{ _('Add resource file and metadata') }}
+{% endblock form_title %}
 
 {% block form %}
   {% snippet resource_form_snippet, data=data, errors=errors, error_summary=error_summary, include_metadata=false, pkg_name=pkg_name, pkg_dict=pkg_dict, stage=stage, allow_upload=g.ofs_impl and logged_in, dataset_type=dataset_type %}
 {% endblock form %}
+
+{% block page_header %}
+{% endblock page_header %}

--- a/ckanext/ontario_theme/templates/internal/package/new_resource_publish.html
+++ b/ckanext/ontario_theme/templates/internal/package/new_resource_publish.html
@@ -1,26 +1,8 @@
 {% extends "package/resource_edit_base.html" %}
 
 {% block pre_primary %}
-  <div class="ontario-step-indicator">
-    <div class="ontario-columns ontario-small-12">
-      <div class="ontario-step-indicator--with-back-button">
-        <button class="ontario-button ontario-button--tertiary">
-          <svg class="ontario-icon"
-               alt=""
-               aria-hidden="true"
-               focusable="false"
-               sol:category="primary"
-               viewBox="0 0 24 24"
-               preserveAspectRatio="xMidYMid meet">
-            <use href="#ontario-icon-chevron-left"></use>
-          </svg>
-          Back
-        </button>
-        <span class="ontario-h4">Step&nbsp;3 of&nbsp;3</span>
-      </div>
-      <hr />
-    </div>
-  </div>
+  {% set back_url = h.url_for('datastore.dictionary', id=pkg.name, resource_id=resource_id) %}
+  {% snippet "package/snippets/step_indicator.html", step=3, back_url=back_url %}
 {% endblock pre_primary %}
 
 {% block page_header %}

--- a/ckanext/ontario_theme/templates/internal/package/new_resource_publish.html
+++ b/ckanext/ontario_theme/templates/internal/package/new_resource_publish.html
@@ -1,16 +1,38 @@
-{% extends "package/base.html" %}
+{% extends "package/resource_edit_base.html" %}
 
+{% block pre_primary %}
+  <div class="ontario-step-indicator">
+    <div class="ontario-columns ontario-small-12">
+      <div class="ontario-step-indicator--with-back-button">
+        <button class="ontario-button ontario-button--tertiary">
+          <svg class="ontario-icon"
+               alt=""
+               aria-hidden="true"
+               focusable="false"
+               sol:category="primary"
+               viewBox="0 0 24 24"
+               preserveAspectRatio="xMidYMid meet">
+            <use href="#ontario-icon-chevron-left"></use>
+          </svg>
+          Back
+        </button>
+        <span class="ontario-h4">Step&nbsp;3 of&nbsp;3</span>
+      </div>
+      <hr />
+    </div>
+  </div>
+{% endblock pre_primary %}
 
+{% block page_header %}
+{% endblock page_header %}
+
+{% block form_title %}
+  {{ _('Add data dictionary') }}
+{% endblock form_title %}
 
 {% block primary_content_inner %}
-
-
-    <p>Click to Submit {{pkg}}</p>
-
-
-
-{% endblock %}
+  <p>Click to Submit {{ pkg }}</p>
+{% endblock primary_content_inner %}
 
 {% block secondary %}
-
 {% endblock secondary %}

--- a/ckanext/ontario_theme/templates/internal/package/resource_edit_base.html
+++ b/ckanext/ontario_theme/templates/internal/package/resource_edit_base.html
@@ -13,6 +13,7 @@
 {% endblock secondary %}
 
 {% block primary %}
+  {% asset "ontario_theme_scripts/ontario_theme_step_indicator" %}
   <div class="resource-margin ontario-columns ontario-small-12">
     {% block primary_content %}
       <article class="module">

--- a/ckanext/ontario_theme/templates/internal/package/resource_edit_base.html
+++ b/ckanext/ontario_theme/templates/internal/package/resource_edit_base.html
@@ -9,7 +9,33 @@
   {% endif %}
 {% endblock breadcrumb_content %}
 
-{% block secondary_content %}
-  {% snippet "package/snippets/disclaimer.html" %}
-  {{ super() }}
-{% endblock secondary_content %}
+{% block secondary %}
+{% endblock secondary %}
+
+{% block primary %}
+  <div class="resource-margin ontario-columns ontario-small-12">
+    {% block primary_content %}
+      <article class="module">
+        {% block page_header %}
+          <header class="module-content page-header">
+            <ul class="nav nav-tabs">
+              {% block content_primary_nav %}
+                {{ super() }}
+              {% endblock content_primary_nav %}
+            </ul>
+          </header>
+        {% endblock page_header %}
+        <div class="module-content">
+          <h1>
+            {% block form_title %}
+              {{ super() }}
+            {% endblock form_title %}
+          </h1>
+          {% block primary_content_inner %}
+            {{ super() }}
+          {% endblock primary_content_inner %}
+        </div>
+      </article>
+    {% endblock primary_content %}
+  </div>
+{% endblock primary %}

--- a/ckanext/ontario_theme/templates/internal/package/snippets/step_indicator.html
+++ b/ckanext/ontario_theme/templates/internal/package/snippets/step_indicator.html
@@ -1,0 +1,33 @@
+{% if step == 1 %}
+  <div class="ontario-step-indicator">
+    <div class="ontario-columns ontario-small-12">
+      <div class="ontario-step-indicator--without-back-button">
+        <span class="ontario-h4">Step&nbsp;{{ step }} of&nbsp;3</span>
+      </div>
+      <hr />
+    </div>
+  </div>
+{% else %}
+  <div class="ontario-step-indicator">
+    <div class="ontario-columns ontario-small-12">
+      <div class="ontario-step-indicator--with-back-button">
+        <button data-module="step-indicator"
+                data-module-url="{{ back_url }}"
+                class="ontario-button ontario-button--tertiary">
+          <svg class="ontario-icon"
+               alt=""
+               aria-hidden="true"
+               focusable="false"
+               sol:category="primary"
+               viewBox="0 0 24 24"
+               preserveAspectRatio="xMidYMid meet">
+            <use href="#ontario-icon-chevron-left"></use>
+          </svg>
+          Back
+        </button>
+        <span class="ontario-h4">Step&nbsp;{{ step }} of&nbsp;3</span>
+      </div>
+      <hr />
+    </div>
+  </div>
+{% endif %}

--- a/ckanext/ontario_theme/templates/internal/page.html
+++ b/ckanext/ontario_theme/templates/internal/page.html
@@ -51,7 +51,36 @@
           {% endblock secondary %}
 
           {% block primary %}
-            {{ super() }}
+            <div class="primary ontario-columns ontario-medium-9 ontario-small-12">
+              {% block primary_content %}
+                <article class="module">
+                  {% block page_header %}
+                    <header class="module-content page-header">
+                      {% if self.content_action() | trim %}
+                        <div class="content_action">
+                          {% block content_action %}
+                          {% endblock content_action %}
+                        </div>
+                      {% endif %}
+                      <ul class="nav nav-tabs">
+                        {% block content_primary_nav %}
+                        {% endblock content_primary_nav %}
+                      </ul>
+                    </header>
+                  {% endblock page_header %}
+                  <div class="module-content">
+                    {% if self.page_primary_action() | trim %}
+                      <div class="page_primary_action">
+                        {% block page_primary_action %}
+                        {% endblock page_primary_action %}
+                      </div>
+                    {% endif %}
+                    {% block primary_content_inner %}
+                    {% endblock primary_content_inner %}
+                  </div>
+                </article>
+              {% endblock primary_content %}
+            </div>
           {% endblock primary %}
         </div>
       {% endblock main_content %}


### PR DESCRIPTION
## What this PR accomplishes

- Adds step indicator to new resource, data dictionary, and publishing pages

## Issue(s) addressed

- DATA-1445

## What needs review

- The back button redirect users to the logical previous step
- Step indicator is present on aforementioned workflow pages