### PR TITLE
[Task] Allow formats for remotes to be changed manually

### DIFF
--- a/ckanext/ontario_theme/resource.py
+++ b/ckanext/ontario_theme/resource.py
@@ -19,6 +19,9 @@ import ckan.lib.base as base
 import ckan.logic as logic
 import ckan.lib.helpers as h
 
+import logging
+log = logging.getLogger(__name__)
+
 NotFound = logic.NotFound
 NotAuthorized = logic.NotAuthorized
 ValidationError = logic.ValidationError
@@ -146,6 +149,7 @@ class CreateView(MethodView):
     def get(
         self, package_type, id, data=None, errors=None, error_summary=None
     ):
+        print('HEJ resourcepy def get of CreateView')
         # get resources for sidebar
         context = {
             u'model': model,
@@ -217,14 +221,27 @@ class EditView(MethodView):
             dict_fns.unflatten(tuplize_dict(parse_params(request.files)))
         ))
 
+        print('HEJ resourcepy def post of EditView')
+
         # we don't want to include save as it is part of the form
         del data[u'save']
 
         data[u'package_id'] = id
         try:
             if resource_id:
-                data[u'id'] = resource_id
-                get_action(u'resource_update')(context, data)
+                try:
+                    info=get_action('datastore_search')(
+                                        data_dict={'id': resource_id})
+                    print('HEJ resourcepy info: ', info)
+                    data[u'id'] = resource_id
+                    get_action(u'resource_update')(context, data)
+                # except:
+                #     print('HEJ resourcepy datastore search failed for ', resource_id)
+                #     get_action(u'resource_create')(context, data)
+                except Exception as e:
+                    print('HEJ resourcepy datastore search failed for ', resource_id)
+                    get_action(u'resource_create')(context, data)
+                    log.error(e)
             else:
                 get_action(u'resource_create')(context, data)
         except ValidationError as e:

--- a/ckanext/ontario_theme/resource.py
+++ b/ckanext/ontario_theme/resource.py
@@ -222,28 +222,40 @@ class EditView(MethodView):
         ))
 
         print('HEJ resourcepy def post of EditView')
+        resource = get_action('resource_show')(None, {"id": resource_id})
+        print('HEJ resourcepy junk: ', resource)
 
         # we don't want to include save as it is part of the form
         del data[u'save']
 
         data[u'package_id'] = id
+        # try:
+        #     if resource_id:
+        #         try:
+        #             info=get_action('datastore_search')(
+        #                                 data_dict={'id': resource_id})
+        #             print('HEJ resourcepy info: ', info)
+        #             data[u'id'] = resource_id
+        #             get_action(u'resource_update')(context, data)
+        #         # except:
+        #         #     print('HEJ resourcepy datastore search failed for ', resource_id)
+        #         #     get_action(u'resource_create')(context, data)
+        #         except Exception as e:
+        #             print('HEJ resourcepy datastore search failed for ', resource_id)
+        #             log.error(e)
+        #             if 'validation_status' not in resource:
+        #                 print('HEJ resourcepy validation_status not in resource, create new resource ')
+        #                 get_action(u'resource_create')(context, data)
+                    
+        #     else:
+        #         get_action(u'resource_create')(context, data)
         try:
             if resource_id:
-                try:
-                    info=get_action('datastore_search')(
-                                        data_dict={'id': resource_id})
-                    print('HEJ resourcepy info: ', info)
-                    data[u'id'] = resource_id
+                data[u'id'] = resource_id
+                if 'validation_status' in resource:
                     get_action(u'resource_update')(context, data)
-                # except:
-                #     print('HEJ resourcepy datastore search failed for ', resource_id)
-                #     get_action(u'resource_create')(context, data)
-                except Exception as e:
-                    print('HEJ resourcepy datastore search failed for ', resource_id)
-                    get_action(u'resource_create')(context, data)
-                    log.error(e)
-            else:
-                get_action(u'resource_create')(context, data)
+              
+
         except ValidationError as e:
             errors = e.error_dict
             error_summary = e.error_summary

--- a/ckanext/ontario_theme/resource.py
+++ b/ckanext/ontario_theme/resource.py
@@ -149,7 +149,6 @@ class CreateView(MethodView):
     def get(
         self, package_type, id, data=None, errors=None, error_summary=None
     ):
-        print('HEJ resourcepy def get of CreateView')
         # get resources for sidebar
         context = {
             u'model': model,
@@ -221,40 +220,19 @@ class EditView(MethodView):
             dict_fns.unflatten(tuplize_dict(parse_params(request.files)))
         ))
 
