### PR TITLE
DATA-1806: URL Validation

### DIFF
--- a/ckanext/ontario_theme/plugin.py
+++ b/ckanext/ontario_theme/plugin.py
@@ -1316,5 +1316,6 @@ type data_last_updated
             'lock_if_odc': validators.lock_if_odc,
             'ontario_theme_copy_fluent_keywords_to_tags': validators.ontario_theme_copy_fluent_keywords_to_tags,
             'ontario_tag_name_validator': validators.tag_name_validator,
-            'ontario_strip_fluent_value': validators.strip_fluent_value
+            'ontario_strip_fluent_value': validators.strip_fluent_value, 
+            'public_https_url_validator': validators.public_https_url_validator
        }

--- a/ckanext/ontario_theme/schemas/external/ontario_theme_dataset.json
+++ b/ckanext/ontario_theme/schemas/external/ontario_theme_dataset.json
@@ -641,6 +641,7 @@
         "fr": "URL"
       },
       "preset": "resource_url_upload",
+      "validators": "ignore_missing unicode_safe remove_whitespace public_https_url_validator",
       "fieldset": 1,
       "fieldset_name": "Add File",
       "classes": ["form-group","col-md-12"],

--- a/ckanext/ontario_theme/schemas/internal/ontario_theme_dataset.json
+++ b/ckanext/ontario_theme/schemas/internal/ontario_theme_dataset.json
@@ -708,6 +708,7 @@
         "fr": "URL"
       },
       "preset": "resource_url_upload",
+      "validators": "ignore_missing unicode_safe remove_whitespace public_https_url_validator",
       "fieldset": 1,
       "fieldset_name": "Add File",
       "classes": ["form-group","col-md-12"],

--- a/ckanext/ontario_theme/validators.py
+++ b/ckanext/ontario_theme/validators.py
@@ -7,7 +7,9 @@ from ckanext.scheming.validation import scheming_validator
 from ckanext.fluent.validators import fluent_text_output
 from ckantoolkit import Invalid
 from ckan.authz import is_sysadmin
+from urllib.parse import urlparse, urlunparse
 import json
+import ipaddress
 
 
 def tag_name_validator(value, context):
@@ -175,3 +177,65 @@ def strip_fluent_value(key, data, errors, context):
             value[lang] = text.strip()
     data[key] = json.dumps(value)
     return
+
+def public_https_url_validator(value, context): 
+
+    if not value: 
+        return value
+
+    # Trim whitespace
+    value = value.strip()
+
+    # Enforce max length
+    if len(value) > 2048: 
+        raise Invalid(_("URL cannot exceed 2048 characters."))
+
+    parsed = urlparse(value)
+
+    # Only allow HTTPS
+    if parsed.scheme != "https": 
+        raise Invalid(_("Enter a valid HTTPS URL."))
+
+    # Require hostname
+    if not parsed.hostname: 
+        raise Invalid(_("Enter a valid HTTPS URL."))
+
+    hostname = parsed.hostname.lower()
+
+    # Reject localhost
+    if hostname == "localhost": 
+        raise Invalid(_("URL must reference a public website."))
+
+    # Reject private IP ranges
+    try: 
+        ip = ipaddress.ip_address(hostname) 
+
+        if (
+           ip.is_private
+           or ip.is_loopback
+           or ip.is_link_local
+           or ip.is_reserved
+        ): 
+           raise Invalid(
+               _("URL must reference a public website.") 
+           ) 
+
+    except ValueError: 
+        pass
+
+    # Normalize hostname and remove default HTTPS port
+    netloc = hostname
+
+    if parsed.port and parsed.port != 443: 
+        netloc = f"{hostname}:{parsed.port}"
+
+    normalized = urlunparse((
+        "https",
+        netloc,
+        parsed.path, 
+        parsed.params, 
+        parsed.query, 
+        parsed.fragment
+    ))
+
+    return normalized

--- a/ckanext/ontario_theme/validators.py
+++ b/ckanext/ontario_theme/validators.py
@@ -180,14 +180,18 @@ def strip_fluent_value(key, data, errors, context):
 
 def public_https_url_validator(value, context): 
 
-    if not value: 
+    if not value:
         return value
 
     # Trim whitespace
     value = value.strip()
 
+    # Auto-prepend HTTPS
+    if value and "://" not in value:
+        value = "https://" + value
+
     # Enforce max length
-    if len(value) > 2048: 
+    if len(value) > 2048:
         raise Invalid(_("URL cannot exceed 2048 characters."))
 
     parsed = urlparse(value)


### PR DESCRIPTION
## What this PR accomplishes
- Added a custom `public_https_url_validator` for resource URLs.
- Enforced HTTPS-only URLs and rejected non-secure or unsafe protocols (`http`, `javascript`, `ftp`, `file`, `data`, etc.).
- Added validation to reject malformed URLs, missing hostnames, localhost URLs, loopback addresses, and private IP addresses.
- Added URL normalization by trimming leading/trailing whitespace and converting hostnames to lowercase before storage.
- Added validation to reject URLs longer than 2048 characters.
- Registered the custom validator in `plugin.py`.
- Applied the validator to resource URL fields in both the internal and external dataset schemas.
- Manually tested valid URLs, invalid URLs, URL normalization, whitespace trimming, and length-limit validation.

## Issue(s) addressed
- DATA-1806

## What needs to be reviewed
- Verify valid HTTPS URLs continue to save successfully.
- Verify invalid URLs are rejected as expected:
- - `http://example.com`
- - `javascript:alert(1)`
- - `ftp://example.com`
- - `file:///tmp/test`
- - `data:text/html,test`
- - `https://localhost`
- - `https://127.0.0.1`
- - `https://192.168.1.5`
- Verify hostname normalization (e.g. `https://EXAMPLE.COM/test` is stored as `https://example.com/test`).
- Verify leading/trailing whitespace is removed before validation and storage.
- Verify URLs longer than 2048 characters are rejected.

<img width="1268" height="759" alt="Screenshot 2026-07-15 104308" src="https://github.com/user-attachments/assets/c0642075-be24-4bc3-b25e-b079ee1e2303" />
<img width="1439" height="926" alt="Screenshot 2026-07-15 103220" src="https://github.com/user-attachments/assets/5fead33f-f9a7-48a1-8dfa-26ab350997db" />
<img width="1296" height="759" alt="Screenshot 2026-07-15 103159" src="https://github.com/user-attachments/assets/4be2ad64-06cb-4f16-80da-3fccdbc923f8" />
<img width="1611" height="928" alt="Screenshot 2026-07-15 101056" src="https://github.com/user-attachments/assets/469c37cc-991f-4354-a0f6-0c1104e82cf0" />


