### PR TITLE
Disable pipeline for ckanext_validation_develop branch

### DIFF
--- a/pipeline/azure-pipelines.yml
+++ b/pipeline/azure-pipelines.yml
@@ -39,7 +39,6 @@ trigger:
     include:
       - main
       - develop
-      - ckanext_validation_develop
   tags:
     exclude:
     - '*'


### PR DESCRIPTION
## What this PR accomplishes
- stops CI builds for the validation branch

## What needs review
- ckanext_validation_develop is removed from the pipeline file