### PR TITLE
Display same Step 1 title for resource adding or editing

### DIFF
--- a/ckanext/ontario_theme/templates/internal/package/new_resource_not_draft.html
+++ b/ckanext/ontario_theme/templates/internal/package/new_resource_not_draft.html
@@ -1,5 +1,9 @@
 {% ckan_extends %}
 
+{% block subtitle %}
+  {{ _('Add or edit') }} {{ g.template_title_delimiter }} {{ h.dataset_display_name(pkg) }}
+{% endblock %}
+
 {% block breadcrumb %}
 {% endblock breadcrumb %}
 
@@ -11,7 +15,7 @@
 {% endblock pre_primary %}
 
 {% block form_title %}
-  Add or edit data resource
+  {{ _('Add or edit data resource') }}
 {% endblock form_title %}
 
 {% block form %}

--- a/ckanext/ontario_theme/templates/internal/package/new_resource_not_draft.html
+++ b/ckanext/ontario_theme/templates/internal/package/new_resource_not_draft.html
@@ -11,7 +11,7 @@
 {% endblock pre_primary %}
 
 {% block form_title %}
-  {{ _('Add resource file and metadata') }}
+  Add or edit data resource
 {% endblock form_title %}
 
 {% block form %}

--- a/ckanext/ontario_theme/templates/internal/package/resource_edit.html
+++ b/ckanext/ontario_theme/templates/internal/package/resource_edit.html
@@ -1,0 +1,5 @@
+{% ckan_extends %}
+
+{% block subtitle %}
+  {{ _('Add or edit') }} {{ g.template_title_delimiter }} {{ h.resource_display_name(res) }} {{ g.template_title_delimiter }} {{ h.dataset_display_name(pkg) }}
+{% endblock subtitle %}

--- a/ckanext/ontario_theme/templates/internal/package/resource_edit_base.html
+++ b/ckanext/ontario_theme/templates/internal/package/resource_edit_base.html
@@ -20,7 +20,7 @@
         <div class="module-content">
           <h1>
             {% block form_title %}
-              {{ super() }}
+              Add or edit data resource
             {% endblock form_title %}
           </h1>
           {% block primary_content_inner %}

--- a/ckanext/ontario_theme/templates/internal/package/resource_edit_base.html
+++ b/ckanext/ontario_theme/templates/internal/package/resource_edit_base.html
@@ -20,7 +20,7 @@
         <div class="module-content">
           <h1>
             {% block form_title %}
-              Add or edit data resource
+              {{ _('Add or edit data resource') }}
             {% endblock form_title %}
           </h1>
           {% block primary_content_inner %}


### PR DESCRIPTION
## What this PR accomplishes

- Changes the title of Step 1 for new resources and for editing existing resources to be the same. The title should be: "Add or edit data resource" for both pages.
- Consolidates the text of the browser tab such that text starts with "Add or edit" instead of "Add resource" (new resources) or "Edit" (existing resources). The rest of the tab text should remain as before.

## What needs review
Confirm that:
- Step 1 page `h1` title is `Add or edit data resource` both when creating a new resource and when editing an existing resource
- Step 1 browser tab reads `Add or edit - {dataset name} - {ckan site name}` for new resources and `Add or edit - {resource name} - {dataset name} - {ckan site name}` for existing resources