### PR TITLE
[Bug]: Resources with URL titles overlap with side boxes

### DIFF
--- a/ckanext/ontario_theme/fanstatic/common.css
+++ b/ckanext/ontario_theme/fanstatic/common.css
@@ -1776,6 +1776,11 @@ via submission form. Copied from DS.*/
   float: right;
 }
 
+.resource-main h1 {
+  margin-top: unset;
+  overflow-wrap: break-word
+}
+
 @media screen and (max-width: 73em) {
   .right-col {
     clear: left;
@@ -1805,12 +1810,20 @@ via submission form. Copied from DS.*/
     padding-bottom: 0;
     margin: 40px 0 0;
   }
+
+  .right-col .module-narrow.data-api,
+  .right-col .module-narrow:last-child {
+    margin: 40px 0 0 0;
+  }
 }
 
 .resource-aside .module-narrow:first-child {
   margin: 0 0 40px 0;
 }
 
+.resource-aside .module-narrow:only-child {
+  margin: 0;
+}
 
 .module-narrow {
   background: #f2f2f2;
@@ -1827,6 +1840,11 @@ via submission form. Copied from DS.*/
 
   .resource-info {
     display: flow-root;
+  }
+
+  .dataset-main .page-header {
+    margin-top: 0;
+    margin-bottom: 20px;
   }
 }
 
@@ -2066,6 +2084,12 @@ a.ontario-button.ontario-button--tertiary:hover {
 .datafile-p {
   font-size: 16px;
   line-height: 27.24px;
+}
+
+@media screen and (max-width: 40em) {
+  .break-all {
+    word-break: break-all;
+  }
 }
 
 /* Make API help panel wide enough to fit all elements */
@@ -3351,7 +3375,7 @@ label::after {
 .res-additional-info-th,
 .res-additional-info-td {
   display: table-cell;
-  word-wrap: break-word;
+  overflow-wrap: break-word;
 }
 
 .dataset-label.package-additional-info-th,
@@ -3392,7 +3416,7 @@ label::after {
 
   .dataset-details.package-additional-info-td,
   .res-additional-info-td {
-    padding: 5px 0;
+    padding: 5px 5px;
   }
 
   .dataset-label.package-additional-info-th,

--- a/ckanext/ontario_theme/templates/internal/package/snippets/package_base_breadcrumb.html
+++ b/ckanext/ontario_theme/templates/internal/package/snippets/package_base_breadcrumb.html
@@ -8,13 +8,13 @@
     <li id="ministry-name"
         ministry-name="{{ pkg.organization.title }}"
         ministry-name-fr="{{ h.ontario_theme_get_translated_lang(organization_dict, 'title', 'fr') }}">
-      {% link_for organization|truncate(30), named_route='organization.read', id=pkg.organization.name, named_route=group_type + '.read' %}
+      {% link_for organization, named_route='organization.read', id=pkg.organization.name, named_route=group_type + '.read' %}
     </li>
     {%- if res -%}
       <li id="dataset-name"
           dataset-name="{{ pkg.title }}"
           dataset-name-fr="{{ h.ontario_theme_get_translated_lang(pkg, 'title', 'fr') }}">
-        {% link_for dataset|truncate(30), named_route='dataset.read', id=pkg.name %}
+        {% link_for dataset, named_route='dataset.read', id=pkg.name %}
       </li>
     {%- endif -%}
   {% else %}

--- a/ckanext/ontario_theme/templates/internal/scheming/package/resource_read.html
+++ b/ckanext/ontario_theme/templates/internal/scheming/package/resource_read.html
@@ -4,9 +4,9 @@
 #}
 {% extends "package/resource_read.html" %}
 
-{% block wrapper_class %}
+{% block wrapper_class -%}
   resource-main
-{% endblock wrapper_class %}
+{%- endblock wrapper_class %}
 
 {%- block head_extras -%}
 {%- endblock head_extras -%}
@@ -49,7 +49,9 @@
       {% block resource_content %}
         <div class="ontario-columns ontario-small-12 ontario-large-8">
           {% block resource_read_title %}
-            <h1>{{ h.resource_display_name(res) }}</h1>
+            <h1 {% if "https://" in h.resource_display_name(res) -%}
+                class="break-all"
+                {%- endif -%}>{{ h.resource_display_name(res) }}</h1>
           {% endblock resource_read_title %}
 
           <div class="datafile-p" property="rdfs:label">
@@ -147,7 +149,7 @@
         {% endif %}
         {% if res.datastore_active %}
           {% block data_api_button %}
-            <div class="module module-narrow module-shallow context-info">
+            <div class="module module-narrow module-shallow context-info data-api">
               <h2 class="ontario-h4">{{ _('Use the data API') }}</h2>
               {% set loading_text = _('Loading...') %}
               {% set api_info_url = h.url_for(controller='api', action='snippet', ver=1, snippet_path='api_info.html', resource_id=res.id) %}


### PR DESCRIPTION
## What this PR accomplishes

- Adds `overflow-wrap: break-word` to the resource page titles
- Adds `word-break: break-all` to the resource page titles with URLs as the titles on mobile
- Replace instance of `word-wrap: break-word` as it is deprecated
- Removed truncation on breadcrumbs on resource page

## Issue(s) addressed

- DATA-1507

## What needs review

- Resource with URL titles do not overflow horizontally on mobile
- On medium and large screens do not overlap with the side boxes
- No truncation on resource page breadcrumbs