### PR TITLE
Refactoring `before_search` for radio buttons

### DIFF
--- a/ckanext/ontario_theme/fanstatic/common.css
+++ b/ckanext/ontario_theme/fanstatic/common.css
@@ -525,8 +525,8 @@ a.pill {
 
   .search-form .filter-list {
     font-size: 20px;
-    margin: 0 -16px;
-    padding: 0 16px;
+    margin: 0 -20px;
+    padding: 0 20px;
     background-color: #fff;
   }
 

--- a/ckanext/ontario_theme/plugin.py
+++ b/ckanext/ontario_theme/plugin.py
@@ -1091,14 +1091,14 @@ type data_last_updated
 
     def dataset_facets(self, facets_dict, package_type):
         '''Add new search facet dictionary for datasets.
-        Not including access_level for radio buttons
         '''
         reordered_facet_dict = OrderedDict({
             'keywords_en': toolkit._('Topics'),
             'keywords_fr': toolkit._('Topics'),
             'organization': toolkit._('Ministries'),
             'res_format': toolkit._('Formats'),
-            '{!ex=al}access_level': toolkit._('Formats'),
+            # exclusion tag necessary for displaying facet counts
+            '{!ex=al}access_level': toolkit._('Access level'),
             'update_frequency': toolkit._('Update frequency'),
             'license_id': toolkit._('Licences'),
             'asset_type': toolkit._('Asset type'),
@@ -1156,6 +1156,7 @@ type data_last_updated
                     if fq_list[i] == facet_al[0]:
                         fq_list[i] = facet_tag
                 search_params.pop('fq')
+        # Show default open datasets on dataset search page
         else:
             fq_list = search_params.setdefault('fq_list', [tag + ":open"])
 

--- a/ckanext/ontario_theme/plugin.py
+++ b/ckanext/ontario_theme/plugin.py
@@ -1150,7 +1150,9 @@ type data_last_updated
                 fq += (" {!tag=al}access_level:open")
             fq_list = re.findall("(?:\".*?\"|\\S)+", fq)
             if facet_al and facet_field:
+                # Replaces access_level with {!tag=al}access_level
                 al_sub = re.sub(access_level, tag, facet_al[0])
+                # Removes quotes for solr querying
                 facet_tag = re.sub("\"", "", al_sub)
                 for i in range(len(fq_list)):
                     if fq_list[i] == facet_al[0]:

--- a/ckanext/ontario_theme/templates/internal/snippets/access_level_radio_buttons.html
+++ b/ckanext/ontario_theme/templates/internal/snippets/access_level_radio_buttons.html
@@ -27,11 +27,11 @@
         {% endwith %}
         {# Displaying the "All levels" radio button #}
         {% set total_count = h.get_facet_items_dict(name)|sum(attribute='count') %}
-        {% if "" == request.params[name] %}
+        {% if "*" == request.params[name] %}
           {% set checked = "checked" %}
         {% endif %}
         <div class="ontario-radios__item">
-          <input class="ontario-radios__input" id="radio-button-option-all" name="access_level" type="radio" value="" {{ checked }}>
+          <input class="ontario-radios__input" id="radio-button-option-all" name="access_level" type="radio" value="*" {{ checked }}>
           <label class="ontario-label ontario-radios__label"
                   for="radio-button-option-all">{{ _('All levels') }} ({{ h.localised_number(total_count) }})</label>
         </div>


### PR DESCRIPTION
## What this PR accomplishes

- Refactored `before_search` to fix issue causing the search-index to not be able to rebuild
- Fixes CSS on ministry and groups pages
- Uses `access_level:*` for the all levels access level radio button

## What needs review

- Search index can be rebuilt without an error
- Can navigate to the homepage without error and dataset counts and lists are accurate (showing datasets from all access levels)
- On dataset page
    - by default, the datasets presented are open
    - switching between access levels displays the datasets with the corresponding access level
    - "Access level" facet grey box is not in the facet list
    - facets/filters work as expected
- On ministry/group pages
    - in ministry/group list, all dataset counts are correct and show count of datasets from all access levels
    - in the ministry/group dataset search pages, by default, the datasets presented are open
    - switching between access levels displays the datasets with the corresponding access level
    - "Access level" facet grey box is not in the side bar list
    - facets/filters work as expected