### PR TITLE
rm check for validation_status in resource

### DIFF
--- a/ckanext/ontario_theme/resource.py
+++ b/ckanext/ontario_theme/resource.py
@@ -217,8 +217,6 @@ class EditView(MethodView):
             dict_fns.unflatten(tuplize_dict(parse_params(request.files)))
         ))
 
-        resource = get_action('resource_show')(None, {"id": resource_id})
-
         # we don't want to include save as it is part of the form
         del data[u'save']
 
@@ -226,8 +224,7 @@ class EditView(MethodView):
         try:
             if resource_id:
                 data[u'id'] = resource_id
-                if 'validation_status' in resource:
-                    get_action(u'resource_update')(context, data)
+                get_action(u'resource_update')(context, data)
             else:
                 get_action(u'resource_create')(context, data)
 


### PR DESCRIPTION
## What this PR accomplishes
Removes a check for `validation_status` in the `resource` object which prevents pre-validation resources from being updated.

## What needs review
Needs to work for all cases (pre-validation resources, post-validation resources, new resources).