-        print('HEJ resourcepy def post of EditView')
         resource = get_action('resource_show')(None, {"id": resource_id})
-        print('HEJ resourcepy junk: ', resource)
 
         # we don't want to include save as it is part of the form
         del data[u'save']
 
         data[u'package_id'] = id
-        # try:
-        #     if resource_id:
-        #         try:
-        #             info=get_action('datastore_search')(
-        #                                 data_dict={'id': resource_id})
-        #             print('HEJ resourcepy info: ', info)
-        #             data[u'id'] = resource_id
-        #             get_action(u'resource_update')(context, data)
-        #         # except:
-        #         #     print('HEJ resourcepy datastore search failed for ', resource_id)
-        #         #     get_action(u'resource_create')(context, data)
-        #         except Exception as e:
-        #             print('HEJ resourcepy datastore search failed for ', resource_id)
-        #             log.error(e)
-        #             if 'validation_status' not in resource:
-        #                 print('HEJ resourcepy validation_status not in resource, create new resource ')
-        #                 get_action(u'resource_create')(context, data)
-                    
-        #     else:
-        #         get_action(u'resource_create')(context, data)
         try:
             if resource_id:
                 data[u'id'] = resource_id
                 if 'validation_status' in resource:
                     get_action(u'resource_update')(context, data)
-              
+            else:
+                get_action(u'resource_create')(context, data)
 
         except ValidationError as e:
             errors = e.error_dict

--- a/ckanext/ontario_theme/resource.py
+++ b/ckanext/ontario_theme/resource.py
@@ -19,9 +19,6 @@ import ckan.lib.base as base
 import ckan.logic as logic
 import ckan.lib.helpers as h
 
-import logging
-log = logging.getLogger(__name__)
-
 NotFound = logic.NotFound
 NotAuthorized = logic.NotAuthorized
 ValidationError = logic.ValidationError

--- a/ckanext/ontario_theme/resource_upload.py
+++ b/ckanext/ontario_theme/resource_upload.py
@@ -172,8 +172,5 @@ class ResourceUpload(DefaultResourceUpload):
         elif self.clear:
             resource['url_type'] = ''
 
-        # if url and not (resource.get('url_type') == 'upload') and not resource.get('format'):
-        #     resource['format'] = 'WEB'
-
         if resource.get('format'):
             resource['format'] = resource.get('format').upper()

--- a/ckanext/ontario_theme/resource_upload.py
+++ b/ckanext/ontario_theme/resource_upload.py
@@ -172,8 +172,8 @@ class ResourceUpload(DefaultResourceUpload):
         elif self.clear:
             resource['url_type'] = ''
 
-        if url and not (resource.get('url_type') == 'upload') and not resource.get('format'):
-            resource['format'] = 'WEB'
+        # if url and not (resource.get('url_type') == 'upload') and not resource.get('format'):
+        #     resource['format'] = 'WEB'
 
         if resource.get('format'):
             resource['format'] = resource.get('format').upper()

--- a/ckanext/ontario_theme/resource_upload.py
+++ b/ckanext/ontario_theme/resource_upload.py
@@ -144,14 +144,8 @@ class ResourceUpload(DefaultResourceUpload):
         upload_field_storage = resource.pop('upload', None)
         self.clear = resource.pop('clear_upload', None)
 
-        this_format = None
         if url and config_mimetype_guess == 'file_ext':
             self.mimetype = mimetypes.guess_type(url)[0]
-            try:
-                # always upper case
-                this_format = accepted_resource_formats()[0][accepted_resource_formats()[1].index(mimetypes.guess_type(url)[0])]
-            except:
-                log.error("Format cannot be guessed")
 
         if bool(upload_field_storage) and \
                 isinstance(upload_field_storage, ALLOWED_UPLOAD_TYPES):
@@ -177,16 +171,9 @@ class ResourceUpload(DefaultResourceUpload):
                       
         elif self.clear:
             resource['url_type'] = ''
-        
-        # Format should be WEB for all remote resources regardless of
-        # the actual type
-        if url and not (resource.get('url_type') == 'upload'):
+
+        if url and not (resource.get('url_type') == 'upload') and not resource.get('format'):
             resource['format'] = 'WEB'
 
-        # For uploaded resources, use the specified format unless it does
-        # not agree with the format derived from the guessed mime type
-        if not h.is_url(resource.get('url')) and resource.get('format'):
-            if this_format.lower() and resource.get('format').lower() != this_format.lower():
-                resource['format'] = this_format
-            else:
-                resource['format'] = resource.get('format').upper()
+        if resource.get('format'):
+            resource['format'] = resource.get('format').upper()

