### PR TITLE
Develop bypassremotes

### DIFF
--- a/ckanext/ontario_theme/datastore.py
+++ b/ckanext/ontario_theme/datastore.py
@@ -81,48 +81,49 @@ class DictionaryView(MethodView):
                 for f, fi in zip_longest(fields, info)
             ]
         }
-        has_override = True if [x for x in dict_fields['fields'] if len(x['info']['type_override'])>0] else False
-        if has_override:
-            # Reformat dictionary into structure used by ckanext-validation and
-            # replace PostgreSQL data types with Frictionless equivalents
-            ui_dict_fields = copy.deepcopy(dict_fields)
-            ui_dict = reformat_ui_dict(ui_dict_fields["fields"])
-            for row in dict_fields["fields"]:
-                if "info" in row:
-                    col_name = row["id"]
-                    row["info"]["frictionless_dict"] = [
-                        item for item in ui_dict["fields"] if item.get("name") == col_name
-                    ]
-            # Push the Frictionless data dictionary to database so that
-            # ckanext-validation can retrieve it in _run_sync_validation (logic.py)
-            get_action("datastore_create")(
-                None,
-                {
-                    "resource_id": resource_id,
-                    "force": True,
-                    "fields": dict_fields.get("fields"),
-                },
-            )
-            # Trigger ckanext-validation
-            get_action("resource_validation_run")(
-                {"ignore_auth": True},
-                {"resource_id": resource_id, "async": False, "ui_dict": ui_dict},
-            )
-            # Get status of validation to submit
-            # to xloader when status is successful
-            status = get_action(u"resource_validation_show")(
-                {u'ignore_auth': True},
-                {u"resource_id": resource_id}
-            )
-            if status['status'] == 'success':
-                get_action("xloader_submit")(
+        try:
+            has_override = True if [x for x in dict_fields['fields'] if len(x['info']['type_override'])>0] else False
+            if has_override:
+                # Reformat dictionary into structure used by ckanext-validation and
+                # replace PostgreSQL data types with Frictionless equivalents
+                ui_dict_fields = copy.deepcopy(dict_fields)
+                ui_dict = reformat_ui_dict(ui_dict_fields["fields"])
+                for row in dict_fields["fields"]:
+                    if "info" in row:
+                        col_name = row["id"]
+                        row["info"]["frictionless_dict"] = [
+                            item for item in ui_dict["fields"] if item.get("name") == col_name
+                        ]
+                # Push the Frictionless data dictionary to database so that
+                # ckanext-validation can retrieve it in _run_sync_validation (logic.py)
+                get_action("datastore_create")(
                     None,
-                    {"resource_id": resource_id, "ignore_hash": True}
+                    {
+                        "resource_id": resource_id,
+                        "force": True,
+                        "fields": dict_fields.get("fields"),
+                    },
                 )
-                return h.redirect_to("ontario_theme.new_resource_publish", id=id, resource_id=resource_id)
-            elif not status:
-                return h.redirect_to("ontario_theme.new_resource_publish", id=id, resource_id=resource_id)
-            else:
-                return h.redirect_to("datastore.dictionary", id=id, resource_id=resource_id)
-        else:
+                # Trigger ckanext-validation
+                get_action("resource_validation_run")(
+                    {"ignore_auth": True},
+                    {"resource_id": resource_id, "async": False, "ui_dict": ui_dict},
+                )
+                # Get status of validation to submit
+                # to xloader when status is successful
+                status = get_action(u"resource_validation_show")(
+                    {u'ignore_auth': True},
+                    {u"resource_id": resource_id}
+                )
+                if status['status'] == 'success':
+                    get_action("xloader_submit")(
+                        None,
+                        {"resource_id": resource_id, "ignore_hash": True}
+                    )
+                    return h.redirect_to("ontario_theme.new_resource_publish", id=id, resource_id=resource_id)
+                elif not status:
+                    return h.redirect_to("ontario_theme.new_resource_publish", id=id, resource_id=resource_id)
+                else:
+                    return h.redirect_to("datastore.dictionary", id=id, resource_id=resource_id)
+        except:
             return h.redirect_to("ontario_theme.new_resource_publish", id=id, resource_id=resource_id)

--- a/ckanext/ontario_theme/templates/internal/datastore/dictionary.html
+++ b/ckanext/ontario_theme/templates/internal/datastore/dictionary.html
@@ -61,7 +61,7 @@
   {% endif %}
 
   <form {{ method }} action="{{ action }}">
-    {% if fields %}
+    {% if fields and res.url_type %}
       {% block dictionary_form %}
         {% for field in fields %}
           {% snippet "datastore/snippets/dictionary_form.html",
@@ -71,12 +71,16 @@
         {% endfor %}
       {% endblock dictionary_form %}
     {% else %}
+      {% if not fields %}
         <p>This resource does not need a data dictionary.</p>
         <p>
           Data dictionaries give users the information they need to understand the data they are 
           looking at. The data dictionary is displayed alongside the data for easy reference.
           Data dictionaries are only used for CSV files.
         </p>
+      {% else %}
+        <p>Data dictionaries cannot be defined for remote CSV files.</p>
+      {% endif %}
     {% endif %}
     <button class="ontario-button ontario-button--primary"
             name="save"

--- a/ckanext/ontario_theme/templates/internal/package/new_resource_publish.html
+++ b/ckanext/ontario_theme/templates/internal/package/new_resource_publish.html
@@ -64,7 +64,7 @@
     </dl>
   </div>
   <div class="resource-metadata-edit-row">
-    {% if res.datastore_active %}
+    {% if res.datastore_active and res.url_type %}
       <h2 class="ontario-h2">Data dictionary</h2>
       {% link_for _('Edit data dictionary'), named_route='datastore.dictionary', id=pkg.name, resource_id=resource_id %}
     </div>

--- a/ckanext/ontario_theme/templates/internal/package/resource_validation.html
+++ b/ckanext/ontario_theme/templates/internal/package/resource_validation.html
@@ -19,7 +19,7 @@
       id=id,
     resource_id=resource.id) %}
 
-  {% if validation.report %}
+  {% if validation.report and resource.url_type %}
     {% set button_id = "step2Btn" %}
     {% set success_message = "Data validated successfully" %}
     <div class="validation-details">

--- a/ckanext/ontario_theme/templates/internal/package/resource_validation.html
+++ b/ckanext/ontario_theme/templates/internal/package/resource_validation.html
@@ -80,7 +80,11 @@
 
   {% else %}
     {% set button_id = "nextBtn" %}
-    {% set success_message = "Data uploaded successfully" %}
+    {% if resource.url_type %}
+      {% set success_message = "Data uploaded successfully" %}
+    {% else %}
+      {% set success_message = "Data linked successfully" %}
+    {% endif %}
     {% snippet "package/snippets/successful_page_alert.html", success_message=success_message %}
   {% endif %}
 


### PR DESCRIPTION
## What this PR accomplishes
Does not send remote CSVs for validation when either creating a new resource or updating an existing resource. Also displays different content for the Step2 page and the Step 3 Data Dictionary page customized for remotes.

## Issue(s) addressed
DATA-1639

## What needs review
Test that remote CSVs do not get sent for validation when either creating a new resource or updating an existing resource, and the appropriate content is displayed in Steps 2 and 3. Also do the regular tests to make sure this fix does not break anything.

To be reviewed together with https://github.com/ongov/ckanext-validation/pull/15