### PR TITLE
[Bug] Column names not cutoff on dictionary page

### DIFF
--- a/ckanext/ontario_theme/fanstatic/common.css
+++ b/ckanext/ontario_theme/fanstatic/common.css
@@ -3863,6 +3863,10 @@ label::after {
 .form-column-name {
   border: none;
   background-color: #fff;
+  display: inline-block;
+  margin: 0 0 1rem 0;
+  width: 100%;
+  max-width: 48rem
 }
 
 .column-name-div {


### PR DESCRIPTION
## What this PR accomplishes
Modifies css to allow full column title to be displayed in `<input>` element on Data Dictionary page.

## Issue(s) addressed

- DATA-1613

## What needs review
Test that full column names are displayed in Data Dictionary page, e.g. this file https://data.ontario.ca/dataset/ontario-guaranteed-annual-income-system-benefit-rates/resource/bbf69b48-16a3-47d2-b127-5fca0626008b