--- a/ckanext/ontario_theme/templates/internal/datastore/dictionary.html
+++ b/ckanext/ontario_theme/templates/internal/datastore/dictionary.html
@@ -71,23 +71,12 @@
         {% endfor %}
       {% endblock dictionary_form %}
     {% else %}
-      {% if res['mimetype'] != 'text/csv' %}
         <p>This resource does not need a data dictionary.</p>
         <p>
           Data dictionaries give users the information they need to understand the data they are 
           looking at. The data dictionary is displayed alongside the data for easy reference.
           Data dictionaries are only used for CSV files.
         </p>
-      {% else %}
-        {% if res['mimetype'] == 'text/csv' %}
-          <p>Data dictionaries can only be defined here for uploaded CSV files, not for CSV files 
-          hosted on external sites.</p>
-          <p>
-            Data dictionaries give users the information they need to understand the data they are 
-            looking at. Please upload a separate file containing the data dictionary.
-          </p>
-        {% endif %}
-      {% endif %}
     {% endif %}
     <button class="ontario-button ontario-button--primary"
             name="save"

--- a/ckanext/ontario_theme/templates/internal/package/new_resource_publish.html
+++ b/ckanext/ontario_theme/templates/internal/package/new_resource_publish.html
@@ -64,58 +64,60 @@
     </dl>
   </div>
   <div class="resource-metadata-edit-row">
