### PR TITLE
DATA-1556: Broken Link Fix to "Ontario Open Data Terms Use" Licence Webpage

### DIFF
--- a/ckanext/ontario_theme/schemas/licences.json
+++ b/ckanext/ontario_theme/schemas/licences.json
@@ -150,9 +150,9 @@
         "en": "Ontario Open Data Terms of Use",
         "fr": "Ontario conditions d’utilisation pour les données ouvertes"
     },
-    "url": "http://www.ontario.ca/government/ontario-open-data-terms-use",
+    "url": "https://www.ontario.ca/page/ontario-open-data-terms-use",
     "url_translated": {
-        "en": "http://www.ontario.ca/government/ontario-open-data-terms-use",
+        "en": "https://www.ontario.ca/page/ontario-open-data-terms-use",
         "fr": "https://www.ontario.ca/fr/page/acces-aux-donnees-gouvernementales"
     },
     "description": "Data in this record is open and is published in the language in which it’s collected. Please contact us to obtain assistance in either official language.",

--- a/ckanext/ontario_theme/templates/external/home/snippets/about_text.html
+++ b/ckanext/ontario_theme/templates/external/home/snippets/about_text.html
@@ -187,7 +187,7 @@
       <a href="#other-data">Read more about non-open data.</a>
     </p>
     <p>
-      <a href="https://www.ontario.ca/document/open-data-guidebook-guide-open-data-directive-2015/data-inventory#section-1">
+      <a href="https://www.ontario.ca/document/open-data-guidebook-guide-open-data-directive/data-inventory#section-1">
         Read more about restricted data.
       </a>
     </p>

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # http://packaging.python.org/en/latest/tutorial.html#version
-    version='3.0.21',
+    version='3.0.22',
 
     description='''Theme for internal CKAN build.''',
     long_description=long_description,

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # http://packaging.python.org/en/latest/tutorial.html#version
-    version='3.0.22',
+    version='3.0.21',
 
     description='''Theme for internal CKAN build.''',
     long_description=long_description,


### PR DESCRIPTION
## What this PR accomplishes

- Updated the Ontario Open Data Terms of Use URL in `licences.json`.
- Replaced the outdated URL:
  - `http://www.ontario.ca/government/ontario-open-data-terms-use`
- With the current URL:
  - `https://www.ontario.ca/page/ontario-open-data-terms-use`

## Issue(s) addressed

- DATA-1556

## What needs to be reviewed

- Verify datasets using the Ontario Open Data Terms of Use licence link to the updated URL.
- Verify the licence link works correctly in both English and French.
- Confirm no other licence URLs were affected by the change.