### PR TITLE
DATA-480: Test Case Cleaning

### DIFF
--- a/ckanext/ontario_theme/templates/external/home/snippets/about_text.html
+++ b/ckanext/ontario_theme/templates/external/home/snippets/about_text.html
@@ -187,7 +187,7 @@
       <a href="#other-data">Read more about non-open data.</a>
     </p>
     <p>
-      <a href="https://www.ontario.ca/document/open-data-guidebook-guide-open-data-directive-2015/data-inventory#section-1">
+      <a href="https://www.ontario.ca/document/open-data-guidebook-guide-open-data-directive/data-inventory#section-1">
         Read more about restricted data.
       </a>
     </p>

--- a/ckanext/ontario_theme/tests/test_before_search.py
+++ b/ckanext/ontario_theme/tests/test_before_search.py
@@ -9,7 +9,7 @@ from ckanext.ontario_theme.plugin import (
   num_resources_filter_scrub
 )
 
-@pytest.mark.usefixtures('clean_db', 'with_plugins', 'with_request_context')
+@pytest.mark.usefixtures('with_plugins', 'with_request_context')
 class TestBeforeSearch(object):
   def test_before_search_with_good_value(self):
     u'''If search_params given num_resources remove double quotes around

--- a/ckanext/ontario_theme/tests/test_create_dataset.py
+++ b/ckanext/ontario_theme/tests/test_create_dataset.py
@@ -12,6 +12,7 @@ import pytest
 
 import ckan.lib.navl.dictization_functions as df
 import datetime
+import uuid
 
 import ckanext.ontario_theme.plugin as ontario_theme
 
@@ -21,7 +22,7 @@ import ckan.tests.factories as factories
 import ckan.logic as logic
 
 
-@pytest.mark.usefixtures('clean_db', 'with_plugins', 'with_request_context')  
+@pytest.mark.usefixtures('with_plugins', 'with_request_context')  
 class TestCreateDataset(object):
     '''Ensure dataset creates still work and don't work as expected.
     '''
@@ -32,7 +33,7 @@ class TestCreateDataset(object):
         org = factories.Organization()
         dataset = helpers.call_action(
             'package_create',
-            name = 'package-name',
+            name = f'package-name-{uuid.uuid4().hex}',
             maintainer_translated = {
                 'en': u'Joe Smith',
                 'fr': u'...'
@@ -48,7 +49,7 @@ class TestCreateDataset(object):
             },
             owner_org = org['name'] # depends on config.
         )
-        assert dataset['name'] == 'package-name'
+        assert dataset['name'].startswith('package-name-')
 
         dataset = helpers.call_action('package_show', id=dataset['id'])
         assert dataset['title_translated']['fr'] == u'Un novel par Tolstoy'
@@ -63,7 +64,7 @@ class TestCreateDataset(object):
         org = factories.Organization()
         dataset = helpers.call_action(
             'package_create',
-            name = 'package-name',
+            name = f'package-name-{uuid.uuid4().hex}',
             maintainer_translated = {
                 'en': u'Joe Smith',
                 'fr': u'...'
@@ -80,7 +81,7 @@ class TestCreateDataset(object):
             access_level= u'open',
             owner_org = org['name'] # depends on config.
         )
-        assert dataset['name'] == 'package-name'
+        assert dataset['name'].startswith('package-name-')
 
         dataset = helpers.call_action('package_show', id=dataset['id'])
         assert dataset['title_translated']['fr'] == u'Un novel par Tolstoy'
@@ -96,7 +97,7 @@ class TestCreateDataset(object):
         org = factories.Organization()
         dataset = helpers.call_action(
             'package_create',
-            name = 'package-name',
+            name = f'package-name-{uuid.uuid4().hex}',
             maintainer_translated = {
                 'en': u'Joe Smith',
                 'fr': u'...'
@@ -140,7 +141,7 @@ class TestCreateDataset(object):
             org = factories.Organization()
             dataset = helpers.call_action(
                 'package_create',
-                name = 'package-name',
+                name = f'package-name-{uuid.uuid4().hex}',
                 maintainer_translated = {
                     'en': u'Joe Smith',
                     'fr': u'...'
@@ -162,7 +163,7 @@ class TestCreateDataset(object):
             )
         except logic.ValidationError as e:
             update_frequency_values = ["Value must be one of ['as_required', 'biannually', 'current', 'daily', 'historical', 'monthly', 'never', 'on_demand', 'other', 'periodically', 'quarterly', 'weekly', 'yearly', 'quinquennial']"]
-                                        
+
             assert e.error_dict['update_frequency'] == update_frequency_values
 
         else:
@@ -185,7 +186,7 @@ class TestCreateDataset(object):
             org = factories.Organization()
             dataset = helpers.call_action(
                 'package_create',
-                name = 'package-name',
+                name = f'package-name-{uuid.uuid4().hex}',
                 maintainer_translated = {
                     'en': u'Joe Smith',
                     'fr': u'...'

--- a/ckanext/ontario_theme/tests/test_helpers.py
+++ b/ckanext/ontario_theme/tests/test_helpers.py
@@ -4,6 +4,7 @@
 '''
 
 import pytest
