### PR TITLE
set ignore hash to False to ignore unchanged files

### DIFF
--- a/ckanext/ontario_theme/datastore.py
+++ b/ckanext/ontario_theme/datastore.py
@@ -118,7 +118,7 @@ class DictionaryView(MethodView):
                 if status['status'] == 'success':
                     get_action("xloader_submit")(
                         None,
-                        {"resource_id": resource_id, "ignore_hash": True}
+                        {"resource_id": resource_id, "ignore_hash": False}
                     )
                     return h.redirect_to("ontario_theme.new_resource_publish", id=id, resource_id=resource_id)
                 elif not status:


### PR DESCRIPTION
## What this PR accomplishes
Ignores resources whose hash has not changed, rather than always pushing to datastore even when the data file has not changed.

## Issue(s) addressed
DATA1668

## What needs review
A full test of validation test cases to ensure that data is still being properly uploaded when data edits are made and when metadata edits only are made.