### PR TITLE
[Bug]: Fix alignment in admin resource list

### DIFF
--- a/ckanext/ontario_theme/fanstatic/common.css
+++ b/ckanext/ontario_theme/fanstatic/common.css
@@ -1687,6 +1687,7 @@ via submission form. Copied from DS.*/
 .resource-list {
   overflow: hidden;
   padding-bottom: 10px;
+  padding-top: 16px;
 }
 
 .resource-item {

--- a/ckanext/ontario_theme/templates/internal/package/snippets/resource_item.html
+++ b/ckanext/ontario_theme/templates/internal/package/snippets/resource_item.html
@@ -52,23 +52,23 @@
       {% endif %}
     {% endblock resource_item_description %}
   </div>
-    {% block resource_item_explore %}
-      {% if not url_is_edit %}
-        <div class="resource-buttons text-right">
-          {% block resource_item_explore_links %}
-            {% if can_edit %}
-              <a href="{{ url }}" class="ontario-button ontario-button--secondary">{{ _('Explore') }}</a>
-              <a href="{{ h.url_for(pkg.type ~ '_resource.edit', id=pkg.name, resource_id=res.id) }}"
-                class="ontario-button ontario-button--tertiary">
-                <i class="fa fa-pencil-square-o">&nbsp;</i>{{ _('Edit') }}
-              </a>
-            {% else %}
-              <span class="ontario-button ontario-button--secondary">{{ _('Explore') }}</span>
-            {% endif %}
-          {% endblock resource_item_explore_links %}
-      {% endif %}
-    {% endblock resource_item_explore %}
-  </div>
+  {% block resource_item_explore %}
+    {% if not url_is_edit %}
+      <div class="resource-buttons text-right">
+        {% block resource_item_explore_links %}
+          {% if can_edit %}
+            <a href="{{ url }}" class="ontario-button ontario-button--secondary">{{ _('Explore') }}</a>
+            <a href="{{ h.url_for(pkg.type ~ '_resource.edit', id=pkg.name, resource_id=res.id) }}"
+              class="ontario-button ontario-button--tertiary">
+              <i class="fa fa-pencil-square-o">&nbsp;</i>{{ _('Edit') }}
+            </a>
+          {% else %}
+            <span class="ontario-button ontario-button--secondary">{{ _('Explore') }}</span>
+          {% endif %}
+        {% endblock resource_item_explore_links %}
+      </div>
+    {% endif %}
+  {% endblock resource_item_explore %}
   {% if not can_edit %}
     <a href="{{ url }}"
        class="anchor-div"


### PR DESCRIPTION
## What this PR accomplishes

- Fixes alignment in admin resource list
- Adds padding to top of ul

## Issue(s) addressed

- DATA-1506 & DATA-1505

## What needs review

- Alignment in admin resource list is fixed
- Hover on first resource does not overlap buttons