+import uuid
 
 import json
 import os
@@ -16,7 +17,7 @@ from ckanext.ontario_theme.plugin import (
     get_package_keywords
 )
 
-@pytest.mark.usefixtures('clean_db', 'clean_index', 'with_plugins', 'with_request_context') 
+@pytest.mark.usefixtures('with_plugins', 'with_request_context') 
 class TestGetLicense(object):
     def test_get_license_returns_proper_value(self):
         '''Ensure get_license returns proper license object from licences.json.
@@ -28,7 +29,7 @@ class TestGetLicense(object):
         assert get_license("OGL-ON-1.0")._data == license
 
 
-@pytest.mark.usefixtures('clean_db', 'clean_index', 'with_plugins', 'with_request_context') 
+@pytest.mark.usefixtures('with_plugins', 'with_request_context') 
 class TestDefaultLocale(object):
     def test_default_locale_returns_proper_value(self):
         default = config.get('ckan.locale_default', 'en')
@@ -41,7 +42,7 @@ class TestGetPackageKeywords(object):
         org = factories.Organization()
         dataset = helpers.call_action(
             'package_create',
-            name = 'package-name',
+            name = f'package-name-{uuid.uuid4().hex}',
             access_level = 'restricted',
             maintainer_translated = {
                 'en': u'Joe Smith',
@@ -60,7 +61,7 @@ class TestGetPackageKeywords(object):
             keywords={'en': [u'English Tag'], 'fr': [u'French Tag']}
         )
         # Make sure package was returned as expected.
-        assert dataset['name'] == 'package-name'
+        assert dataset['name'].startswith('package-name-')
         # Expected keyword list based on dataset above.
         keywords = [{
                 'count': 1,
@@ -74,7 +75,7 @@ class TestGetPackageKeywords(object):
         org = factories.Organization()
         dataset = helpers.call_action(
             'package_create',
-            name = 'package-name',
+            name = f'package-name-{uuid.uuid4().hex}',
             access_level = 'restricted',
             maintainer_translated = {
                 'en': u'Joe Smith',
@@ -96,7 +97,7 @@ class TestGetPackageKeywords(object):
             }
         )
         # Make sure package was returned as expected.
-        assert dataset['name'] == 'package-name'
+        assert dataset['name'].startswith('package-name-')
         # Expected keyword list based on dataset above.
         keywords = [{
                 'count': 1,
@@ -110,7 +111,7 @@ class TestGetPackageKeywords(object):
         org = factories.Organization()
         dataset = helpers.call_action(
             'package_create',
-            name = 'package-name',
+            name = f'package-name-{uuid.uuid4().hex}',
             access_level = 'restricted',
             maintainer_translated = {
                 'en': u'Joe Smith',
@@ -132,7 +133,7 @@ class TestGetPackageKeywords(object):
             }
         )
         # Make sure package was returned as expected.
-        assert dataset['name'] == 'package-name'
+        assert dataset['name'].startswith('package-name-')
         # Expected keyword list based on dataset above.
         keywords = [{
                 'count': 1,
@@ -146,7 +147,7 @@ class TestGetPackageKeywords(object):
         org = factories.Organization()
         dataset = helpers.call_action(
             'package_create',
-            name = 'package-name',
+            name = f'package-name-{uuid.uuid4().hex}',
             access_level = 'restricted',
             maintainer_translated = {
                 'en': u'Joe Smith',
@@ -168,7 +169,7 @@ class TestGetPackageKeywords(object):
             }
         )
         # Make sure package was returned as expected.
-        assert dataset['name'] == 'package-name'
+        assert dataset['name'].startswith('package-name-')
         # Expected keyword list based on dataset above.
         keywords = [{
                 'count': 1,

--- a/ckanext/ontario_theme/tests/test_plugin.py
+++ b/ckanext/ontario_theme/tests/test_plugin.py
@@ -5,7 +5,7 @@ import pytest
 import datetime
 import ckan.tests.helpers as helpers
 
-@pytest.mark.usefixtures('clean_db', 'with_plugins', 'with_request_context','app')
+@pytest.mark.usefixtures('with_plugins', 'with_request_context','app')
 class TestOntarioThemePlugin(helpers.FunctionalTestBase):
 
     def setup(self):

--- a/ckanext/ontario_theme/tests/test_resource_upload.py
+++ b/ckanext/ontario_theme/tests/test_resource_upload.py
@@ -50,7 +50,7 @@ class TestResourceCreate(object):
     @mock.patch.object(builtins, 'open', side_effect=mock_open_if_open_fails)
     @mock.patch.object(ckan.lib.uploader, '_storage_path', new='doesnt_exist')
     @pytest.mark.ckan_config('ckan.plugins', 'ontario_theme_external ontario_theme scheming_datasets scheming_organizations scheming_groups fluent')
-    @pytest.mark.usefixtures('clean_db', 'with_plugins', 'with_request_context','create_with_upload') 
+    @pytest.mark.usefixtures('with_plugins', 'with_request_context','create_with_upload') 
     def test_mimetype_by_upload_by_filename(self, mock_open, create_with_upload):
         '''
         The type is determined using python magic which checks file

