### PR TITLE
Restore ministry route with css for navbar

### DIFF
--- a/ckanext/ontario_theme/fanstatic/common.css
+++ b/ckanext/ontario_theme/fanstatic/common.css
@@ -1344,6 +1344,12 @@ a:focus {
   border-bottom-right-radius: 0;
 }
 
+.ontario-application-subheader__menu a[aria-current="page"] {
+  border-bottom: 4px solid #fff;
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
 .ontario-application-subheader-menu__container .ontario-header-button--with-outline {
   top: calc(-4rem + -0.25rem);
 }

--- a/ckanext/ontario_theme/templates/internal/header.html
+++ b/ckanext/ontario_theme/templates/internal/header.html
@@ -124,14 +124,10 @@
                 <ul id="navigation"
                     class="ontario-application-subheader__menu ontario-show-for-large">
                   {% block header_site_navigation_tabs %}
-                    {{ h.build_nav_main(('dataset.search', _('Datasets'))) }}
-                    {% set ministries_active =
-                            request.path.startswith('/organization')
-                            or (request.blueprint is defined and request.blueprint in ['organization', 'ontario_theme']) %}
-                    <li class="{{'active' if ministries_active else ''}}">
-                      <a href="{{ h.url_for('organization.index') }}">{{ _('Ministries') }}</a>
-                    </li>
-                    {{ h.build_nav_main(('home.about', _('About'))) }}
+                    {{ h.build_nav_main(
+                    ('dataset.search', _('Datasets')),
+                    ('ontario_theme.organization_index', _('Ministries')),
+                    ('home.about', _('About')) ) }}
                   {% endblock header_site_navigation_tabs %}
                 </ul>
                 {% block header_site_search %}
@@ -199,13 +195,9 @@
 
                 <ul id="medium-navigation"
                     class="ontario-application-subheader__menu ontario-hide-for-small ontario-show-for-medium ontario-hide-for-large">
-                  {{ h.build_nav_main(('dataset.search', _('Datasets'))) }}
-                  {% set ministries_active =
-                          request.path.startswith('/organization')
-                          or (request.blueprint is defined and request.blueprint in ['organization', 'ontario_theme']) %}
-                  <li class="{{'active' if ministries_active else ''}}">
-                    <a href="{{ h.url_for('organization.index') }}">{{ _('Ministries') }}</a>
-                  </li>
+                  {{ h.build_nav_main(
+                  ('dataset.search', _('Datasets')),
+                  ('ontario_theme.organization_index', _('Ministries')) ) }}
                 </ul>
                 <button class="ontario-hide-for-large ontario-header__menu-toggler ontario-header-button ontario-header-button--with-outline {{ 'fr' if current_lang == 'fr' }}"
                         id="ontario-header-menu-toggler"
@@ -240,14 +232,10 @@
         </button>
         <div class="ontario-navigation__container ontario-hide-for-large">
           <ul>
-            {{ h.build_nav_main(('dataset.search', _('Datasets'))) }}
-            {% set ministries_active =
-                    request.path.startswith('/organization')
-                    or (request.blueprint is defined and request.blueprint in ['organization', 'ontario_theme']) %}
-            <li class="{{'active' if ministries_active else ''}}">
-              <a href="{{ h.url_for('organization.index') }}">{{ _('Ministries') }}</a>
-            </li>
-            {{ h.build_nav_main(('home.about', _('About'))) }}
+            {{ h.build_nav_main(
+            ('dataset.search', _('Datasets')),
+            ('ontario_theme.organization_index', _('Ministries')),
+            ('home.about', _('About')) ) }}
           </ul>
         </div>
       </nav>


### PR DESCRIPTION
## What this PR accomplishes
Re-adds back the route removed in [DATA-1534](https://github.com/ongov/ckanext-ontario_theme/pull/595/changes#diff-880c2924b3a174b3db1a7c3ebbf5ecefc75904ae778e7f187e37586685aff9a3) while preserving the navbar underline and accessibility through CSS rules.

## Issue(s) addressed
DATA-1576, DATA-1534

## What needs review
Test that:
- all ministires are loaded on Ministries page in EN and FR
- sorting asc and desc still shows all Ministries in EN and FR
- the underline is displayed in the navbar when on the Ministries page in EN and FR

[DATA-1534]: https://ontariodigital.atlassian.net/browse/DATA-1534?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