### PR TITLE
Remove hint text from data dictionary page

### DIFF
--- a/ckanext/ontario_theme/templates/internal/datastore/snippets/dictionary_form.html
+++ b/ckanext/ontario_theme/templates/internal/datastore/snippets/dictionary_form.html
@@ -4,7 +4,6 @@
 <div class="column-name-div">
   <label for="column_name" class="form-control-label">Column name:</label><input type="text" name="column_name" disabled value="{{ field.id }}" class="form-column-name">
 </div>
-<p class="ontario-hint">This can only be changed in the data file.</p>
 
 
 {#


### PR DESCRIPTION
## What this PR accomplishes
Removes hint text from data dictionary page under each column that said: "This can only be changed in the data file."

## What needs review
Confirm this text is no longer displayed on the data dictionary page.