### PR TITLE
Add WEB as Resource File Type Option for Remote Links

### DIFF
--- a/ckanext/ontario_theme/plugin.py
+++ b/ckanext/ontario_theme/plugin.py
@@ -648,6 +648,36 @@ def get_license(license_id):
     return Package.get_license_register().get(license_id)
 
 
+def get_accepted_format_options():
+    '''Helper to return accepted resource format options for select dropdown.
+    Reads from accepted_resource_formats.json and returns a list of dicts
+    with 'value' (format extension) and 'text' (description) keys.
+    '''
+    import os
+    resource_format_path = os.path.join(os.path.dirname(__file__),
+                                        'accepted_resource_formats.json')
+    options = []
+    try:
+        with open(resource_format_path) as format_file:
+            file_resource_formats = json.loads(format_file.read())
+            for format_line in file_resource_formats:
+                ext = (format_line[0] or '').upper()
+                desc = format_line[1] if len(format_line) > 1 else ext
+                if ext:
+                    # Display as "EXT - Description" for better UX
+                    display_text = u'{0} - {1}'.format(ext, desc) if desc else ext
+                    options.append({'value': ext, 'text': display_text})
+    except Exception:
+        pass
+        # Add 'WEB' as an extra option for remote links
+        options.append({'value': 'WEB', 'text': 'Remote Link (WEB)'})
+    # Add 'WEB' as an extra option for remote links if not already present
+    if not any(opt['value'] == 'WEB' for opt in options):
+        options.append({'value': 'WEB', 'text': 'WEB- Remote Link'})
+    print("[DEBUG] get_accepted_format_options called. Options:", options)
+    return options
+
+
 def get_current_year():
     return datetime.datetime.today().strftime('%Y')
 


### PR DESCRIPTION
## [Task]: Add WEB as Resource File Type Option for Remote Links

### What this PR accomplishes

- Added `WEB` as an additional option in the **Resource File Type** dropdown for remote links.
- Updated `get_accepted_format_options()` in `plugin.py` to dynamically append `WEB` at runtime.
- Since `WEB` is not a MIME type or standard file type, it is **not** included in `accepted_resource_formats.json`. Instead, it is appended dynamically in the plugin to allow users to select `WEB` when adding resources that are remote URLs.
- Ensured that standard MIME type validation logic remains unaffected by this addition.

### Issue(s) Addressed

- DATA-1765

### What Needs Review

- Verify that `WEB` appears in the **Format** dropdown when adding or editing a resource.
- Select `WEB` for a resource with a remote URL and confirm that:
  - The selection saves correctly.
  - The selected format displays as expected after saving.
- Verify that other file format options continue to function normally.
- Confirm that MIME type validation behavior is not affected by the dynamic addition of `WEB`.