-    <h2 class="ontario-h2">Data dictionary</h2>
-    {% link_for _('Edit data dictionary'), named_route='datastore.dictionary', id=pkg.name, resource_id=resource_id %}
-  </div>
-  <div class="ontario-small-12">
-    {% set fields = h.datastore_dictionary(resource_id) %}
-    {#- Example of returned dictionary with type override:
-          [{'id': 'rule',
-            'type': 'text',
-            'info': { 'notes': '',
-                      'type_override': '',
-                      'frictionless_dict': [{'type': 'string', 'name': 'rule'}]}},
-          {'id': 'integercol',
-            'type': 'int4',
-            'info': { 'notes': '',
-                      'type_override': 'integer',
-                      'frictionless_dict': [{'type': 'integer', 'name': 'integercol'}]}}]
+    {% if res.datastore_active %}
+      <h2 class="ontario-h2">Data dictionary</h2>
+      {% link_for _('Edit data dictionary'), named_route='datastore.dictionary', id=pkg.name, resource_id=resource_id %}
+    </div>
+    <div class="ontario-small-12">
+      {% set fields = h.datastore_dictionary(resource_id) %}
+      {#- Example of returned dictionary with type override:
+            [{'id': 'rule',
+              'type': 'text',
+              'info': { 'notes': '',
+                        'type_override': '',
+                        'frictionless_dict': [{'type': 'string', 'name': 'rule'}]}},
+            {'id': 'integercol',
+              'type': 'int4',
+              'info': { 'notes': '',
+                        'type_override': 'integer',
+                        'frictionless_dict': [{'type': 'integer', 'name': 'integercol'}]}}]
 
-          "type" is not human-readable for non-text types (e.g. int4), so use
-          field.info["type_override"] (e.g. integer) for these cases. Note we want to
-          stick with the PostgreSQL type names (e.g. "text" not "string") so don't use
-          field.info["frictionless_dict"]["type"].
+            "type" is not human-readable for non-text types (e.g. int4), so use
+            field.info["type_override"] (e.g. integer) for these cases. Note we want to
+            stick with the PostgreSQL type names (e.g. "text" not "string") so don't use
+            field.info["frictionless_dict"]["type"].
 
-        A returned dictionary without any type overrides looks like:
-          [{'id': 'rule', 'type': 'text'},
-           {'id': 'integercol', 'type': 'text'}]
-    -#}
-    {% for field in fields %}
-      <div>
-        <h3 class="ontario-h3">Column {{ loop.index }}</h3>
-        {% if field.info %}
-          {% set field_type = field.type if field.info["type_override"] == '' else field.info["type_override"] %}
-          {% set field_notes = field.info["notes"] %}
-        {% else %}
-          {% set field_type = field.type %}
-          {% set field_notes = "" %}
-        {% endif %}
-        <dl class="resource-metadata-dl">
-          <dt class="resource-metadata-heading ontario-h5">Column name:</dt>
-          <dd>
-            {{ field.id }}
-          </dd>
-          <dt class="resource-metadata-heading ontario-h5">Data type:</dt>
-          <dd>
-            {{ field_type }}
-          </dd>
-          <dt class="resource-metadata-heading ontario-h5">Description:</dt>
-          <dd>
-            {{ field_notes }}
-          </dd>
-        </dl>
-      </div>
-    {% endfor %}
+          A returned dictionary without any type overrides looks like:
+            [{'id': 'rule', 'type': 'text'},
+            {'id': 'integercol', 'type': 'text'}]
+      -#}
+      {% for field in fields %}
+        <div>
+          <h3 class="ontario-h3">Column {{ loop.index }}</h3>
+          {% if field.info %}
+            {% set field_type = field.type if field.info["type_override"] == '' else field.info["type_override"] %}
+            {% set field_notes = field.info["notes"] %}
+          {% else %}
+            {% set field_type = field.type %}
+            {% set field_notes = "" %}
+          {% endif %}
+          <dl class="resource-metadata-dl">
+            <dt class="resource-metadata-heading ontario-h5">Column name:</dt>
+            <dd>
+              {{ field.id }}
+            </dd>
+            <dt class="resource-metadata-heading ontario-h5">Data type:</dt>
+            <dd>
+              {{ field_type }}
+            </dd>
+            <dt class="resource-metadata-heading ontario-h5">Description:</dt>
+            <dd>
+              {{ field_notes }}
+            </dd>
+          </dl>
+        </div>
+      {% endfor %}
+    {% endif %}
   </div>
   {% link_for _('Publish'), named_route='dataset.read', id=pkg.name, class_="ontario-button ontario-button--primary" %}
 {% endblock primary_content_inner %}

--- a/ckanext/ontario_theme/templates/internal/scheming/package/resource_read.html
+++ b/ckanext/ontario_theme/templates/internal/scheming/package/resource_read.html
@@ -102,7 +102,7 @@
           {% endif %}
           <div class="module module-narrow module-shallow context-info">
             <h2 class="ontario-h4">
-              {% if res.datastore_active %}
+              {% if res.datastore_active and res.url_type is not none %}
                 {% if not res['validation_status'] or res['validation_status'] == 'success' %}
                   {{ _('Download data') }}
                 {% else %}
@@ -116,7 +116,7 @@
                 {% endif %}
               {% endif %}
             </h2>
-            {% if not res.datastore_active or res['validation_status'] == 'failure' %}
+            {% if not res.datastore_active or res['validation_status'] == 'failure' or res.url_type is none %}
               <a class="dataset-download-link resource-url-analytics resource-type-{{ res.resource_type }}"
                  href="{{ res.url }}"
                  onclick="trackDownload('{{ res.url }}', '{{ this_org }}', '{{ pkg.title }}', '{{ this_group }}');return true;">
@@ -125,7 +125,7 @@
             {% endif %}
             {% block download_resource_button %}
               {% set this_org = h.get_translated(pkg.organization, 'title') or pkg.organization.name %}
-              {% if res.datastore_active %}
+              {% if res.datastore_active and res.url_type is not none %}
                 {% if not res['validation_status'] or res['validation_status'] == 'success' %}
  
                   <ul>
@@ -155,7 +155,7 @@
             {% endblock download_resource_button %}
           </div>
         {% endif %}
-        {% if res.datastore_active %}
+        {% if res.datastore_active and res.url_type is not none %}
           {% if not res['validation_status'] or res['validation_status'] == 'success' %}
             {% block data_api_button %}
               <div class="module module-narrow module-shallow context-info data-api">


### PR DESCRIPTION
## What this PR accomplishes
Reverts to original code where resource format can be manually entered and removes the automatic application of the `WEB` label to remotes where no format is manually specified. 

Notes: 
- remotely-hosted CSV files will be run through the validation process, but the resource page will not show the Download box or the API box. Since the remote host is the most up-to-date, the catalogue database could potentially diverge significantly from it. 
- the content for the Data Dictionary page created for the case of remote CSV files has been removed, since the validation process is no longer being skipped for remote CSVs.
- manually entered formats that contain a typo (e.g. CVS) or are not in the accepted format list (e.g. MYFORMAT) will not be checked or corrected and will pass as is.

## Issue(s) addressed
DATA-1630

## What needs review
Must be tested with https://github.com/ongov/ckanext-validation/pull/14 branch checked out.

To test, link to remote files of various formats (ZIP, CSV, etc) and manually enter the format. Options:

-   enter a format that is the same as the format of the remote resource
-   enter a format that is different from the format of the remote resource
-   enter a format type that has a typo or make up a format (e.g. MYCSV, BLANK, etc)
-   leave the format blank

Also check that the regular sanity tests also pass (i.e. locally-uploaded CSV files both valid and corrected, and non-CSV files, work as expected.)
