### PR TITLE
[Task]: Edit Resource template header to look like Step 1

### DIFF
--- a/ckanext/ontario_theme/templates/internal/package/resource_edit_base.html
+++ b/ckanext/ontario_theme/templates/internal/package/resource_edit_base.html
@@ -9,6 +9,10 @@
   {% endif %}
 {% endblock breadcrumb_content %}
 
+{% block pre_primary %}
+  {% snippet "package/snippets/step_indicator.html", step=1 %}
+{% endblock pre_primary %}
+
 {% block secondary %}
 {% endblock secondary %}
 
@@ -18,13 +22,6 @@
     {% block primary_content %}
       <article class="module">
         {% block page_header %}
-          <header class="module-content page-header">
-            <ul class="nav nav-tabs">
-              {% block content_primary_nav %}
-                {{ super() }}
-              {% endblock content_primary_nav %}
-            </ul>
-          </header>
         {% endblock page_header %}
         <div class="module-content">
           <h1>


### PR DESCRIPTION
## What this PR accomplishes

- Removes nav tabs from edit resource page
- Adds step indicator to page as step 1

## Issue(s) addressed

- DATA-1471

## What needs review

- Edit resource page has step indicator step 1