### PR TITLE
[Task]: Bypass validation and Data Dictionary form for non-CSV resources

### DIFF
--- a/ckanext/ontario_theme/plugin.py
+++ b/ckanext/ontario_theme/plugin.py
@@ -215,6 +215,25 @@ def new_resource_publish(id, resource_id):
                            resource=res)
 
 
+def resource_validation(id, resource_id):
+    '''Intermediate page for resource validation (step 2)
+    '''
+    pkg_dict = toolkit.get_action(u'package_show')(None, {u'id': id})
+    res = toolkit.get_action(u'resource_show')(None, {u'id': resource_id})
+    try:
+        validation = toolkit.get_action(u'resource_validation_show')(
+            None,
+            {u'resource_id': resource_id})
+    except ckan.logic.NotFound:
+        validation = None
+
+    return render_template('/package/resource_validation.html',
+                           id=id,
+                           pkg_dict=pkg_dict,
+                           resource=res,
+                           validation=validation)
+
+
 def csv_dump():
     '''
         This was rewritten to be compatible with python3.6/ckan2.9
@@ -1133,7 +1152,8 @@ type data_last_updated
         rules = [
             (u'/help', u'help', help),
             (u'/dataset/inventory', u'inventory', csv_dump),
-            (u'/dataset/<id>/<resource_id>/new_resource_publish/', u'new_resource_publish', new_resource_publish)
+            (u'/dataset/<id>/<resource_id>/new_resource_publish/', u'new_resource_publish', new_resource_publish),
+            (u'/dataset/<id>/<resource_id>/resource_validation/', u'resource_validation', resource_validation)
         ]
 
         for rule in rules:

--- a/ckanext/ontario_theme/resource.py
+++ b/ckanext/ontario_theme/resource.py
@@ -131,7 +131,9 @@ class CreateView(MethodView):
             resource_id_array = [p['id'] for p in resource_dict]
             resource_id = resource_id_array[-1]
             return h.redirect_to(
-                u'validation_read', id=id, resource_id=resource_id
+                "ontario_theme.resource_validation",
+                id=id,
+                resource_id=resource_id
             )
         else:
             # add more resources

--- a/ckanext/ontario_theme/templates/internal/datastore/dictionary.html
+++ b/ckanext/ontario_theme/templates/internal/datastore/dictionary.html
@@ -19,8 +19,12 @@
 {% endblock form_title %}
 
 {% block primary_content_inner %}
-
-  {% set action = h.url_for('datastore.dictionary', id=pkg.name, resource_id=res.id) %}
+  {% if fields %}
+    {% set action = h.url_for('datastore.dictionary', id=pkg.name, resource_id=res.id) %}
+    {% set method = "method=post" %}
+  {% else %}
+    {% set action = h.url_for('ontario_theme.new_resource_publish', id=pkg.name, resource_id=res.id) %}
+  {% endif %}
 
   {% if res.validation_status and res.validation_status == 'failure' %}
     <div class="ontario-alert ontario-alert--error">
@@ -56,17 +60,25 @@
     {% snippet 'validation/snippets/validation_report_dialog.html', validation_report=validation_report %}
   {% endif %}
 
-  <form method="post" action="{{ action }}">
-    {% block dictionary_form %}
-      {% for field in fields %}
-        {% snippet "datastore/snippets/dictionary_form.html",
-        field=field,
-        position=loop.index
-        %}
-      {% endfor %}
-    {% endblock dictionary_form %}
+  <form {{ method }} action="{{ action }}">
+    {% if fields %}
+      {% block dictionary_form %}
+        {% for field in fields %}
+          {% snippet "datastore/snippets/dictionary_form.html",
+          field=field,
+          position=loop.index
+          %}
+        {% endfor %}
+      {% endblock dictionary_form %}
+    {% else %}
+      <p>This resource does not need a data dictionary.</p>
+      <p>
+        Data dictionaries give users the information they need to understand the data they are looking at. The data dictionary is displayed alongside the data for easy reference.
+        Data dictionaries are only needed for machine-readable data (for example, CSV, JSON, XML).
+      </p>
+    {% endif %}
     <button class="ontario-button ontario-button--primary"
             name="save"
-            type="submit">{{ _('Run validator to continue') }}</button>
+            type="submit">{{ _('Continue') }}</button>
   </form>
 {% endblock primary_content_inner %}

--- a/ckanext/ontario_theme/templates/internal/datastore/dictionary.html
+++ b/ckanext/ontario_theme/templates/internal/datastore/dictionary.html
@@ -74,7 +74,7 @@
       <p>This resource does not need a data dictionary.</p>
       <p>
         Data dictionaries give users the information they need to understand the data they are looking at. The data dictionary is displayed alongside the data for easy reference.
-        Data dictionaries are only needed for machine-readable data (for example, CSV, JSON, XML).
+        Data dictionaries are only used for CSV files.
       </p>
     {% endif %}
     <button class="ontario-button ontario-button--primary"

--- a/ckanext/ontario_theme/templates/internal/package/resource_validation.html
+++ b/ckanext/ontario_theme/templates/internal/package/resource_validation.html
@@ -1,0 +1,41 @@
+{% extends "package/resource_edit_base.html" %}
+
+{%- block subtitle -%}
+    {{ h.resource_display_name(resource) }}
+{%- endblock subtitle -%}
+
+{% block pre_primary %}
+  {% set back_url = h.url_for(pkg_dict.type ~ '_resource.edit', id=pkg_dict.id, resource_id=resource.id) %}
+  {% snippet "package/snippets/step_indicator.html", step=2, back_url=back_url %}
+{% endblock pre_primary %}
+
+{% block form_title %}
+  {{ h.resource_display_name(resource) }}
+  {% if validation.report %}{{ h.get_validation_badge(resource)|safe }}{% endif %}
+{% endblock form_title %}
+
+{% block primary_content_inner %}
+  {% if validation.report %}
+    {% set success_message = "Data validated successfully" %}
+    <div class="validation-details">
+      <div>{{ _('Validation timestamp') }}: {{ h.render_datetime(resource.validation_timestamp, with_hours=True) }}</div>
+      <div>{{ _('Duration') }}: {{ h.validation_dict(validation.report)["stats"]["seconds"] }}s</div>
+    </div>
+    {% snippet "package/snippets/successful_page_alert.html", success_message=success_message %}
+  {% else %}
+    {% set success_message = "Data uploaded successfully" %}
+    {% snippet "package/snippets/successful_page_alert.html", success_message=success_message %}
+  {% endif %}
+
+  {% set package_id = resource.get('package_id') %}
+  {% set resource_id = resource.get('id') %}
+  {% set action = h.url_for('datastore.dictionary',
+      id=package_id,
+      resource_id=resource.id) %}
+ 
+  <form method="get" action="{{ action }}">
+    <button class="ontario-button ontario-button--primary"
+            name="save"
+            type="submit">Continue</button>
+  </form>
+{% endblock primary_content_inner %}

--- a/ckanext/ontario_theme/templates/internal/package/snippets/successful_page_alert.html
+++ b/ckanext/ontario_theme/templates/internal/package/snippets/successful_page_alert.html
@@ -1,0 +1,16 @@
+<div class="ontario-alert ontario-alert--success">
+  <div class="ontario-alert__header">
+    <div class="ontario-alert__header-icon">
+      <svg class="ontario-icon"
+           alt=""
+           aria-hidden="true"
+           focusable="false"
+           sol:category="primary"
+           viewBox="0 0 24 24"
+           preserveAspectRatio="xMidYMid meet">
+        <use href="#ontario-icon-alert-success"></use>
+      </svg>
+    </div>
+    <h2 class="ontario-alert__header-title ontario-h4">{{ success_message }}</h2>
+  </div>
+</div>


### PR DESCRIPTION
## What this PR accomplishes

- When a non-CSV file is added as a new resource, redirects to Step 2.
- Added new file and blueprint to show validation/upload status as needed.
- Added snippet for successful status page alert.
- Step 2 redirects to data dictionary page with non-CSV files, reworked the data dictionary prepare function

## Issue(s) addressed

- DATA-1444

## What needs review

- Going through workflow with non-csv files work as expected. (no errors, user goes through all steps and content follow figma)
- Going through workflow with csv files work as expected. (no changes)