### PR TITLE
[Task]: Step 4 Content

### DIFF
--- a/ckanext/ontario_theme/datastore.py
+++ b/ckanext/ontario_theme/datastore.py
@@ -125,4 +125,6 @@ class DictionaryView(MethodView):
                 None,
                 {"resource_id": resource_id, "ignore_hash": True}
             )
-        return h.redirect_to("datastore.dictionary", id=id, resource_id=resource_id)
+            return h.redirect_to("ontario_theme.new_resource_publish", id=id, resource_id=resource_id)
+        else:
+            return h.redirect_to("datastore.dictionary", id=id, resource_id=resource_id)

--- a/ckanext/ontario_theme/fanstatic/common.css
+++ b/ckanext/ontario_theme/fanstatic/common.css
@@ -3454,9 +3454,13 @@ label::after {
   margin: unset;
 }
 
-
 .resource-metadata-dl dd {
   margin-bottom: 16px;
+}
+
+.resource-metadata-dl dd,
+.resource-metadata-dl dt {
+  padding-right: 16px;
 }
 
 .resource-metadata-dl > div,

--- a/ckanext/ontario_theme/fanstatic/common.css
+++ b/ckanext/ontario_theme/fanstatic/common.css
@@ -3450,8 +3450,9 @@ label::after {
   margin: unset;
 }
 
