### PR TITLE
Redirect to publish page when dictionary form left blank

### DIFF
--- a/ckanext/ontario_theme/datastore.py
+++ b/ckanext/ontario_theme/datastore.py
@@ -84,7 +84,9 @@ class DictionaryView(MethodView):
         try:
             # Check if any data types have been defined in dictionary form
             has_override = True if [x for x in dict_fields['fields'] if len(x['info']['type_override'])>0] else False
-            if has_override:
+            # Check if any descriptions have been added in dictionary form
+            has_notes = True if [x for x in dict_fields['fields'] if len(x['info']['notes'])>0] else False
+            if has_override or has_notes:
                 # Reformat dictionary into structure used by ckanext-validation and
                 # replace PostgreSQL data types with Frictionless equivalents
                 ui_dict_fields = copy.deepcopy(dict_fields)
@@ -127,7 +129,7 @@ class DictionaryView(MethodView):
                 else:
                     return h.redirect_to("datastore.dictionary", id=id, resource_id=resource_id)
             else:
-                # Dictionary data type fields all left blank, nothing to xloader so continue
+                # Dictionary form fields all left blank, nothing to xloader so continue
                 return h.redirect_to("ontario_theme.new_resource_publish", id=id, resource_id=resource_id)
         except:
             return h.redirect_to("ontario_theme.new_resource_publish", id=id, resource_id=resource_id)

--- a/ckanext/ontario_theme/datastore.py
+++ b/ckanext/ontario_theme/datastore.py
@@ -82,6 +82,7 @@ class DictionaryView(MethodView):
             ]
         }
         try:
+            # Check if any data types have been defined in dictionary form
             has_override = True if [x for x in dict_fields['fields'] if len(x['info']['type_override'])>0] else False
             if has_override:
                 # Reformat dictionary into structure used by ckanext-validation and
@@ -125,5 +126,8 @@ class DictionaryView(MethodView):
                     return h.redirect_to("ontario_theme.new_resource_publish", id=id, resource_id=resource_id)
                 else:
                     return h.redirect_to("datastore.dictionary", id=id, resource_id=resource_id)
+            else:
+                # Dictionary data type fields all left blank, nothing to xloader so continue
+                return h.redirect_to("ontario_theme.new_resource_publish", id=id, resource_id=resource_id)
         except:
             return h.redirect_to("ontario_theme.new_resource_publish", id=id, resource_id=resource_id)


### PR DESCRIPTION
## What this PR accomplishes
Resolves the 500 server error when the data dictionary form is left completely blank by redirecting to publish page after Step 3. 

Also takes care of case when the data type field not filled in but the description field is added. In this case, the modified data dictionary needs to be pushed to database, same as when the data type is defined.

## Issue(s) addressed
DATA-1678

## What needs review
Test
- creating a new resource without filling out the data dictionary form redirects to publish page without error
- creating a new resource and filling out description field only (leaving data type untouched) in data dictionary form redirects to publish page without error and the description is listed in the publish page
- creating or editing a resource with data dictionary form filled out works as normal

Also test that 