--- a/ckanext/ontario_theme/tests/test_update_dataset.py
+++ b/ckanext/ontario_theme/tests/test_update_dataset.py
@@ -9,11 +9,12 @@ being done here. Refactor if / when tests become more complex.
 '''
 
 import pytest 
+import uuid
 
 from ckan.tests import factories
 import ckan.tests.helpers as helpers
 
-@pytest.mark.usefixtures('clean_db', 'with_plugins', 'with_request_context')
+@pytest.mark.usefixtures('with_plugins', 'with_request_context')
 class TestUpdateDataset(object):
     '''Ensure dataset updates still work and don't work as expected.
     '''
@@ -25,7 +26,7 @@ class TestUpdateDataset(object):
         user = factories.User()
         dataset = factories.Dataset(
             user = user,
-            name = 'package-name',
+            name = f'package-name-{uuid.uuid4().hex}',
             maintainer_translated = {
                 'en': u'Joe Smith',
                 'fr': u'...'
@@ -42,12 +43,12 @@ class TestUpdateDataset(object):
             access_level = u'restricted',
             owner_org = org['name'] # depends on config.
         )
-        
+
         # All required fields needed here as this is update not patch.
         dataset_ = helpers.call_action(
             'package_update',
             id = dataset['id'],
-            name = 'new-name',
+            name = f'new-name-{uuid.uuid4().hex}',
             maintainer_translated = {
                 'en': u'Jane Smith',
                 'fr': u'...'
@@ -65,11 +66,11 @@ class TestUpdateDataset(object):
         )
 
         # Make sure update works and returns saved value.
-        assert dataset_['name'] == 'new-name'
+        assert dataset_['name'].startswith('new-name-')
 
         # Safe measure - query the package again and validate values.
         dataset_ = helpers.call_action('package_show', id=dataset['id'])
-        assert dataset_['name'] == 'new-name'
+        assert dataset_['name'].startswith('new-name-')
         assert dataset_['maintainer_translated']['en'] == 'Jane Smith'
         assert dataset_['maintainer_email'] == 'Jane.Smith@ontario.ca'
         assert dataset_['notes_translated']['en'] == 'shorter description'
@@ -84,7 +85,7 @@ class TestUpdateDataset(object):
         user = factories.User()
         dataset = factories.Dataset(
             user = user,
-            name = 'package-name',
+            name = f'package-name-{uuid.uuid4().hex}',
             maintainer_translated = {
                 'en': u'Joe Smith',
                 'fr': u'...'
@@ -107,7 +108,7 @@ class TestUpdateDataset(object):
         dataset_ = helpers.call_action(
             'package_update',
             id = dataset['id'],
-            name = 'package-name',
+            name = f'package-name-{uuid.uuid4().hex}',
             maintainer_translated = {
                 'en': u'Jane Smith',
                 'fr': u'...'
@@ -127,7 +128,7 @@ class TestUpdateDataset(object):
             access_level ='open',
             exemption = '' # Defaults to none when key provided and value is empty.
         )
-        
+
         package_show = helpers.call_action('package_show', id=dataset['id'])
         assert dataset_['maintainer_translated']['en'] == 'Jane Smith'
         assert dataset_['maintainer_email'] == 'Jane.Smith@ontario.ca'

--- a/ckanext/ontario_theme/tests/test_validators.py
+++ b/ckanext/ontario_theme/tests/test_validators.py
@@ -4,13 +4,14 @@
 '''
 
 import pytest
+import uuid
 
 import ckan.tests.factories as factories
 import ckan.logic as logic
 
 import ckan.tests.helpers as helpers
 