-.resource-metadata-dl div {
+.resource-metadata-dl > div {
   padding-left: unset;
+  display: flex;
 }
 
 .resource-metadata-dl dd {

--- a/ckanext/ontario_theme/fanstatic/common.css
+++ b/ckanext/ontario_theme/fanstatic/common.css
@@ -3446,26 +3446,41 @@ label::after {
   max-width: 48rem
 }
 
+/* ========================================================================
+   New Resource Publish Page
+   ======================================================================== */
+
 .resource-metadata-heading.ontario-h5 {
   margin: unset;
 }
 
-.resource-metadata-dl > div {
-  padding-left: unset;
-  display: flex;
-}
 
 .resource-metadata-dl dd {
   margin-bottom: 16px;
 }
 
+.resource-metadata-dl > div,
 .resource-metadata-edit-row {
-  display: inline-flex;
-  align-items: center;
-  gap: 20px;
+  display: block;
+  padding-left: unset;
+}
+
+.resource-metadata-edit-row {
   margin-bottom: 18px;
 }
 
-.resource-metadata-edit-row h2 {
-  margin-bottom: unset;
+@media screen and (min-width: 40em) {
+  .resource-metadata-dl > div {
+    display: flex;
+  }
+
+  .resource-metadata-edit-row h2 {
+    margin-bottom: unset;
+  }
+
+  .resource-metadata-edit-row {
+    display: inline-flex;
+    align-items: center;
+    gap: 20px;
+  }
 }

--- a/ckanext/ontario_theme/fanstatic/common.css
+++ b/ckanext/ontario_theme/fanstatic/common.css
@@ -3445,3 +3445,26 @@ label::after {
 .ontario-step-indicator p {
   max-width: 48rem
 }
+
+.resource-metadata-heading.ontario-h5 {
+  margin: unset;
+}
+
+.resource-metadata-dl div {
+  padding-left: unset;
+}
+
+.resource-metadata-dl dd {
+  margin-bottom: 16px;
+}
+
+.resource-metadata-edit-row {
+  display: inline-flex;
+  align-items: center;
+  gap: 20px;
+  margin-bottom: 18px;
+}
+
+.resource-metadata-edit-row h2 {
+  margin-bottom: unset;
+}

--- a/ckanext/ontario_theme/plugin.py
+++ b/ckanext/ontario_theme/plugin.py
@@ -204,9 +204,12 @@ def new_resource_publish(id, resource_id):
     '''New page for submitting new resource for publication.
     '''
     pkg_dict = toolkit.get_action(u'package_show')(None, {u'id': id})
+    res = toolkit.get_action(u'resource_show')(None, {u'id': resource_id})
 
-    return render_template('/package/new_resource_publish.html', id=id, resource_id=resource_id, pkg_dict=pkg_dict)
-
+    return render_template('/package/new_resource_publish.html', id=id, 
+                                                                 resource_id=resource_id, 
+                                                                 pkg_dict=pkg_dict, 
+                                                                 res=res)
 
 
 def csv_dump():

--- a/ckanext/ontario_theme/plugin.py
+++ b/ckanext/ontario_theme/plugin.py
@@ -204,16 +204,7 @@ def new_resource_publish(id, resource_id):
     '''New page for submitting new resource for publication.
     '''
     pkg_dict = toolkit.get_action(u'package_show')(None, {u'id': id})
-    # Get data dictionary fields
-    datastore_search = toolkit.get_action('datastore_search')(None, {u'id': resource_id})
-    fields = [
-                    f for f in datastore_search[u'fields'] if not f[u'id'].startswith(u'_')
-                ]
-    resources = pkg_dict.get('resources')
-    resource_num = next((i for i, obj in enumerate(resources) if obj["id"] == resource_id), None)
-    # Append dictionary fields to the resource_id in pkg_dict
-    pkg_dict["resources"][resource_num]["fields"] = fields
-    pkg_dict["resource_num"] = resource_num
+
     return render_template('/package/new_resource_publish.html', id=id, resource_id=resource_id, pkg_dict=pkg_dict)
 
 

--- a/ckanext/ontario_theme/plugin.py
+++ b/ckanext/ontario_theme/plugin.py
@@ -200,16 +200,18 @@ def help():
     '''
     return render_template('home/help.html')
 
+
 def new_resource_publish(id, resource_id):
     '''New page for submitting new resource for publication.
     '''
     pkg_dict = toolkit.get_action(u'package_show')(None, {u'id': id})
     res = toolkit.get_action(u'resource_show')(None, {u'id': resource_id})
 
-    return render_template('/package/new_resource_publish.html', id=id, 
-                                                                 resource_id=resource_id, 
-                                                                 pkg_dict=pkg_dict, 
-                                                                 res=res)
+    return render_template('/package/new_resource_publish.html',
+                           id=id,
+                           resource_id=resource_id,
+                           pkg_dict=pkg_dict,
+                           resource=res)
 
 
 def csv_dump():

--- a/ckanext/ontario_theme/plugin.py
+++ b/ckanext/ontario_theme/plugin.py
@@ -200,6 +200,23 @@ def help():
     '''
     return render_template('home/help.html')
 
+def new_resource_publish(id, resource_id):
+    '''New page for submitting new resource for publication.
+    '''
+    pkg_dict = toolkit.get_action(u'package_show')(None, {u'id': id})
+    # Get data dictionary fields
+    datastore_search = toolkit.get_action('datastore_search')(None, {u'id': resource_id})
+    fields = [
+                    f for f in datastore_search[u'fields'] if not f[u'id'].startswith(u'_')
+                ]
+    resources = pkg_dict.get('resources')
+    resource_num = next((i for i, obj in enumerate(resources) if obj["id"] == resource_id), None)
+    # Append dictionary fields to the resource_id in pkg_dict
+    pkg_dict["resources"][resource_num]["fields"] = fields
+    pkg_dict["resource_num"] = resource_num
+    return render_template('/package/new_resource_publish.html', id=id, resource_id=resource_id, pkg_dict=pkg_dict)
+
+
 
 def csv_dump():
     '''
@@ -936,12 +953,6 @@ ckanext.ontario_theme:schemas/ontario_theme_organization.json
         config_['scheming.group_schemas'] = """
 ckanext.ontario_theme:schemas/ontario_theme_group.json
 """
-
-def new_resource_publish(id, resource_id):
-    '''New page for submitting new resource for publication.
-    '''
-    pkg_dict = toolkit.get_action(u'package_show')(None, {u'id': id})
-    return render_template('/package/new_resource_publish.html', id=id, resource_id=resource_id, pkg_dict=pkg_dict)
 
 class OntarioThemePlugin(plugins.SingletonPlugin, DefaultTranslation):
     plugins.implements(plugins.ITranslation)

--- a/ckanext/ontario_theme/plugin.py
+++ b/ckanext/ontario_theme/plugin.py
@@ -937,6 +937,11 @@ ckanext.ontario_theme:schemas/ontario_theme_organization.json
 ckanext.ontario_theme:schemas/ontario_theme_group.json
 """
 
+def new_resource_publish(id, resource_id):
+    '''New page for submitting new resource for publication.
+    '''
+    pkg_dict = toolkit.get_action(u'package_show')(None, {u'id': id})
+    return render_template('/package/new_resource_publish.html', id=id, resource_id=resource_id, pkg_dict=pkg_dict)
 
 class OntarioThemePlugin(plugins.SingletonPlugin, DefaultTranslation):
     plugins.implements(plugins.ITranslation)
@@ -1094,6 +1099,7 @@ type data_last_updated
 
     # IBlueprint
 
+
     def get_blueprint(self):
         '''Return a Flask Blueprint object to be registered by the app.
         '''
@@ -1118,15 +1124,16 @@ type data_last_updated
         # Add url rules to Blueprint object.
         rules = [
             (u'/help', u'help', help),
-            (u'/dataset/inventory', u'inventory', csv_dump)
+            (u'/dataset/inventory', u'inventory', csv_dump),
+            (u'/dataset/<id>/<resource_id>/new_resource_publish/', u'new_resource_publish', new_resource_publish)
         ]
 
         for rule in rules:
             blueprint.add_url_rule(*rule)
         blueprint.add_url_rule('/dataset/new', view_func=OntarioThemeCreateView.as_view(str(u'new')), defaults={u'package_type': u'dataset'})
         blueprint.add_url_rule(u'/organization', view_func=organization_index, strict_slashes=False)
-        blueprint.add_url_rule(u'/dataset/<id>/dictionary/<resource_id>',view_func=DictionaryView.as_view(str(u'dictionary'))
-)
+        blueprint.add_url_rule(u'/dataset/<id>/dictionary/<resource_id>',view_func=DictionaryView.as_view(str(u'dictionary')))
+
         return blueprint
 
     # IUploader

--- a/ckanext/ontario_theme/templates/internal/package/new_resource_publish.html
+++ b/ckanext/ontario_theme/templates/internal/package/new_resource_publish.html
@@ -1,83 +1,65 @@
-{% extends "package/base.html" %}
+{% extends "package/resource_edit_base.html" %}
 
-
+{% set res = resource %}
 
 {% block primary_content_inner %}
-
-  {%- set exclude_fields = [
-    "url",
-    "format",
-    "schema",
-    "validation_options",
-    "validation_status",
-    "validation_timestamp"
-    ] 
-  -%}
-
-<h1 class="ontario-h1">Step 4: Review and publish</h1>
-
-<div class="ontario-row">
+  {%- set exclude_fields = ["url", "format", "schema", "validation_options", "validation_status", "validation_timestamp"] -%}
+  <h1 class="ontario-h1">Step 4: Review and publish</h1>
+  <div class="ontario-row">
     <div class="ontario-columns ontario-small-7">
-        <h2 class="ontario-h2">Resource file and metadata</h2>
+      <h2 class="ontario-h2">Resource file and metadata</h2>
     </div>
-    <div class="ontario-columns ontario-small-5">        
-        {% link_for _('Edit resource file and metadata'), named_route='resource.edit', 
-                                                          id=pkg.name,
-                                                          resource_id=resource_id
-        %}
-
+    <div class="ontario-columns ontario-small-5">
+      {% link_for _('Edit resource file and metadata'), named_route='resource.edit',
+      id=pkg.name,
+      resource_id=resource_id
+      %}
     </div>
-</div>
-
-<div class="ontario-column ontario-small-12">
+  </div>
+  <div class="ontario-column ontario-small-12">
     <h3 class="ontario-h3">Resource file</h3>
     <b>File</b>
     <p>{{ res.url.split('download/')[-1] }}</p>
     <b>File format</b>
     <p>{{ res.format }}</p>
-
-</div>
-
-
-<h3 class="ontario-h3">Metadata</h3>
-{% set schema = h.scheming_get_dataset_schema(dataset_type) %}
-{%- for field in schema.resource_fields -%}
+  </div>
+  <h3 class="ontario-h3">Metadata</h3>
+  {% set schema = h.scheming_get_dataset_schema(dataset_type) %}
+  {%- for field in schema.resource_fields -%}
     {%- if field.form_snippet is not none and field.field_name not in exclude_fields -%}
-    {% set pkg_field = field.field_name %}
-        <div>
-            <ul>
-                {% if res.get(pkg_field) is mapping %} 
-                    {% for key, value in res.get(pkg_field).items() %}
-                        <dt>{{ key.upper() }} {{ h.scheming_language_text(field.label) }}</dt>                
-                        <dd>{{ value }}</dd>
-                    {% endfor %} 
-                {% else %}
-                    <dt>{{ h.scheming_language_text(field.label) }} </dt>
-                    <dd>{{ res.get(pkg_field) }}</dd> 
-
-                {% endif %}
-
-            </ul>
-        </div>
-
+      {% set pkg_field = field.field_name %}
+      <div>
+        <ul>
+          {% if res.get(pkg_field) is mapping %}
+            {% for key, value in res.get(pkg_field).items() %}
+              <dt>{{ key.upper() }} {{ h.scheming_language_text(field.label) }}</dt>
+              <dd>
+                {{ value }}
+              </dd>
+            {% endfor %}
+          {% else %}
+            <dt>{{ h.scheming_language_text(field.label) }}</dt>
+            <dd>
+              {{ res.get(pkg_field) }}
+            </dd>
+          {% endif %}
+        </ul>
+      </div>
     {%- endif -%}
-{%- endfor -%}
-
-
-<div class="ontario-row">
+  {%- endfor -%}
+  <div class="ontario-row">
     <div class="ontario-columns ontario-small-4">
-        <h2 class="ontario-h2">Data dictionary</h2>
+      <h2 class="ontario-h2">Data dictionary</h2>
     </div>
-    <div class="ontario-columns ontario-small-8">        
-        {% link_for _('Edit data dictionary'), named_route='datastore.dictionary', 
-                                                          id=pkg.name,
-                                                          resource_id=resource_id
-        %}
+    <div class="ontario-columns ontario-small-8">
+      {% link_for _('Edit data dictionary'), named_route='datastore.dictionary',
+      id=pkg.name,
+      resource_id=resource_id
+      %}
     </div>
-
     <div class="ontario-column ontario-small-12">
-        {% set fields = h.datastore_dictionary(resource_id) %}
-        {# Example of returned dictionary:
+      {% set fields = h.datastore_dictionary(resource_id) %}
+      {# Example of returned dictionary:
 
             [{'id': 'rule', 
               'type': 'text', 
@@ -97,35 +79,26 @@
             stick with the PostgreSQL type names (e.g. "text" not "string") so don't use 
             field.info["frictionless_dict"]["type"]. 
         #}
-
-        {% for field in fields %}
-            <div>
-                <h3 class="ontario-h3">Field {{ loop.index }}. {{ field.id }}</h3>
-                <b>Type</b>                
-                {% set field_type = field.type if field.info["type_override"] == '' else field.info["type_override"] %}
-                <p>{{ field_type }}</p>
-                {% if field.info["label"] %}
-                    <b>Label</b>
-                    <p>{{ field.info["label"] }}</p>
-                {% endif %}
-                {% if field.info["notes"] %}
-                    <b>Description</b>
-                    <p>{{ field.info["notes"] }}</p>
-                {% endif %}
-          </div>
-        {% endfor %}
-
+      {% for field in fields %}
+        <div>
+          <h3 class="ontario-h3">Field {{ loop.index }}. {{ field.id }}</h3>
+          <b>Type</b>
+          {% set field_type = field.type if field.info["type_override"] == '' else field.info["type_override"] %}
+          <p>{{ field_type }}</p>
+          {% if field.info["label"] %}
+            <b>Label</b>
+            <p>{{ field.info["label"] }}</p>
+          {% endif %}
+          {% if field.info["notes"] %}
+            <b>Description</b>
+            <p>{{ field.info["notes"] }}</p>
+          {% endif %}
+        </div>
+      {% endfor %}
     </div>
-
-
-
-</div>
-
-    {% link_for _('Publish'), named_route='dataset.read', id=pkg.name, class_="ontario-button ontario-button--primary" %}
+  </div>
+  {% link_for _('Publish'), named_route='dataset.read', id=pkg.name, class_="ontario-button ontario-button--primary" %}
 {% endblock primary_content_inner %}
 
-
-
 {% block secondary %}
-
 {% endblock secondary %}

--- a/ckanext/ontario_theme/templates/internal/package/new_resource_publish.html
+++ b/ckanext/ontario_theme/templates/internal/package/new_resource_publish.html
@@ -11,103 +11,100 @@
 {% endblock page_header %}
 
 {% block form_title %}
-  {{ _('Add data dictionary') }}
+  {{ _('Review and publish') }}
 {% endblock form_title %}
 
 {% block primary_content_inner %}
   {%- set exclude_fields = ["url", "format", "schema", "validation_options", "validation_status", "validation_timestamp"] -%}
-  <h1 class="ontario-h1">Step 4: Review and publish</h1>
-  <div class="ontario-row">
-    <div class="ontario-columns ontario-small-7">
-      <h2 class="ontario-h2">Resource file and metadata</h2>
-    </div>
-    <div class="ontario-columns ontario-small-5">
-      {% link_for _('Edit resource file and metadata'), named_route='resource.edit',
-      id=pkg.name,
-      resource_id=resource_id
-      %}
-    </div>
+  <div class="resource-metadata-edit-row">
+    <h2 class="ontario-h2">Resource file and metadata</h2>
+    {% link_for _('Edit resource file and metadata'), named_route='resource.edit', id=pkg.name, resource_id=resource_id %}
   </div>
-  <div class="ontario-column ontario-small-12">
+  <div class="ontario-small-12">
     <h3 class="ontario-h3">Resource file</h3>
-    <b>File</b>
-    <p>{{ res.url.split('download/')[-1] }}</p>
-    <b>File format</b>
-    <p>{{ res.format }}</p>
+    <dl class="resource-metadata-dl">
+      <dt class="resource-metadata-heading ontario-h5">File:</dt>
+      <dd>
+        {{ res.url.split('download/')[-1] }}
+      </dd>
+      <dt class="resource-metadata-heading ontario-h5">File format:</dt>
+      <dd>
+        {{ res.format }}
+      </dd>
+    </dl>
   </div>
   <h3 class="ontario-h3">Metadata</h3>
-  {% set schema = h.scheming_get_dataset_schema(dataset_type) %}
-  {%- for field in schema.resource_fields -%}
-    {%- if field.form_snippet is not none and field.field_name not in exclude_fields -%}
-      {% set pkg_field = field.field_name %}
-      <div>
-        <ul>
+  <div>
+    <dl class="resource-metadata-dl">
+      {% set schema = h.scheming_get_dataset_schema(dataset_type) %}
+      {%- for field in schema.resource_fields -%}
+        {%- if field.form_snippet is not none and field.field_name not in exclude_fields -%}
+          {% set pkg_field = field.field_name %}
           {% if res.get(pkg_field) is mapping %}
             {% for key, value in res.get(pkg_field).items() %}
-              <dt>{{ key.upper() }} {{ h.scheming_language_text(field.label) }}</dt>
-              <dd>
-                {{ value }}
-              </dd>
+              <div class="ontario-columns ontario-small-6">
+                <dt class="resource-metadata-heading ontario-h5">{{ key.upper() }} {{ h.scheming_language_text(field.label) }}:</dt>
+                <dd>
+                  {{ value }}
+                </dd>
+              </div>
             {% endfor %}
           {% else %}
-            <dt>{{ h.scheming_language_text(field.label) }}</dt>
+            <dt class="resource-metadata-heading ontario-h5">{{ h.scheming_language_text(field.label) }}:</dt>
             <dd>
               {{ res.get(pkg_field) }}
             </dd>
           {% endif %}
-        </ul>
-      </div>
-    {%- endif -%}
-  {%- endfor -%}
-  <div class="ontario-row">
-    <div class="ontario-columns ontario-small-4">
-      <h2 class="ontario-h2">Data dictionary</h2>
-    </div>
-    <div class="ontario-columns ontario-small-8">
-      {% link_for _('Edit data dictionary'), named_route='datastore.dictionary',
-      id=pkg.name,
-      resource_id=resource_id
-      %}
-    </div>
-    <div class="ontario-column ontario-small-12">
-      {% set fields = h.datastore_dictionary(resource_id) %}
-      {# Example of returned dictionary:
+        {%- endif -%}
+      {%- endfor -%}
+    </dl>
+  </div>
+  <div class="resource-metadata-edit-row">
+    <h2 class="ontario-h2">Data dictionary</h2>
+    {% link_for _('Edit data dictionary'), named_route='datastore.dictionary', id=pkg.name, resource_id=resource_id %}
+  </div>
+  <div class="ontario-small-12">
+    {% set fields = h.datastore_dictionary(resource_id) %}
+    {#- Example of returned dictionary:
 
-            [{'id': 'rule', 
-              'type': 'text', 
-              'info': {'label': '', 
-                       'notes': '', 
-                       'type_override': '', 
-                       'frictionless_dict': [{'type': 'string', 'name': 'rule'}]}}, 
-            {'id': 'integercol', 
-             'type': 'int4', 
-              'info': {'label': '', 
-                       'notes': '', 
-                       'type_override': 'integer', 
-                       'frictionless_dict': [{'type': 'integer', 'name': 'integercol'}]}}]
+          [{'id': 'rule',
+            'type': 'text',
+            'info': {'label': '',
+                      'notes': '',
+                      'type_override': '',
+                      'frictionless_dict': [{'type': 'string', 'name': 'rule'}]}},
+          {'id': 'integercol',
+            'type': 'int4',
+            'info': {'label': '',
+                      'notes': '',
+                      'type_override': 'integer',
+                      'frictionless_dict': [{'type': 'integer', 'name': 'integercol'}]}}]
 
-            "type" is not human-readable for non-text types (e.g. int4), so use 
-            field.info["type_override"] (e.g. integer) for these cases. Note we want to 
-            stick with the PostgreSQL type names (e.g. "text" not "string") so don't use 
-            field.info["frictionless_dict"]["type"]. 
-        #}
-      {% for field in fields %}
-        <div>
-          <h3 class="ontario-h3">Field {{ loop.index }}. {{ field.id }}</h3>
-          <b>Type</b>
+          "type" is not human-readable for non-text types (e.g. int4), so use
+          field.info["type_override"] (e.g. integer) for these cases. Note we want to
+          stick with the PostgreSQL type names (e.g. "text" not "string") so don't use
+          field.info["frictionless_dict"]["type"].
+      -#}
+    {% for field in fields %}
+      <div>
+        <h3 class="ontario-h3">Field {{ loop.index }}. {{ field.id }}</h3>
+        <dl class="resource-metadata-dl">
+          <dt class="resource-metadata-heading ontario-h5">Type:</dt>
           {% set field_type = field.type if field.info["type_override"] == '' else field.info["type_override"] %}
-          <p>{{ field_type }}</p>
-          {% if field.info["label"] %}
-            <b>Label</b>
-            <p>{{ field.info["label"] }}</p>
-          {% endif %}
-          {% if field.info["notes"] %}
-            <b>Description</b>
-            <p>{{ field.info["notes"] }}</p>
-          {% endif %}
-        </div>
-      {% endfor %}
-    </div>
+          <dd>
+            {{ field_type }}
+          </dd>
+          <dt class="resource-metadata-heading ontario-h5">Label:</dt>
+          <dd>
+            {{ field.info["label"] }}
+          </dd>
+          <dt class="resource-metadata-heading ontario-h5">Description:</dt>
+          <dd>
+            {{ field.info["notes"] }}
+          </dd>
+        </dl>
+      </div>
+    {% endfor %}
   </div>
   {% link_for _('Publish'), named_route='dataset.read', id=pkg.name, class_="ontario-button ontario-button--primary" %}
 {% endblock primary_content_inner %}

--- a/ckanext/ontario_theme/templates/internal/package/new_resource_publish.html
+++ b/ckanext/ontario_theme/templates/internal/package/new_resource_publish.html
@@ -44,15 +44,33 @@ RESOURCE_ID: {{resource_id}}
 
     <div class="ontario-column ontario-small-12">
         {% set fields = h.datastore_dictionary(resource_id) %}
+        {# Example of returned dictionary:
 
-        <p>show fields {{fields}}</p>
+            [{'id': 'rule', 
+              'type': 'text', 
+              'info': {'label': '', 
+                       'notes': '', 
+                       'type_override': '', 
+                       'frictionless_dict': [{'type': 'string', 'name': 'rule'}]}}, 
+            {'id': 'integercol', 
+             'type': 'int4', 
+              'info': {'label': '', 
+                       'notes': '', 
+                       'type_override': 'integer', 
+                       'frictionless_dict': [{'type': 'integer', 'name': 'integercol'}]}}]
 
+            "type" is not human-readable for non-text types (e.g. int4), so use 
+            field.info["type_override"] (e.g. integer) for these cases. Note we want to 
+            stick with the PostgreSQL type names (e.g. "text" not "string") so don't use 
+            field.info["frictionless_dict"]["type"]. 
+        #}
 
         {% for field in fields %}
             <div>
                 <h3 class="ontario-h3">Field {{ loop.index }}. {{ field.id }}</h3>
-                <b>Type</b>
-                <p>{{ field.type }}</p>
+                <b>Type</b>                
+                {% set field_type = field.type if field.info["type_override"] == '' else field.info["type_override"] %}
+                <p>{{ field_type }}</p>
                 {% if field.info["label"] %}
                     <b>Label</b>
                     <p>{{ field.info["label"] }}</p>

--- a/ckanext/ontario_theme/templates/internal/package/new_resource_publish.html
+++ b/ckanext/ontario_theme/templates/internal/package/new_resource_publish.html
@@ -1,9 +1,7 @@
 {% extends "package/resource_edit_base.html" %}
 
-{% set res = resource %}
-
 {% block pre_primary %}
-  {% set back_url = h.url_for('datastore.dictionary', id=pkg.name, resource_id=res.id) %}
+  {% set back_url = h.url_for('datastore.dictionary', id=pkg.name, resource_id=resource.id) %}
   {% snippet "package/snippets/step_indicator.html", step=3, back_url=back_url %}
 {% endblock pre_primary %}
 
@@ -24,12 +22,12 @@
     <h3 class="ontario-h3">Resource file</h3>
     <dl class="resource-metadata-dl">
       <dt class="resource-metadata-heading ontario-h5">File:</dt>
-      <dd>
-        {{ res.url.split('download/')[-1] }}
+      <dd class="break-word">
+        {{ resource.url.split('download/')[-1] }}
       </dd>
       <dt class="resource-metadata-heading ontario-h5">File format:</dt>
       <dd>
-        {{ res.format }}
+        {{ resource.format }}
       </dd>
     </dl>
   </div>
@@ -40,9 +38,9 @@
       {%- for field in schema.resource_fields -%}
         {%- if field.form_snippet is not none and field.field_name not in exclude_fields -%}
           {% set pkg_field = field.field_name %}
-          {% if res.get(pkg_field) is mapping %}
+          {% if resource.get(pkg_field) is mapping %}
             <div class="ontario-columns ontario-small-12">
-            {% for key, value in res.get(pkg_field).items() %}
+            {% for key, value in resource.get(pkg_field).items() %}
               <div class="ontario-small-12 ontario-medium-6">
                 <dt class="resource-metadata-heading ontario-h5">{{ key.upper() }} {{ h.scheming_language_text(field.label) }}:</dt>
                 <dd>
@@ -54,7 +52,11 @@
           {% else %}
             <dt class="resource-metadata-heading ontario-h5">{{ h.scheming_language_text(field.label) }}:</dt>
             <dd>
-              {{ res.get(pkg_field) }}
+              {%- if field.preset == "date" -%}
+                {{- h.render_datetime(resource[field.field_name]) -}}
+              {%- else -%}
+                {%- snippet "scheming/snippets/display_field.html", field=field, data=resource, entity_type='dataset', object_type=dataset_type -%}
+              {%- endif -%}
             </dd>
           {% endif %}
         {%- endif -%}

--- a/ckanext/ontario_theme/templates/internal/package/new_resource_publish.html
+++ b/ckanext/ontario_theme/templates/internal/package/new_resource_publish.html
@@ -1,0 +1,16 @@
+{% extends "package/base.html" %}
+
+
+
+{% block primary_content_inner %}
+
+
+    <p>Click to Submit {{pkg}}</p>
+
+
+
+{% endblock %}
+
+{% block secondary %}
+
+{% endblock secondary %}

--- a/ckanext/ontario_theme/templates/internal/package/new_resource_publish.html
+++ b/ckanext/ontario_theme/templates/internal/package/new_resource_publish.html
@@ -31,7 +31,18 @@ RESOURCE_ID: {{resource_id}}
   <h3 class="ontario-h3">Metadata</h3>
 </div>
 
-<h2 class="ontario-h2">Data dictionary</h2>
+<div class="ontario-row">
+    <div class="ontario-columns ontario-small-4">
+        <h2 class="ontario-h2">Data dictionary</h2>
+    </div>
+    <div class="ontario-columns ontario-small-8">        
+        {% link_for _('Edit data dictionary'), named_route='datastore.dictionary', 
+                                                          id=pkg.name,
+                                                          resource_id=resource_id
+        %}
+
+    </div>
+</div>
 
     <p>package id: {{pkg['id']}}</p>
 

--- a/ckanext/ontario_theme/templates/internal/package/new_resource_publish.html
+++ b/ckanext/ontario_theme/templates/internal/package/new_resource_publish.html
@@ -1,7 +1,7 @@
 {% extends "package/resource_edit_base.html" %}
 
 {% block pre_primary %}
-  {% set back_url = h.url_for('datastore.dictionary', id=pkg.name, resource_id=resource.id) %}
+  {% set back_url = h.url_for('datastore.dictionary', id=pkg.name, resource_id=resource_id) %}
   {% snippet "package/snippets/step_indicator.html", step=3, back_url=back_url %}
 {% endblock pre_primary %}
 

--- a/ckanext/ontario_theme/templates/internal/package/new_resource_publish.html
+++ b/ckanext/ontario_theme/templates/internal/package/new_resource_publish.html
@@ -41,14 +41,16 @@
         {%- if field.form_snippet is not none and field.field_name not in exclude_fields -%}
           {% set pkg_field = field.field_name %}
           {% if res.get(pkg_field) is mapping %}
+            <div class="ontario-columns ontario-small-12">
             {% for key, value in res.get(pkg_field).items() %}
-              <div class="ontario-columns ontario-small-6">
+              <div class="ontario-small-12 ontario-medium-6">
                 <dt class="resource-metadata-heading ontario-h5">{{ key.upper() }} {{ h.scheming_language_text(field.label) }}:</dt>
                 <dd>
                   {{ value }}
                 </dd>
               </div>
             {% endfor %}
+            </div>
           {% else %}
             <dt class="resource-metadata-heading ontario-h5">{{ h.scheming_language_text(field.label) }}:</dt>
             <dd>
@@ -89,7 +91,7 @@
       <div>
         <h3 class="ontario-h3">Field {{ loop.index }}. {{ field.id }}</h3>
         <dl class="resource-metadata-dl">
-          <dt class="resource-metadata-heading ontario-h5">Type:</dt>
+          <dt class="resource-metadata-heading ontario-h5">Type override:</dt>
           {% set field_type = field.type if field.info["type_override"] == '' else field.info["type_override"] %}
           <dd>
             {{ field_type }}

--- a/ckanext/ontario_theme/templates/internal/package/new_resource_publish.html
+++ b/ckanext/ontario_theme/templates/internal/package/new_resource_publish.html
@@ -40,14 +40,14 @@
           {% set pkg_field = field.field_name %}
           {% if resource.get(pkg_field) is mapping %}
             <div class="ontario-columns ontario-small-12">
-            {% for key, value in resource.get(pkg_field).items() %}
-              <div class="ontario-small-12 ontario-medium-6">
-                <dt class="resource-metadata-heading ontario-h5">{{ key.upper() }} {{ h.scheming_language_text(field.label) }}:</dt>
-                <dd>
-                  {{ value }}
-                </dd>
-              </div>
-            {% endfor %}
+              {% for key, value in resource.get(pkg_field).items() %}
+                <div class="ontario-small-12 ontario-medium-6">
+                  <dt class="resource-metadata-heading ontario-h5">{{ key.upper() }} {{ h.scheming_language_text(field.label) }}:</dt>
+                  <dd>
+                    {{ value }}
+                  </dd>
+                </div>
+              {% endfor %}
             </div>
           {% else %}
             <dt class="resource-metadata-heading ontario-h5">{{ h.scheming_language_text(field.label) }}:</dt>

--- a/ckanext/ontario_theme/templates/internal/package/new_resource_publish.html
+++ b/ckanext/ontario_theme/templates/internal/package/new_resource_publish.html
@@ -4,6 +4,35 @@
 
 {% block primary_content_inner %}
 
+
+<h1 class="ontario-h1">Step 4: Review and publish</h1>
+RESOURCE_ID: {{resource_id}}
+
+<div class="ontario-row">
+    <div class="ontario-columns ontario-small-7">
+        <h2 class="ontario-h2">Resource file and metadata</h2>
+    </div>
+    <div class="ontario-columns ontario-small-5">        
+        {% link_for _('Edit resource file and metadata'), named_route='resource.edit', 
+                                                          id=pkg.name,
+                                                          resource_id=resource_id
+        %}
+
+    </div>
+</div>
+
+
+
+<div class="ontario-column ontario-small-12">
+    <h3 class="ontario-h3">Resource file</h3>
+</div>
+
+<div class="ontario-column ontario-small-12">
+  <h3 class="ontario-h3">Metadata</h3>
+</div>
+
+<h2 class="ontario-h2">Data dictionary</h2>
+
     <p>package id: {{pkg['id']}}</p>
 
     <p>pkg: {{pkg}}</p>

--- a/ckanext/ontario_theme/templates/internal/package/new_resource_publish.html
+++ b/ckanext/ontario_theme/templates/internal/package/new_resource_publish.html
@@ -43,16 +43,25 @@ RESOURCE_ID: {{resource_id}}
     </div>
 
     <div class="ontario-column ontario-small-12">
-        {% set resource_num = pkg['resource_num'] %}
-        {% set fields = pkg['resources'][resource_num]['fields'] %}
+        {% set fields = h.datastore_dictionary(resource_id) %}
+
         <p>show fields {{fields}}</p>
 
 
         {% for field in fields %}
-            {% snippet "datastore/snippets/dictionary_form.html", 
-            field=field, 
-            position=loop.index 
-            %}
+            <div>
+                <h3 class="ontario-h3">Field {{ loop.index }}. {{ field.id }}</h3>
+                <b>Type</b>
+                <p>{{ field.type }}</p>
+                {% if field.info["label"] %}
+                    <b>Label</b>
+                    <p>{{ field.info["label"] }}</p>
+                {% endif %}
+                {% if field.info["notes"] %}
+                    <b>Description</b>
+                    <p>{{ field.info["notes"] }}</p>
+                {% endif %}
+          </div>
         {% endfor %}
 
     </div>
@@ -60,9 +69,6 @@ RESOURCE_ID: {{resource_id}}
 
 
 </div>
-
-    <p>package id: {{pkg['id']}}</p>
-    <p>pkg: {{pkg}}</p>
 
     {% link_for _('Publish'), named_route='dataset.read', id=pkg.name, class_="ontario-button ontario-button--primary" %}
 {% endblock primary_content_inner %}

--- a/ckanext/ontario_theme/templates/internal/package/new_resource_publish.html
+++ b/ckanext/ontario_theme/templates/internal/package/new_resource_publish.html
@@ -4,9 +4,17 @@
 
 {% block primary_content_inner %}
 
+  {%- set exclude_fields = [
+    "url",
+    "format",
+    "schema",
+    "validation_options",
+    "validation_status",
+    "validation_timestamp"
+    ] 
+  -%}
 
 <h1 class="ontario-h1">Step 4: Review and publish</h1>
-RESOURCE_ID: {{resource_id}}
 
 <div class="ontario-row">
     <div class="ontario-columns ontario-small-7">
@@ -21,15 +29,40 @@ RESOURCE_ID: {{resource_id}}
     </div>
 </div>
 
-
-
 <div class="ontario-column ontario-small-12">
     <h3 class="ontario-h3">Resource file</h3>
+    <b>File</b>
+    <p>{{ res.url.split('download/')[-1] }}</p>
+    <b>File format</b>
+    <p>{{ res.format }}</p>
+
 </div>
 
-<div class="ontario-column ontario-small-12">
-  <h3 class="ontario-h3">Metadata</h3>
-</div>
+
+<h3 class="ontario-h3">Metadata</h3>
+{% set schema = h.scheming_get_dataset_schema(dataset_type) %}
+{%- for field in schema.resource_fields -%}
+    {%- if field.form_snippet is not none and field.field_name not in exclude_fields -%}
+    {% set pkg_field = field.field_name %}
+        <div>
+            <ul>
+                {% if res.get(pkg_field) is mapping %} 
+                    {% for key, value in res.get(pkg_field).items() %}
+                        <dt>{{ key.upper() }} {{ h.scheming_language_text(field.label) }}</dt>                
+                        <dd>{{ value }}</dd>
+                    {% endfor %} 
+                {% else %}
+                    <dt>{{ h.scheming_language_text(field.label) }} </dt>
+                    <dd>{{ res.get(pkg_field) }}</dd> 
+
+                {% endif %}
+
+            </ul>
+        </div>
+
+    {%- endif -%}
+{%- endfor -%}
+
 
 <div class="ontario-row">
     <div class="ontario-columns ontario-small-4">

--- a/ckanext/ontario_theme/templates/internal/package/new_resource_publish.html
+++ b/ckanext/ontario_theme/templates/internal/package/new_resource_publish.html
@@ -4,12 +4,14 @@
 
 {% block primary_content_inner %}
 
+    <p>package id: {{pkg['id']}}</p>
 
-    <p>Click to Submit {{pkg}}</p>
+    <p>pkg: {{pkg}}</p>
+
+    {% link_for _('Publish'), named_route='dataset.read', id=pkg.name, class_="ontario-button ontario-button--primary" %}
+{% endblock primary_content_inner %}
 
 
-
-{% endblock %}
 
 {% block secondary %}
 

--- a/ckanext/ontario_theme/templates/internal/package/new_resource_publish.html
+++ b/ckanext/ontario_theme/templates/internal/package/new_resource_publish.html
@@ -40,12 +40,28 @@ RESOURCE_ID: {{resource_id}}
                                                           id=pkg.name,
                                                           resource_id=resource_id
         %}
+    </div>
+
+    <div class="ontario-column ontario-small-12">
+        {% set resource_num = pkg['resource_num'] %}
+        {% set fields = pkg['resources'][resource_num]['fields'] %}
+        <p>show fields {{fields}}</p>
+
+
+        {% for field in fields %}
+            {% snippet "datastore/snippets/dictionary_form.html", 
+            field=field, 
+            position=loop.index 
+            %}
+        {% endfor %}
 
     </div>
+
+
+
 </div>
 
     <p>package id: {{pkg['id']}}</p>
-
     <p>pkg: {{pkg}}</p>
 
     {% link_for _('Publish'), named_route='dataset.read', id=pkg.name, class_="ontario-button ontario-button--primary" %}


### PR DESCRIPTION
## What this PR accomplishes

- The “Edit resource file and metadata” links both redirect back to Step 1: add metadata
- The “Edit data dictionary” link redirects back to Step 2: Add data dictionary
- FR and EN fields are split into two columns

## Issue(s) addressed

- DATA-1443

## What needs review

- The “Edit resource file and metadata” links both redirect back to Step 1: add metadata
- The “Edit data dictionary” link redirects back to Step 2: Add data dictionary
- FR and EN fields are split into two columns
- The page generally looks like the figma