### PR TITLE
Fix missing Ministries from Ministries page

### DIFF
--- a/ckanext/ontario_theme/fanstatic/common.css
+++ b/ckanext/ontario_theme/fanstatic/common.css
@@ -1344,6 +1344,12 @@ a:focus {
   border-bottom-right-radius: 0;
 }
 
+.ontario-application-subheader__menu a[aria-current="page"] {
+  border-bottom: 4px solid #fff;
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
 .ontario-application-subheader-menu__container .ontario-header-button--with-outline {
   top: calc(-4rem + -0.25rem);
 }

--- a/ckanext/ontario_theme/plugin.py
+++ b/ckanext/ontario_theme/plugin.py
@@ -1177,7 +1177,7 @@ type data_last_updated
             view_func=OntarioThemeResourceEditView.as_view(str(u'edit')), defaults={u'package_type': u'dataset'}
         )
         blueprint.add_url_rule(u'/dataset/<id>/dictionary/<resource_id>',view_func=DictionaryView.as_view(str(u'dictionary')))
-        blueprint.add_url_rule(u'/organization', endpoint='organization.index', view_func=organization_index, strict_slashes=False
+        blueprint.add_url_rule(u'/organization', endpoint='organization.index', view_func=organization_index, strict_slashes=False)
 
         return blueprint
 

--- a/ckanext/ontario_theme/plugin.py
+++ b/ckanext/ontario_theme/plugin.py
@@ -1177,7 +1177,7 @@ type data_last_updated
             view_func=OntarioThemeResourceEditView.as_view(str(u'edit')), defaults={u'package_type': u'dataset'}
         )
         blueprint.add_url_rule(u'/dataset/<id>/dictionary/<resource_id>',view_func=DictionaryView.as_view(str(u'dictionary')))
-        blueprint.add_url_rule(u'/organization', endpoint='organization.index', view_func=organization_index, strict_slashes=False)
+        blueprint.add_url_rule(u'/organization', endpoint='organization_index', view_func=organization_index, strict_slashes=False)
 
         return blueprint
 

--- a/ckanext/ontario_theme/plugin.py
+++ b/ckanext/ontario_theme/plugin.py
@@ -1177,6 +1177,7 @@ type data_last_updated
             view_func=OntarioThemeResourceEditView.as_view(str(u'edit')), defaults={u'package_type': u'dataset'}
         )
         blueprint.add_url_rule(u'/dataset/<id>/dictionary/<resource_id>',view_func=DictionaryView.as_view(str(u'dictionary')))