-@pytest.mark.usefixtures('clean_db', 'clean_index', 'with_plugins', 'with_request_context')  
+@pytest.mark.usefixtures('with_plugins', 'with_request_context')  
 class TestOntarioThemeCopyFluentKeywordsToTags(object):
     '''Ensure Fluent multi-lingual keywords are copied to CKAN core Tags.
     '''
@@ -25,7 +26,7 @@ class TestOntarioThemeCopyFluentKeywordsToTags(object):
         org = factories.Organization()
         dataset = helpers.call_action(
             'package_create',
-            name = 'package-name',
+            name = f'package-name-{uuid.uuid4().hex}',
             access_level = 'restricted',
             maintainer_translated = {
                 'en': u'Joe Smith',
@@ -54,7 +55,7 @@ class TestOntarioThemeCopyFluentKeywordsToTags(object):
             }
         assert dataset['keywords'] == comparative_keywords
         assert sorted([tag['name'] for tag in dataset['tags']]) == [u'...', u'English', u'Français', u'Language']
-        
+
         assert helpers.call_action('tag_autocomplete', query='Engl') == [u'English']
 
 @pytest.mark.usefixtures('clean_db', 'with_plugins', 'with_request_context')
@@ -71,7 +72,7 @@ class TestOntarioThemeTagNameValidator(object):
         org = factories.Organization()
         dataset = helpers.call_action(
             'package_create',
-            name = 'package-name',
+            name = f'package-name-{uuid.uuid4().hex}',
             access_level = 'restricted',
             maintainer_translated = {
                 'en': u'Joe Smith',
@@ -116,7 +117,7 @@ class TestOntarioThemeTagNameValidator(object):
         org = factories.Organization()
         dataset = helpers.call_action(
             'package_create',
-            name = 'package-name',
+            name = f'package-name-{uuid.uuid4().hex}',
             access_level = 'restricted',
             maintainer_translated = {
                 'en': u'Joe Smith',
@@ -163,7 +164,7 @@ class TestOntarioThemeTagNameValidator(object):
             org = factories.Organization()
             dataset = helpers.call_action(
                 'package_create',
-                name = 'package-name',
+                name = f'package-name-{uuid.uuid4().hex}',
                 access_level = 'restricted',
                 maintainer_translated = {
                     'en': u'Joe Smith',
@@ -210,7 +211,7 @@ class TestOntarioThemeTagNameValidator(object):
             org = factories.Organization()
             dataset = helpers.call_action(
                 'package_create',
-                name = 'package-name',
+                name = f'package-name-{uuid.uuid4().hex}',
                 access_level = 'restricted',
                 maintainer_translated = {
                     'en': u'Joe Smith',
@@ -247,4 +248,4 @@ class TestOntarioThemeTagNameValidator(object):
 
         except logic.ValidationError as e:
             assert e.error_dict['keywords'] == [u'Tag "Languages, dialects and locales" may not contain commas']
-            
+

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # http://packaging.python.org/en/latest/tutorial.html#version
-    version='3.0.21',
+    version='3.0.22',
 
     description='''Theme for internal CKAN build.''',
     long_description=long_description,

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # http://packaging.python.org/en/latest/tutorial.html#version
-    version='3.0.22',
+    version='3.0.21',
 
     description='''Theme for internal CKAN build.''',
     long_description=long_description,


### PR DESCRIPTION
## What this PR accomplishes

- Removed unnecessary `clean_db` and `clean_index` fixtures from test cases that do not depend on database or search-index state.
- Replaced static dataset names with UUID-based names to avoid test conflicts and improve test reliability.
- Updated affected test assertions to work with dynamically generated dataset names.
- Verified that all test cases continue to pass after these changes.

## Issue(s) addressed

- DATA-480

## What needs to be reviewed

- Verify all test suites continue to pass without the removed fixtures.
- Verify UUID-based dataset names do not introduce any regressions.
- Verify test behavior remains unchanged apart from improved isolation and reliability.
- Review the fixture removals to ensure database/search-index cleanup is only retained where required.

## Notes

During implementation, we discussed in stand-ups that `TestGetPackageKeywords` in `test_helpers.py` could not safely have `clean_db` and `clean_index` removed without additional work.

This test relies on keyword facet results returned by `package_search()`. When the fixtures were removed, keyword data persisted between tests, causing counts to accumulate and resulting in test failures. Several approaches were investigated, but the issue appears to require additional refactoring (likely a separate ticket) before those fixtures can be removed safely.

As a result, `clean_db` and `clean_index` were retained for `TestGetPackageKeywords`, while unnecessary usages were removed from the remaining test files.