### PR TITLE
bugfix: add extras dict to url

### DIFF
--- a/ckanext/ontario_theme/templates/internal/organization/bulk_process.html
+++ b/ckanext/ontario_theme/templates/internal/organization/bulk_process.html
@@ -9,7 +9,7 @@
   {% set sorting = [
       (_('Name Ascending'), 'titles asc'),
       (_('Name Descending'), 'titles desc'),
-      (_('Last Modified'), 'data_modified desc'),
+      (_('Last Modified'), 'metadata_modified desc'),
       (_('Relevance'), 'score desc, metadata_modified desc'), ] %}
   {% set extras = {'id': group_dict.id} %}
   {% snippet 'snippets/search_form.html', form_id='organization-datasets-search-form',

--- a/ckanext/ontario_theme/templates/internal/organization/bulk_process.html
+++ b/ckanext/ontario_theme/templates/internal/organization/bulk_process.html
@@ -4,13 +4,14 @@
   {% if request['params'] and 'sort' in request['params'] %}
     {% set sort_by_selected = request.params['sort'] %}
   {% else %}
-    {% set sort_by_selected = "titles asc" %}
+    {% set sort_by_selected = "score desc, metadata_modified desc" %}
   {% endif %}
   {% set sorting = [
       (_('Name Ascending'), 'titles asc'),
       (_('Name Descending'), 'titles desc'),
-      (_('Last Modified'), 'data_modified desc') ] %}
-  {% set extras = {'id': c.page.items[0]['organization']['id']} %}
+      (_('Last Modified'), 'data_modified desc'),
+      (_('Relevance'), 'score desc, metadata_modified desc'), ] %}
+  {% set extras = {'id': group_dict.id} %}
   {% snippet 'snippets/search_form.html', form_id='organization-datasets-search-form',
   type='dataset',
   query=q,

--- a/ckanext/ontario_theme/templates/internal/organization/bulk_process.html
+++ b/ckanext/ontario_theme/templates/internal/organization/bulk_process.html
@@ -1,0 +1,23 @@
+{% ckan_extends %}
+
+{% block search_form %}
+  {% if request['params'] and 'sort' in request['params'] %}
+    {% set sort_by_selected = request.params['sort'] %}
+  {% else %}
+    {% set sort_by_selected = "titles asc" %}
+  {% endif %}
+  {% set sorting = [
+      (_('Name Ascending'), 'titles asc'),
+      (_('Name Descending'), 'titles desc'),
+      (_('Last Modified'), 'data_modified desc') ] %}
+  {% set extras = {'id': c.page.items[0]['organization']['id']} %}
+  {% snippet 'snippets/search_form.html', form_id='organization-datasets-search-form',
+  type='dataset',
+  query=q,
+  count=page.item_count,
+  sorting=sorting,
+  sorting_selected=sort_by_selected,
+  no_title=true,
+  search_class=' ',
+  extras=extras %}
+{% endblock %}

--- a/ckanext/ontario_theme/templates/internal/snippets/search_form.html
+++ b/ckanext/ontario_theme/templates/internal/snippets/search_form.html
@@ -172,6 +172,12 @@
                 {% set sort_in_params = true if request.params['sort'] %}
                 {% if label and value %}
                   {% set selected = 'selected' if (sorting_selected == value) %}
+                  {% if 'organization' in c.page.items[0] %}
+                    {% set org_id = c.page.items[0]['organization']['id'] %}
+                    {% set org_type = c.page.items[0]['organization']['type'] %}
+                    {% set is_org = c.page.items[0]['organization']['is_organization'] %}
+                    {% set extras = {'id': org_id,'group_type': org_type,'is_organization': is_org} %}
+                  {% endif %}
                   {% set href = h.remove_url_param('sort', replace=value, extras=extras) if sort_in_params else h.add_url_param(new_params={'sort': value}, extras=extras) %}
                   <li class="sort-by-options {{ selected }}">
                     <a href="{{ href }}">{{ label }}</a>

--- a/ckanext/ontario_theme/templates/internal/snippets/search_form.html
+++ b/ckanext/ontario_theme/templates/internal/snippets/search_form.html
@@ -172,12 +172,6 @@
                 {% set sort_in_params = true if request.params['sort'] %}
                 {% if label and value %}
                   {% set selected = 'selected' if (sorting_selected == value) %}
-                  {% if 'organization' in c.page.items[0] %}
-                    {% set org_id = c.page.items[0]['organization']['id'] %}
-                    {% set org_type = c.page.items[0]['organization']['type'] %}
-                    {% set is_org = c.page.items[0]['organization']['is_organization'] %}
-                    {% set extras = {'id': org_id,'group_type': org_type,'is_organization': is_org} %}
-                  {% endif %}
                   {% set href = h.remove_url_param('sort', replace=value, extras=extras) if sort_in_params else h.add_url_param(new_params={'sort': value}, extras=extras) %}
                   <li class="sort-by-options {{ selected }}">
                     <a href="{{ href }}">{{ label }}</a>


### PR DESCRIPTION
## What this PR accomplishes
The `h.add_url_param()` function requires a dictionary with 3 elements: `id`, `group_type`, and `is_organization`. This PR adds those parameters in to the empty `extras` object which was causing an error when rendering the Datasets page from the admin panel of the Ministry page.

## What needs review
1. Go to Ministries page and pick a ministry
2. click the Edit button
3. click the Datasets tab. Verify that the page displays.