### PR TITLE
rm breadcrumbs from workflow

### DIFF
--- a/ckanext/ontario_theme/templates/internal/package/new_resource_not_draft.html
+++ b/ckanext/ontario_theme/templates/internal/package/new_resource_not_draft.html
@@ -1,10 +1,6 @@
 {% ckan_extends %}
 
 {% block breadcrumb_content %}
-  {% snippet "package/snippets/package_base_breadcrumb.html", pkg=pkg %}
-  <li>
-    {% link_for h.dataset_display_name(pkg)|truncate(30), named_route=pkg.type ~ '.read', id=pkg.id if is_activity_archive else pkg.name %}
-  </li>
 {% endblock breadcrumb_content %}
 
 {% block secondary %}

--- a/ckanext/ontario_theme/templates/internal/package/resource_edit_base.html
+++ b/ckanext/ontario_theme/templates/internal/package/resource_edit_base.html
@@ -1,12 +1,6 @@
 {% ckan_extends %}
 
 {% block breadcrumb_content %}
-  {% snippet "package/snippets/package_base_breadcrumb.html", pkg=pkg, res=res %}
-  {% if res %}
-    <li>
-      {% link_for h.resource_display_name(res)|truncate(30), named_route=pkg.type ~ '_resource.read', id=pkg.name, resource_id=res.id %}
-    </li>
-  {% endif %}
 {% endblock breadcrumb_content %}
 
 {% block pre_primary %}


### PR DESCRIPTION
## What this PR accomplishes
Removes breadcrumbs from the workflow.

## What needs review
Verify that there are no longer any breadcrumbs in the workflow pages:
- Step 1-4
- when clicking Back button while in any of Step 1-4
- Step 1 of editing an existing resource