+        blueprint.add_url_rule(u'/organization', endpoint='organization.index', view_func=organization_index, strict_slashes=False
 
         return blueprint
 

--- a/ckanext/ontario_theme/templates/internal/header.html
+++ b/ckanext/ontario_theme/templates/internal/header.html
@@ -124,14 +124,10 @@
                 <ul id="navigation"
                     class="ontario-application-subheader__menu ontario-show-for-large">
                   {% block header_site_navigation_tabs %}
-                    {{ h.build_nav_main(('dataset.search', _('Datasets'))) }}
-                    {% set ministries_active =
-                            request.path.startswith('/organization')
-                            or (request.blueprint is defined and request.blueprint in ['organization', 'ontario_theme']) %}
-                    <li class="{{'active' if ministries_active else ''}}">
-                      <a href="{{ h.url_for('organization.index') }}">{{ _('Ministries') }}</a>
-                    </li>
-                    {{ h.build_nav_main(('home.about', _('About'))) }}
+                    {{ h.build_nav_main(
+                    ('dataset.search', _('Datasets')),
+                    ('ontario_theme.organization_index', _('Ministries')),
+                    ('home.about', _('About')) ) }}
                   {% endblock header_site_navigation_tabs %}
                 </ul>
                 {% block header_site_search %}
@@ -199,13 +195,9 @@
 
                 <ul id="medium-navigation"
                     class="ontario-application-subheader__menu ontario-hide-for-small ontario-show-for-medium ontario-hide-for-large">
-                  {{ h.build_nav_main(('dataset.search', _('Datasets'))) }}
-                  {% set ministries_active =
-                          request.path.startswith('/organization')
-                          or (request.blueprint is defined and request.blueprint in ['organization', 'ontario_theme']) %}
-                  <li class="{{'active' if ministries_active else ''}}">
-                    <a href="{{ h.url_for('organization.index') }}">{{ _('Ministries') }}</a>
-                  </li>
+                  {{ h.build_nav_main(
+                  ('dataset.search', _('Datasets')),
+                  ('ontario_theme.organization_index', _('Ministries')) ) }}
                 </ul>
                 <button class="ontario-hide-for-large ontario-header__menu-toggler ontario-header-button ontario-header-button--with-outline {{ 'fr' if current_lang == 'fr' }}"
                         id="ontario-header-menu-toggler"
@@ -240,14 +232,10 @@
         </button>
         <div class="ontario-navigation__container ontario-hide-for-large">
           <ul>
-            {{ h.build_nav_main(('dataset.search', _('Datasets'))) }}
-            {% set ministries_active =
-                    request.path.startswith('/organization')
-                    or (request.blueprint is defined and request.blueprint in ['organization', 'ontario_theme']) %}
-            <li class="{{'active' if ministries_active else ''}}">
-              <a href="{{ h.url_for('organization.index') }}">{{ _('Ministries') }}</a>
-            </li>
-            {{ h.build_nav_main(('home.about', _('About'))) }}
+            {{ h.build_nav_main(
+            ('dataset.search', _('Datasets')),
+            ('ontario_theme.organization_index', _('Ministries')),
+            ('home.about', _('About')) ) }}
           </ul>
         </div>
       </nav>

--- a/ckanext/ontario_theme/templates/internal/header.html
+++ b/ckanext/ontario_theme/templates/internal/header.html
@@ -124,10 +124,14 @@
                 <ul id="navigation"
                     class="ontario-application-subheader__menu ontario-show-for-large">
                   {% block header_site_navigation_tabs %}
-                    {{ h.build_nav_main(
-                    ('dataset.search', _('Datasets')),
-                    ('organization.index', _('Ministries')),
-                    ('home.about', _('About')) ) }}
+                    {{ h.build_nav_main(('dataset.search', _('Datasets'))) }}
+                    {% set ministries_active =
+                            request.path.startswith('/organization')
+                            or (request.blueprint is defined and request.blueprint in ['organization', 'ontario_theme']) %}
+                    <li class="{{'active' if ministries_active else ''}}">
+                      <a href="{{ h.url_for('organization.index') }}">{{ _('Ministries') }}</a>
+                    </li>
+                    {{ h.build_nav_main(('home.about', _('About'))) }}
                   {% endblock header_site_navigation_tabs %}
                 </ul>
                 {% block header_site_search %}
@@ -195,9 +199,13 @@
 
                 <ul id="medium-navigation"
                     class="ontario-application-subheader__menu ontario-hide-for-small ontario-show-for-medium ontario-hide-for-large">
-                  {{ h.build_nav_main(
-                  ('dataset.search', _('Datasets')),
-                  ('organization.index', _('Ministries')) ) }}
+                  {{ h.build_nav_main(('dataset.search', _('Datasets'))) }}
+                  {% set ministries_active =
+                          request.path.startswith('/organization')
+                          or (request.blueprint is defined and request.blueprint in ['organization', 'ontario_theme']) %}
+                  <li class="{{'active' if ministries_active else ''}}">
+                    <a href="{{ h.url_for('organization.index') }}">{{ _('Ministries') }}</a>
+                  </li>
                 </ul>
                 <button class="ontario-hide-for-large ontario-header__menu-toggler ontario-header-button ontario-header-button--with-outline {{ 'fr' if current_lang == 'fr' }}"
                         id="ontario-header-menu-toggler"
@@ -232,10 +240,14 @@
         </button>
         <div class="ontario-navigation__container ontario-hide-for-large">
           <ul>
-            {{ h.build_nav_main(
-            ('dataset.search', _('Datasets')),
-            ('organization.index', _('Ministries')),
-            ('home.about', _('About')) ) }}
+            {{ h.build_nav_main(('dataset.search', _('Datasets'))) }}
+            {% set ministries_active =
+                    request.path.startswith('/organization')
+                    or (request.blueprint is defined and request.blueprint in ['organization', 'ontario_theme']) %}
+            <li class="{{'active' if ministries_active else ''}}">
+              <a href="{{ h.url_for('organization.index') }}">{{ _('Ministries') }}</a>
+            </li>
+            {{ h.build_nav_main(('home.about', _('About'))) }}
           </ul>
         </div>
       </nav>


### PR DESCRIPTION
## What this PR accomplishes
- Resolves the issue of incomplete ministries list on /organizations/ page

## Issue(s) addressed
DATA-1576

## What needs review
- Navigation between pages works
- Ministries page (/organizations) has complete list of ministries
- Nav bar accessibility issues from DATA-1534 do not return