### PR TITLE
DATA-1777: Fix broken About page link to Open Data Guidebook

### DIFF
--- a/ckanext/ontario_theme/templates/external/home/snippets/about_text.html
+++ b/ckanext/ontario_theme/templates/external/home/snippets/about_text.html
@@ -187,7 +187,7 @@
       <a href="#other-data">Read more about non-open data.</a>
     </p>
     <p>
-      <a href="https://www.ontario.ca/document/open-data-guidebook-guide-open-data-directive-2015/data-inventory#section-1">
+      <a href="https://www.ontario.ca/document/open-data-guidebook-guide-open-data-directive/data-inventory#section-1">
         Read more about restricted data.
       </a>
     </p>


### PR DESCRIPTION
## What this PR accomplishes
- Fixes a broken link on the About page under "Read more about restricted data".

## Issue(s) addressed
- DATA-1777

## What needs to be reviewed
- Verify that the About page displays correctly
- Confirm that the updated link redirects to the correct section