### PR TITLE
replace legacy ._data in license obj and ensure get_license returns a dict

### DIFF
--- a/ckanext/ontario_theme/plugin.py
+++ b/ckanext/ontario_theme/plugin.py
@@ -654,7 +654,30 @@ def get_recently_updated_datasets():
 def get_license(license_id):
     '''Helper to return license based on id.
     '''
-    return Package.get_license_register().get(license_id)
+    
+def get_license(license_id: str) -> dict:
+    """
+    Return a dict for the given license_id; never None.
+    Compatible with h.get_translated(dict, 'field').
+    """
+    lic_obj = Package.get_license_register().get(license_id)
+    if not lic_obj:
+        return {}  # <<< avoid None
+
+    # If legacy objects expose a _data dict, unwrap it:
+    if hasattr(lic_obj, '_data') and isinstance(lic_obj._data, dict):
+        return lic_obj._data
+
+    # Otherwise, build a dict explicitly (adapt fields to your schema)
+    lic_dict = {
+        'id': getattr(lic_obj, 'id', None),
+        'title': getattr(lic_obj, 'title', None),
+        'title_translated': getattr(lic_obj, 'title_translated', {}) or {},
+        'description': getattr(lic_obj, 'description', None),
+        'description_translated': getattr(lic_obj, 'description_translated', {}) or {},
+        'url': getattr(lic_obj, 'url', None),
+    }
+    return {k: v for k, v in lic_dict.items() if v is not None}
 
 
 def get_current_year():

--- a/ckanext/ontario_theme/templates/internal/package/snippets/schema_markup.html
+++ b/ckanext/ontario_theme/templates/internal/package/snippets/schema_markup.html
@@ -2,7 +2,8 @@
 {# CKAN 2.11 updates for license and keywords to handle when they are null #}
 {# lic might be None; guard it and prefer translated text if present #}
 {% set lic_obj = license if license is not none else None %}
-{% set lic_dict = lic_obj.license_dictize() if lic_obj else {} %}
+{# Existing lic_obj may be a dict now; use the dict directly #}
+{% set lic_dict = lic_obj if lic_obj else {} %}
 
 {# Prefer translated description/title if available, else raw fields, else empty #}
 {% set lic_descr = (

--- a/ckanext/ontario_theme/templates/internal/scheming/package/resource_read.html
+++ b/ckanext/ontario_theme/templates/internal/scheming/package/resource_read.html
@@ -291,7 +291,7 @@
                     <div class="res-additional-info-tr">
                       <dt class="res-additional-info-th">{{ _('Licence') }}</dt>
                       <dd class="res-additional-info-td">
-                        {{ h.get_translated(license._data, 'title') }}
+                        {{ h.get_translated(license, 'title') or pkg.license_title }}
                       </dd>
                     </div>
                   {%- endblock resource_license -%}

--- a/ckanext/ontario_theme/templates/internal/snippets/facet_list.html
+++ b/ckanext/ontario_theme/templates/internal/snippets/facet_list.html
@@ -41,7 +41,7 @@
               <div class="ontario-checkboxes">
                 {% for item in items %}
                   {%- if name == "license_id" %}
-                    {% set translate = h.ontario_theme_get_license(item.name)._data %}
+                    {% set translate = h.ontario_theme_get_license(item.name) %}
                   {% elif name == "organization" %}
                     {% set translate = h.get_organization(item.name) %}
                   {% elif name == "groups" %}
@@ -49,7 +49,11 @@
                   {% else %}
                     {% do item.update({'display_name': h.scheming_choices_label(scheming_choices, item.display_name)}) if scheming_choices %}
                   {% endif -%}
-                  {% set label = label_function(translate, "title") if (label_function and translate) else item.display_name %}
+                  {# Prefer the translated title from dict; fallback to existing display_name #}
+                  {% set label = (
+                    h.get_translated(translate, 'title') if translate
+                    else item.display_name
+                  ) %}
                   {% set count = count_label(item['count']) if count_label else ('(%d)' % item['count']) %}
                   {% set item_name = item.name|replace(' ', '-') %}
                   <div class="ontario-checkboxes__item

--- a/ckanext/ontario_theme/templates/internal/snippets/license.html
+++ b/ckanext/ontario_theme/templates/internal/snippets/license.html
@@ -26,7 +26,7 @@
   {% if license %}
     <p>
       {% block license_content_inner %}
-        {{ license_string_from_license(license._data) }}
+        {{ license_string_from_license(license) }}
         {% if pkg_dict.isopen %}
           <a href="https://opendefinition.org/okd/"
              title="{{ _('This dataset satisfies the Open Definition.') }}">
@@ -38,7 +38,8 @@
       {% endblock license_content_inner %}
     </p>
     <p>
-      {% if h.get_translated(license._data, 'description') %}{{ h.get_translated(license._data, 'description') }}{% endif %}
+      {% set lic_desc = h.get_translated(license, 'description') %}
+      {% if lic_desc %}{{ lic_desc }}{% endif %}
     </p>
   {% endif %}
 {% endblock license_content %}

--- a/ckanext/ontario_theme/templates/internal/snippets/translate_facets.html
+++ b/ckanext/ontario_theme/templates/internal/snippets/translate_facets.html
@@ -11,6 +11,6 @@
   {% set scheming_choices = scheming_choices or h.scheming_field_by_name(fields, name).choices or None %}
 {% endif %}
 {% do item.update({'display_name': h.scheming_choices_label(scheming_choices, item.display_name)}) if scheming_choices %}
-{% do item.update({'display_name': h.get_translated( h.ontario_theme_get_license(item.name)._data, "title" )}) if name == "license_id" %}
+{% do item.update({'display_name': h.get_translated( h.ontario_theme_get_license(item.name), "title" )}) if name == "license_id" %}
 {% do item.update({'display_name': h.get_translated( h.get_organization(item.name), "title") or item.display_name}) if name == "organization" %}
 {% do item.update({'display_name': h.get_translated( h.ontario_theme_get_group(item.name), "title") or item.display_name}) if name == "groups" %}

--- a/ckanext/ontario_theme/tests/test_helpers.py
+++ b/ckanext/ontario_theme/tests/test_helpers.py
@@ -25,7 +25,7 @@ class TestGetLicense(object):
             os.path.dirname(__file__), '../schemas', 'licences.json')
         ) as licenses:
             license = json.load(licenses)[0]
-        assert get_license("OGL-ON-1.0")._data == license
+        assert get_license("OGL-ON-1.0") == license
 
 
 @pytest.mark.usefixtures('clean_db', 'clean_index', 'with_plugins', 'with_request_context') 


### PR DESCRIPTION
## What this PR accomplishes
CKAN 2.11 replaced license objects with dictionaries, so any calling of `._data` will throw an error. This PR replaces the legacy sytnax in the entire code base and adds a check to `get_license()` to ensure that a dictionary is returned, even in the case of empty license.

These fixes allow a dataset page or resource page with no license to load.

## Issue(s) addressed
DATA-1733, DATA-1729 (seems that PR #631 did not fix the issue)

## What needs review
-   verify that a dataset and a resource with no license can be accessed from home page (Dataset page is currently not working so don't try from there)
- verify that datasets and resources with a license still work
-   test EN and FR
