### PR TITLE
DATA-1812: Recently updated sorting fix

### DIFF
--- a/ckanext/ontario_theme/templates/external/home/snippets/about_text.html
+++ b/ckanext/ontario_theme/templates/external/home/snippets/about_text.html
@@ -187,7 +187,7 @@
       <a href="#other-data">Read more about non-open data.</a>
     </p>
     <p>
-      <a href="https://www.ontario.ca/document/open-data-guidebook-guide-open-data-directive-2015/data-inventory#section-1">
+      <a href="https://www.ontario.ca/document/open-data-guidebook-guide-open-data-directive/data-inventory#section-1">
         Read more about restricted data.
       </a>
     </p>

--- a/ckanext/ontario_theme/templates/internal/package/search.html
+++ b/ckanext/ontario_theme/templates/internal/package/search.html
@@ -41,7 +41,7 @@ in the core template for search.html.
               (_('Name Ascending'), 'titles asc'),
               (_('Name Descending'), 'titles desc'),
               (_('Last Modified'), 'metadata_modified desc'),
-              (_('Recently Created'), 'dataset_published_date desc'),
+              (_('Recently Created'), 'metadata_created desc'),
             (_('Popular'), 'views_recent desc') if g.tracking_enabled else (false, false) ] %}
       <!-- arguments for DS search bar -->
       {% set input_text = _('Search ' + dataset_type + 's') %}

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # http://packaging.python.org/en/latest/tutorial.html#version
-    version='3.0.21',
+    version='3.0.22',
 
     description='''Theme for internal CKAN build.''',
     long_description=long_description,

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # http://packaging.python.org/en/latest/tutorial.html#version
-    version='3.0.22',
+    version='3.0.21',
 
     description='''Theme for internal CKAN build.''',
     long_description=long_description,


### PR DESCRIPTION
## What this PR accomplishes
- Fixes incorrect sorting behavior for “Recently Created” datasets
- Updates sorting field from `dataset_published_date` to `metadata_created`
- Ensures datasets are ordered correctly from newest to oldest
- Aligns UI label (“Recently Created”) with actual sorting logic

## Issue(s) addressed
- DATA-1812

##  What needs to be reviewed
- Verify “Recently Created” displays datasets in correct descending order (newest created→ oldest created)
- Confirm no older datasets appear at the top of the list
- Ensure other sorting options are unaffected

<img width="1607" height="890" alt="Screenshot 2026-06-15 091728" src="https://github.com/user-attachments/assets/ec1b3ce7-f918-4fa5-b408-f0eb638c107d" />
